### PR TITLE
ENH: optimize: array API support for `ScalarFunction`

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -582,7 +582,7 @@ def xp_array_equal(x1, x2, xp):
     x2 = xp.asarray(x2)
     if x1.shape != x2.shape:
         return False
-    return item(xp.all(xp.equal(x1, x2)))
+    return _item_for_scalar_function(xp.all(xp.equal(x1, x2)))
 
 
 class _ScalarFunctionWrapper:

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -16,7 +16,7 @@ from typing import Literal
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array, is_numpy,
                                    is_marray, xp_size, xp_result_device, xp_result_type,
-                                   xp_capabilities, xp_isscalar)
+                                   xp_capabilities, xp_isscalar, xp_copy)
 from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._sparse import issparse
 
@@ -576,19 +576,29 @@ def _item_for_scalar_function(x, xp=None):
     return x
 
 
+def xp_array_equal(x1, x2, xp):
+    # an array-api compliant equivalent to np.array_equal
+    x1 = xp.asarray(x1)
+    x2 = xp.asarray(x2)
+    if x1.shape != x2.shape:
+        return False
+    return item(xp.all(xp.equal(x1, x2)))
+
+
 class _ScalarFunctionWrapper:
     """
     Object to wrap scalar user function, allowing picklability
     """
-    def __init__(self, f, args=None):
+    def __init__(self, f, args=None, x0=None):
         self.f = f
         self.args = [] if args is None else args
         self.nfev = 0
+        self._xp = array_namespace(x0)
 
     def __call__(self, x):
         # Send a copy because the user may overwrite it.
         # The user of this class might want `x` to remain unchanged.
-        fx = self.f(np.copy(x), *self.args)
+        fx = self.f(xp_copy(x, xp=self._xp), *self.args)
         self.nfev += 1
 
         # Make sure the function returns a true scalar
@@ -600,6 +610,16 @@ class _ScalarFunctionWrapper:
                 "must return a scalar value."
             ) from e
         return fx
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        self.__dict__.update(state)
+
 
 class MapWrapper:
     """

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -5,9 +5,9 @@ import scipy.sparse as sps
 from ._numdiff import approx_derivative, group_columns
 from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy.sparse.linalg import LinearOperator
-from scipy._lib._array_api import array_namespace, xp_copy
+from scipy._lib._array_api import (array_namespace, xp_copy, xp_capabilities)
 from scipy._external import array_api_extra as xpx
-from scipy._lib._util import _ScalarFunctionWrapper
+from scipy._lib._util import _ScalarFunctionWrapper, xp_array_equal
 
 
 FD_METHODS = ('2-point', '3-point', 'cs')
@@ -18,11 +18,12 @@ class _ScalarGradWrapper:
     Wrapper class for gradient calculation
     """
     def __init__(
-            self,
-            grad,
-            fun=None,
-            args=None,
-            finite_diff_options=None,
+        self,
+        grad,
+        fun=None,
+        args=None,
+        finite_diff_options=None,
+        x0=None,
     ):
         self.fun = fun
         self.grad = grad
@@ -31,12 +32,17 @@ class _ScalarGradWrapper:
         self.ngev = 0
         # number of function evaluations consumed by finite difference
         self.nfev = 0
+        self._xp = array_namespace(x0)
 
     def __call__(self, x, f0=None, **kwds):
         # Send a copy because the user may overwrite it.
         # The user of this class might want `x` to remain unchanged.
         if callable(self.grad):
-            g = np.atleast_1d(self.grad(np.copy(x), *self.args))
+            g = xpx.atleast_nd(
+                self.grad(xp_copy(x, xp=self._xp), *self.args),
+                ndim=1,
+                xp=self._xp
+            )
         elif self.grad in FD_METHODS:
             g, dct = approx_derivative(
                 self.fun,
@@ -48,6 +54,15 @@ class _ScalarGradWrapper:
 
         self.ngev += 1
         return g
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        self.__dict__.update(state)
 
 
 class _ScalarHessWrapper:
@@ -71,9 +86,10 @@ class _ScalarHessWrapper:
         self.nhev = 0
         self.H = None
         self._hess_func = None
+        self._xp = array_namespace(x0)
 
         if callable(hess):
-            self.H = hess(np.copy(x0), *args)
+            self.H = hess(xp_copy(x0, xp=self._xp), *args)
             self.nhev += 1
 
             if sps.issparse(self.H):
@@ -84,7 +100,14 @@ class _ScalarHessWrapper:
             else:
                 # dense
                 self._hess_func = "dense_callable"
-                self.H = np.atleast_2d(np.asarray(self.H))
+                if self.H is None:
+                    self.H = []
+
+                self.H = xpx.atleast_nd(
+                    self._xp.asarray(self.H),
+                    ndim=2,
+                    xp=self._xp
+                )
         elif hess in FD_METHODS:
                 self._hess_func = "fd_hess"
 
@@ -99,7 +122,7 @@ class _ScalarHessWrapper:
             case "fd_hess":
                 _h = self._fd_hess
 
-        return _h(np.copy(x), f0=f0)
+        return _h(xp_copy(x, xp=self._xp), f0=f0)
 
     def _fd_hess(self, x, f0=None, **kwds):
         self.H, dct = approx_derivative(
@@ -115,8 +138,14 @@ class _ScalarHessWrapper:
 
     def _dense_callable(self, x, **kwds):
         self.nhev += 1
-        self.H = np.atleast_2d(
-            np.asarray(self.hess(x, *self.args))
+        _h = self.hess(x, *self.args)
+        if _h is None:
+            _h = []
+        _h = self._xp.asarray(_h)
+        self.H = xpx.atleast_nd(
+            _h,
+            ndim=2,
+            xp=self._xp
         )
         return self.H
 
@@ -125,6 +154,26 @@ class _ScalarHessWrapper:
         self.H = self.hess(x, *self.args)
         return self.H
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        self.__dict__.update(state)
+
+
+@xp_capabilities(
+    skip_backends=[
+        ("dask.array", "would need lazy_xp_function to avoid dask.compute"),
+        (
+            "jax.numpy",
+            "needs jax control flow logic (if -> xp.where) and conversion to be "
+            "functionally pure"
+        ),
+    ]
+)
 class ScalarFunction:
     """Scalar function and its derivatives.
 
@@ -242,7 +291,7 @@ class ScalarFunction:
             _dtype = _x.dtype
 
         # original arguments
-        self._wrapped_fun = _ScalarFunctionWrapper(fun, args)
+        self._wrapped_fun = _ScalarFunctionWrapper(fun, args, x0=_x)
         self._orig_fun = fun
         self._orig_grad = grad
         self._orig_hess = hess
@@ -288,6 +337,7 @@ class ScalarFunction:
             fun=self._wrapped_fun,
             args=args,
             finite_diff_options=finite_diff_options,
+            x0=x0
         )
         self._update_grad()
 
@@ -356,6 +406,7 @@ class ScalarFunction:
             self.f_updated = False
             self.g_updated = False
             self.H_updated = False
+        return True
 
     def _update_fun(self):
         if not self.f_updated:
@@ -372,7 +423,7 @@ class ScalarFunction:
         if not self.g_updated:
             if self._orig_grad in FD_METHODS:
                 self._update_fun()
-            self.g = self._wrapped_grad(self.x, f0=self.f)
+            self.g = self._wrapped_grad(self.x, f0=self.f, xp=self.xp)
             self.g_updated = True
 
     def _update_hess(self):
@@ -389,25 +440,25 @@ class ScalarFunction:
             self.H_updated = True
 
     def fun(self, x):
-        if not np.array_equal(x, self.x):
+        if not xp_array_equal(x, self.x, xp=self.xp):
             self._update_x(x)
         self._update_fun()
         return self.f
 
     def grad(self, x):
-        if not np.array_equal(x, self.x):
+        if not xp_array_equal(x, self.x, xp=self.xp):
             self._update_x(x)
         self._update_grad()
         return self.g
 
     def hess(self, x):
-        if not np.array_equal(x, self.x):
+        if not xp_array_equal(x, self.x, xp=self.xp):
             self._update_x(x)
         self._update_hess()
         return self.H
 
     def fun_and_grad(self, x):
-        if not np.array_equal(x, self.x):
+        if not xp_array_equal(x, self.x, xp=self.xp):
             self._update_x(x)
         self._update_fun()
         self._update_grad()

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -9,7 +9,6 @@ from scipy._lib._array_api import (
     array_namespace, xp_result_type, xp_copy, xp_capabilities,
     xp_size, xp_vector_norm
 )
-from scipy._external import array_api_extra as xpx
 from scipy._lib._util import MapWrapper, xp_array_equal
 from scipy._external.array_api_compat import is_numpy_namespace
 from scipy._external import array_api_extra as xpx

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -6,9 +6,10 @@ from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, spmatrix, find, csc_array, csr_array, csr_matrix
 from ._group_columns import group_dense, group_sparse
 from scipy._lib._array_api import (
-    array_namespace, xp_result_type, xp_default_dtype, xp_copy, xp_capabilities,
+    array_namespace, xp_result_type, xp_copy, xp_capabilities,
     xp_size, xp_vector_norm
 )
+from scipy._external import array_api_extra as xpx
 from scipy._lib._util import MapWrapper, xp_array_equal
 from scipy._external.array_api_compat import is_numpy_namespace
 from scipy._external import array_api_extra as xpx
@@ -137,7 +138,7 @@ def _eps_for_method(x0_dtype, f0_dtype, method, xp):
     """
     # the default EPS value. Normally we want this to be 64 bit, but torch
     # has a 32 bit default.
-    out_dtype = xp_default_dtype(xp)
+    out_dtype = xpx.default_dtype(xp)
     EPS = xp.finfo(out_dtype).eps
 
     bits = {}

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -1,17 +1,20 @@
 """Routines for numerical differentiation."""
 import functools
 import numpy as np
-from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, spmatrix, find, csc_array, csr_array, csr_matrix
 from ._group_columns import group_dense, group_sparse
-from scipy._lib._array_api import array_namespace, xp_result_type
-from scipy._lib._util import MapWrapper
+from scipy._lib._array_api import (
+    array_namespace, xp_result_type, xp_default_dtype, xp_copy, xp_capabilities,
+    xp_size, xp_vector_norm
+)
+from scipy._lib._util import MapWrapper, xp_array_equal
+from scipy._external.array_api_compat import is_numpy_namespace
 from scipy._external import array_api_extra as xpx
 
 
-def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
+def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub, xp=None):
     """Adjust final difference scheme to the presence of bounds.
 
     Parameters
@@ -42,19 +45,21 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
         Whether to switch to one-sided scheme. Informative only for
         ``scheme='2-sided'``.
     """
+    xp = xp or array_namespace(x0)
+
     if scheme == '1-sided':
-        use_one_sided = np.ones_like(h, dtype=bool)
+        use_one_sided = xp.ones_like(h, dtype=xp.bool)
     elif scheme == '2-sided':
-        h = np.abs(h)
-        use_one_sided = np.zeros_like(h, dtype=bool)
+        h = xp.abs(h)
+        use_one_sided = xp.zeros_like(h, dtype=xp.bool)
     else:
         raise ValueError("`scheme` must be '1-sided' or '2-sided'.")
 
-    if np.all((lb == -np.inf) & (ub == np.inf)):
+    if xp.all((lb == -xp.inf) & (ub == xp.inf)):
         return h, use_one_sided
 
     h_total = h * num_steps
-    h_adjusted = h.copy()
+    h_adjusted = xp_copy(h, xp=xp)
 
     lower_dist = x0 - lb
     upper_dist = ub - x0
@@ -62,7 +67,7 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
     if scheme == '1-sided':
         x = x0 + h_total
         violated = (x < lb) | (x > ub)
-        fitting = np.abs(h_total) <= np.maximum(lower_dist, upper_dist)
+        fitting = xp.abs(h_total) <= xp.maximum(lower_dist, upper_dist)
         h_adjusted[violated & fitting] *= -1
 
         forward = (upper_dist >= lower_dist) & ~fitting
@@ -73,25 +78,34 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
         central = (lower_dist >= h_total) & (upper_dist >= h_total)
 
         forward = (upper_dist >= lower_dist) & ~central
-        h_adjusted[forward] = np.minimum(
+        h_adjusted[forward] = xp.minimum(
             h[forward], 0.5 * upper_dist[forward] / num_steps)
         use_one_sided[forward] = True
 
         backward = (upper_dist < lower_dist) & ~central
-        h_adjusted[backward] = -np.minimum(
+        h_adjusted[backward] = -xp.minimum(
             h[backward], 0.5 * lower_dist[backward] / num_steps)
         use_one_sided[backward] = True
 
-        min_dist = np.minimum(upper_dist, lower_dist) / num_steps
-        adjusted_central = (~central & (np.abs(h_adjusted) <= min_dist))
+        min_dist = xp.minimum(upper_dist, lower_dist) / num_steps
+        adjusted_central = (~central & (xp.abs(h_adjusted) <= min_dist))
         h_adjusted[adjusted_central] = min_dist[adjusted_central]
         use_one_sided[adjusted_central] = False
 
     return h_adjusted, use_one_sided
 
 
+@xp_capabilities(
+    skip_backends=[
+        (
+            "jax.numpy",
+            "needs jax control flow logic (if -> xp.where) and conversion to be "
+            "functionally pure"
+        ),
+    ]
+)
 @functools.lru_cache
-def _eps_for_method(x0_dtype, f0_dtype, method):
+def _eps_for_method(x0_dtype, f0_dtype, method, xp):
     """
     Calculates relative EPS step to use for a given data type
     and numdiff step method.
@@ -100,51 +114,71 @@ def _eps_for_method(x0_dtype, f0_dtype, method):
 
     Parameters
     ----------
-    f0_dtype: np.dtype
-        dtype of function evaluation
+    f0_dtype: dtype
+        function evaluation
 
-    x0_dtype: np.dtype
-        dtype of parameter vector
+    x0_dtype: dtype
+        parameter vector
 
     method: {'2-point', '3-point', 'cs'}
+
+    xp: array-namespace
 
     Returns
     -------
     EPS: float
-        relative step size. May be np.float16, np.float32, np.float64
+        relative step size. May be xp.float16, xp.float32, xp.float64
 
     Notes
     -----
-    The default relative step will be np.float64. However, if x0 or f0 are
-    smaller floating point types (np.float16, np.float32), then the smallest
+    The default relative step will be xp.float64. However, if x0 or f0 are
+    smaller floating point types (xp.float16, xp.float32), then the smallest
     floating point type is chosen.
     """
-    # the default EPS value
-    EPS = np.finfo(np.float64).eps
+    # the default EPS value. Normally we want this to be 64 bit, but torch
+    # has a 32 bit default.
+    out_dtype = xp_default_dtype(xp)
+    EPS = xp.finfo(out_dtype).eps
+
+    bits = {}
+    for _bits in (16, 32, 64):
+        if hasattr(xp, f"float{_bits}"):
+            bits[_bits] = getattr(xp, f"float{_bits}")
 
     x0_is_fp = False
-    if np.issubdtype(x0_dtype, np.inexact):
+    if xp.isdtype(x0_dtype, 'real floating'):
         # if you're a floating point type then over-ride the default EPS
-        EPS = np.finfo(x0_dtype).eps
-        x0_itemsize = np.dtype(x0_dtype).itemsize
+        EPS = xp.finfo(x0_dtype).eps
+        x0_size = xp.finfo(x0_dtype).bits
+        out_dtype = bits[x0_size]
         x0_is_fp = True
 
-    if np.issubdtype(f0_dtype, np.inexact):
-        f0_itemsize = np.dtype(f0_dtype).itemsize
+    if xp.isdtype(f0_dtype, 'real floating'):
+        f0_size = xp.finfo(f0_dtype).bits
         # choose the smallest itemsize between x0 and f0
-        if x0_is_fp and f0_itemsize < x0_itemsize:
-            EPS = np.finfo(f0_dtype).eps
+        if x0_is_fp and f0_size < x0_size:
+            EPS = xp.finfo(f0_dtype).eps
+            out_dtype = bits[f0_size]
 
     if method in ["2-point", "cs"]:
-        return EPS**0.5
+        return xp.asarray(EPS**0.5, dtype=out_dtype)
     elif method in ["3-point"]:
-        return EPS**(1/3)
+        return xp.asarray(EPS**(1/3), dtype=out_dtype)
     else:
         raise RuntimeError("Unknown step method, should be one of "
                            "{'2-point', '3-point', 'cs'}")
 
 
-def _compute_absolute_step(rel_step, x0, f0, method):
+@xp_capabilities(
+    skip_backends=[
+        (
+            "jax.numpy",
+            "needs jax control flow logic (if -> xp.where) and conversion to be "
+            "functionally pure"
+        ),
+    ]
+)
+def _compute_absolute_step(rel_step, x0, f0, method, xp=None):
     """
     Computes an absolute step from a relative step for finite difference
     calculation.
@@ -157,6 +191,7 @@ def _compute_absolute_step(rel_step, x0, f0, method):
         Parameter vector
     f0 : np.ndarray or scalar
     method : {'2-point', '3-point', 'cs'}
+    xp : array-namespace
 
     Returns
     -------
@@ -174,12 +209,15 @@ def _compute_absolute_step(rel_step, x0, f0, method):
     """
     # this is used instead of np.sign(x0) because we need
     # sign_x0 to be 1 when x0 == 0.
-    sign_x0 = (x0 >= 0).astype(x0.dtype) * 2 - 1
+    xp = xp or array_namespace(x0)
+    gte0 = (x0 >= 0)
+    sign_x0 = xp.astype(gte0, x0.dtype) * 2 - 1
 
-    rstep = _eps_for_method(x0.dtype, f0.dtype, method)
-    default_abs_step = (
-        rstep * sign_x0 * np.maximum(1.0, np.abs(x0))
-    ).astype(x0.dtype)
+    rstep = _eps_for_method(x0.dtype, f0.dtype, method, xp=xp)
+    default_abs_step = xp.astype(
+        rstep * sign_x0 * xp.maximum(xp.asarray(1.0, dtype=x0.dtype), xp.abs(x0)),
+        x0.dtype
+    )
 
     if rel_step is None:
         abs_step = default_abs_step
@@ -187,14 +225,13 @@ def _compute_absolute_step(rel_step, x0, f0, method):
         # User has requested specific relative steps.
         # Don't multiply by max(1, abs(x0) because if x0 < 1 then their
         # requested step is not used.
-        abs_step = (
-            rel_step * sign_x0 * np.abs(x0)
-        ).astype(x0.dtype)
+        _abs_step = rel_step * sign_x0 * xp.abs(x0)
+        abs_step = xp.asarray(_abs_step, dtype=x0.dtype)
 
         # however we don't want an abs_step of 0, which can happen if
         # rel_step is 0, or x0 is 0. Instead, substitute a realistic step
         dx = ((x0 + abs_step) - x0)
-        abs_step = np.where(
+        abs_step = xp.where(
             dx == 0,
             default_abs_step,
             abs_step
@@ -203,7 +240,7 @@ def _compute_absolute_step(rel_step, x0, f0, method):
     return abs_step
 
 
-def _prepare_bounds(bounds, x0):
+def _prepare_bounds(bounds, x0, xp=None):
     """
     Prepares new-style bounds from a two-tuple specifying the lower and upper
     limits for values in x0. If a value is not bound then the lower/upper bound
@@ -214,12 +251,11 @@ def _prepare_bounds(bounds, x0):
     >>> _prepare_bounds([(0, 1, 2), (1, 2, np.inf)], [0.5, 1.5, 2.5])
     (array([0., 1., 2.]), array([ 1.,  2., inf]))
     """
-    lb, ub = (np.asarray(b, dtype=float) for b in bounds)
-    if lb.ndim == 0:
-        lb = np.resize(lb, x0.shape)
+    xp = xp or array_namespace(x0)
 
-    if ub.ndim == 0:
-        ub = np.resize(ub, x0.shape)
+    lb, ub = (xp.asarray(b, dtype=x0.dtype) for b in bounds)
+    lb = xp.broadcast_to(lb, x0.shape)
+    ub = xp.broadcast_to(ub, x0.shape)
 
     return lb, ub
 
@@ -285,6 +321,16 @@ def group_columns(A, order=0):
     return groups
 
 
+@xp_capabilities(
+    skip_backends=[
+        ("dask.array", "would need lazy_xp_function to avoid dask.compute"),
+        (
+            "jax.numpy",
+            "needs jax control flow logic (if -> xp.where) and conversion to be "
+            "functionally pure"
+        ),
+    ]
+)
 def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
                       f0=None, bounds=(-np.inf, np.inf), sparsity=None,
                       as_linear_operator=False, args=(), kwargs=None,
@@ -536,13 +582,18 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     if x0.ndim > 1:
         raise ValueError("`x0` must have at most 1 dimension.")
 
-    lb, ub = _prepare_bounds(bounds, x0)
+    # cast the bounds to the relevant array_namespace
+    lb, ub = _prepare_bounds(bounds, x0, xp=xp)
 
     if lb.shape != x0.shape or ub.shape != x0.shape:
         raise ValueError("Inconsistent shapes between bounds and `x0`.")
 
-    if as_linear_operator and not (np.all(np.isinf(lb))
-                                   and np.all(np.isinf(ub))):
+    if not is_numpy_namespace(xp) and (sparsity is not None):
+        raise RuntimeError("as_linear_operator and sparsity are not yet supported by"
+                           "non-numpy array namespaces")
+
+    if as_linear_operator and not (xp.all(xp.isinf(lb))
+                                   and xp.all(xp.isinf(ub))):
         raise ValueError("Bounds not supported when "
                          "`as_linear_operator` is True.")
 
@@ -564,36 +615,37 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         f0 = fun_wrapped(x0)
         nfev = 1
     else:
-        f0 = np.atleast_1d(f0)
+        f0 = xpx.atleast_nd(f0, ndim=1, xp=xp)
         if f0.ndim > 1:
             raise ValueError("`f0` passed has more than 1 dimension.")
 
-    if np.any((x0 < lb) | (x0 > ub)):
+    if xp.any((x0 < lb) | (x0 > ub)):
         raise ValueError("`x0` violates bound constraints.")
 
     if as_linear_operator:
         if rel_step is None:
-            rel_step = _eps_for_method(x0.dtype, f0.dtype, method)
+            rel_step = _eps_for_method(x0.dtype, f0.dtype, method, xp=xp)
 
         J, _ = _linear_operator_difference(fun_wrapped, x0,
                                            f0, rel_step, method)
     else:
         # by default we use rel_step
         if abs_step is None:
-            h = _compute_absolute_step(rel_step, x0, f0, method)
+            h = _compute_absolute_step(rel_step, x0, f0, method, xp=xp)
         else:
             # user specifies an absolute step
-            sign_x0 = (x0 >= 0).astype(x0.dtype) * 2 - 1
+            sign_x0 = xp.astype(x0 >= 0., x0.dtype) * 2 - 1
             h = abs_step
 
             # cannot have a zero step. This might happen if x0 is very large
             # or small. In which case fall back to relative step.
             dx = ((x0 + h) - x0)
-            h = np.where(dx == 0,
-                         _eps_for_method(x0.dtype, f0.dtype, method) *
-                         sign_x0 * np.maximum(1.0, np.abs(x0)),
+            h = xp.where(dx == 0,
+                         _eps_for_method(x0.dtype, f0.dtype, method, xp=xp) *
+                         sign_x0 *
+                         xp.maximum(xp.asarray(1.0, dtype=x0.dtype), xp.abs(x0)),
                          h)
-            h = h.astype(x0.dtype)
+            h = xp.astype(h, x0.dtype)
 
         if method == '2-point':
             h, use_one_sided = _adjust_scheme_to_bounds(
@@ -624,8 +676,8 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
                     structure = np.atleast_2d(structure)
                 groups = np.atleast_1d(groups)
                 J, _nfev = _sparse_difference(fun_wrapped, x0, f0, h,
-                                             use_one_sided, structure,
-                                             groups, method, mf)
+                                              use_one_sided, structure,
+                                              groups, method, mf, xp=xp)
 
     if full_output:
         nfev += _nfev
@@ -635,18 +687,19 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         return J
 
 
-def _linear_operator_difference(fun, x0, f0, h, method):
-    m = f0.size
-    n = x0.size
+def _linear_operator_difference(fun, x0, f0, h, method, xp=None):
+    m = xp_size(f0)
+    n = xp_size(x0)
 
-    result_dtype = xp_result_type(x0, f0, force_floating=True, xp=np)
+    xp = xp or array_namespace(x0)
+    result_dtype = xp_result_type(x0, f0, force_floating=True, xp=xp)
 
     if method == '2-point':
         # nfev = 1
         def matvec(p):
-            if np.array_equal(p, np.zeros_like(p)):
-                return np.zeros(m, dtype=result_dtype)
-            dx = h / norm(p)
+            if xp_array_equal(p, xp.zeros_like(p), xp):
+                return xp.zeros(m, dtype=result_dtype)
+            dx = h / xp_vector_norm(p, xp=xp)
             x = x0 + dx*p
             df = fun(x) - f0
             return df / dx
@@ -654,9 +707,9 @@ def _linear_operator_difference(fun, x0, f0, h, method):
     elif method == '3-point':
         # nfev = 2
         def matvec(p):
-            if np.array_equal(p, np.zeros_like(p)):
-                return np.zeros(m, dtype=result_dtype)
-            dx = 2*h / norm(p)
+            if xp_array_equal(p, xp.zeros_like(p), xp):
+                return xp.zeros(m, dtype=result_dtype)
+            dx = 2*h / xp_vector_norm(p, xp=xp)
             x1 = x0 - (dx/2)*p
             x2 = x0 + (dx/2)*p
             f1 = fun(x1)
@@ -667,28 +720,30 @@ def _linear_operator_difference(fun, x0, f0, h, method):
     elif method == 'cs':
         # nfev = 1
         def matvec(p):
-            if np.array_equal(p, np.zeros_like(p)):
-                return np.zeros(m, dtype=result_dtype)
-            dx = h / norm(p)
+            if xp_array_equal(p, xp.zeros_like(p), xp):
+                return xp.zeros(m, dtype=result_dtype)
+            dx = h / xp_vector_norm(p, xp=xp)
             x = x0 + dx*p*1.j
             f1 = fun(x)
-            df = f1.imag
+            df = xp.imag(f1)
             return df / dx
     else:
         raise RuntimeError("Never be here.")
 
-    return LinearOperator(shape=(m, n), matvec=matvec, dtype=result_dtype), 0
+    return LinearOperator(shape=(m, n), matvec=matvec, dtype=result_dtype, xp=xp), 0
 
 
-def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers):
-    m = f0.size
-    n = x0.size
+def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers, xp=None):
+    m = xp_size(f0)
+    n = xp_size(x0)
     nfev = 0
 
+    xp = xp or array_namespace(x0)
+
     # h should have same dtype as x0
-    result_type = xp_result_type(x0, f0, force_floating=True, xp=np)
+    result_type = xp_result_type(x0, f0, force_floating=True, xp=xp)
     # output dtype should be the same as df_dx
-    J_transposed = np.empty((n, m), dtype=result_type)
+    J_transposed = xp.empty((n, m), dtype=result_type)
 
     if method == '2-point':
         def x_generator2(x0, h):
@@ -699,7 +754,7 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers):
                 # I also considered creating all the vectors at once, but that
                 # means assembling a very large N x N array. It's therefore a
                 # trade-off between N array copies or creating an NxN array.
-                x1 = np.copy(x0)
+                x1 = xp_copy(x0, xp=xp)
                 x1[i] = x0[i] + h[i]
                 yield x1
 
@@ -714,8 +769,8 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers):
     elif method == '3-point':
         def x_generator3(x0, h, use_one_sided):
             for i, one_sided in enumerate(use_one_sided):
-                x1 = np.copy(x0)
-                x2 = np.copy(x0)
+                x1 = xp_copy(x0, xp=xp)
+                x2 = xp_copy(x0, xp=xp)
                 if one_sided:
                     x1[i] = x0[i] + h[i]
                     x2[i] = x0[i] + 2*h[i]
@@ -746,43 +801,49 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers):
         df_dx = [delf / delx for delf, delx in zip(df, dx)]
         nfev += 2 * len(df_dx)
     elif method == 'cs':
+        bits = xp.finfo(x0).bits
+        xc_dtype = getattr(xp, f"complex{bits*2}")
+
         def x_generator_cs(x0, h):
             for i in range(n):
-                xc = x0.astype(complex, copy=True)
-                xc[i] += h[i] * 1.j
+                xc = xp.astype(x0, xc_dtype)
+                xc[i] += h[i] * 1.0j
                 yield xc
 
         f_evals = iter(workers(fun, x_generator_cs(x0, h)))
-        df_dx = [f1.imag / hi for f1, hi in zip(f_evals, h)]
+        df_dx = [xp.imag(f1) / hi for f1, hi in zip(f_evals, h)]
         nfev += len(df_dx)
     else:
         raise RuntimeError("Never be here.")
 
     for i, v in enumerate(df_dx):
-        J_transposed[i] = v
+        J_transposed[i, ...] = v
 
     if m == 1:
-        J_transposed = np.ravel(J_transposed)
-
-    return J_transposed.T, nfev
+        # flatten the array
+        return xp.reshape(J_transposed, (-1,)), nfev
+    else:
+        # fun(x0) has more than 1-dimension
+        return J_transposed.T, nfev
 
 
 def _sparse_difference(fun, x0, f0, h, use_one_sided,
-                       structure, groups, method, workers):
-    m = f0.size
-    n = x0.size
+                       structure, groups, method, workers, xp=None):
+    xp = xp or array_namespace(x0)
+    m = xp.size(f0)
+    n = xp_size(x0)
     row_indices = []
     col_indices = []
     fractions = []
-    result_type = xp_result_type(x0, f0, force_floating=True, xp=np)
+    result_type = xp_result_type(x0, f0, force_floating=True, xp=xp)
 
-    n_groups = np.max(groups) + 1
+    n_groups = xp.max(groups) + 1
     nfev = 0
 
     def e_generator():
         # Perturb variables which are in the same group simultaneously.
         for group in range(n_groups):
-            yield np.equal(group, groups)
+            yield xp.equal(group, groups)
 
     def x_generator2():
         e_gen = e_generator()
@@ -795,8 +856,8 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
         e_gen = e_generator()
         for e in e_gen:
             h_vec = h * e
-            x1 = x0.copy()
-            x2 = x0.copy()
+            x1 = xp_copy(x0, xp=xp)
+            x2 = xp_copy(x0, xp=xp)
 
             mask_1 = use_one_sided & e
             x1[mask_1] += h_vec[mask_1]
@@ -827,7 +888,7 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
     for e in e_generator():
         # The result is written to columns which correspond to perturbed
         # variables.
-        cols, = np.nonzero(e)
+        cols, = xp.nonzero(e)
         # Find all non-zero elements in selected columns of Jacobian.
         i, j, _ = find(structure[:, cols])
         # Restore column indices in the full array.
@@ -846,7 +907,7 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
             mask_1 = use_one_sided & e
             mask_2 = ~use_one_sided & e
 
-            dx = np.zeros(n, dtype=x0.dtype)
+            dx = xp.zeros(n, dtype=x0.dtype)
             dx[mask_1] = x2[mask_1] - x0[mask_1]
             dx[mask_2] = x2[mask_2] - x1[mask_2]
 
@@ -855,7 +916,7 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
             nfev += 2
 
             mask = use_one_sided[j]
-            df = np.empty(m, dtype=f0.dtype)
+            df = xp.empty(m, dtype=f0.dtype)
 
             rows = i[mask]
             df[rows] = -3 * f0[rows] + 4 * f1[rows] - f2[rows]
@@ -876,9 +937,9 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
         col_indices.append(j)
         fractions.append(df[i] / dx[j])
 
-    row_indices = np.hstack(row_indices)
-    col_indices = np.hstack(col_indices)
-    fractions = np.hstack(fractions)
+    row_indices = xp.concat(row_indices, axis=0)
+    col_indices = xp.concat(col_indices, axis=0)
+    fractions = xp.concat(fractions, axis=0)
 
     if isinstance(structure, spmatrix):
         return csr_matrix(
@@ -900,20 +961,31 @@ class _Fun_Wrapper:
         self.x0 = x0
         self.args = args
         self.kwargs = kwargs
+        self._xp = array_namespace(x0)
 
     def __call__(self, x):
         # send user function same fp type as x0. (but only if cs is not being
         # used
-        xp = array_namespace(self.x0)
-
-        if xp.isdtype(x.dtype, "real floating"):
-            x = xp.astype(x, self.x0.dtype)
-
-        f = np.atleast_1d(self.fun(x, *self.args, **self.kwargs))
+        if self._xp.isdtype(x.dtype, "real floating"):
+            x = self._xp.astype(x, self.x0.dtype)
+        f = xpx.atleast_nd(
+            self.fun(x, *self.args, **self.kwargs),
+            ndim=1,
+            xp=self._xp
+        )
         if f.ndim > 1:
             raise RuntimeError("`fun` return value has "
                                "more than 1 dimension.")
         return f
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        self.__dict__.update(state)
 
 
 def check_derivative(fun, jac, x0, bounds=(-np.inf, np.inf), args=(),

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -8,9 +8,12 @@ from pytest import raises as assert_raises
 
 from scipy._lib._testutils import IS_WASM
 
-from scipy._lib._util import MapWrapper, _ScalarFunctionWrapper
+from scipy._lib._util import (MapWrapper, _ScalarFunctionWrapper,
+                              _item_for_scalar_function)
 from scipy.sparse import csr_array, csc_array, lil_array
-from scipy._lib._array_api import xp_result_type
+from scipy._lib._array_api import (xp_result_type, make_xp_test_case, array_namespace,
+                                   xp_assert_close)
+from scipy._external import array_api_extra as xpx
 
 from scipy.optimize._numdiff import (
     _adjust_scheme_to_bounds, approx_derivative, check_derivative,
@@ -46,40 +49,50 @@ def test_group_columns():
     assert_equal(groups_1, groups_2)
 
 
-def test_correct_fp_eps():
+@make_xp_test_case(
+    _eps_for_method
+)
+def test_correct_fp_eps(xp):
     # check that relative step size is correct for FP size
-    EPS = np.finfo(np.float64).eps
+    EPS = xp.finfo(xp.float64).eps
     relative_step = {"2-point": EPS**0.5,
-                    "3-point": EPS**(1/3),
+                     "3-point": EPS**(1/3),
                      "cs": EPS**0.5}
     for method in ['2-point', '3-point', 'cs']:
-        assert_allclose(
-            _eps_for_method(np.float64, np.float64, method),
-            relative_step[method])
-        assert_allclose(
-            _eps_for_method(np.complex128, np.complex128, method),
-            relative_step[method]
+        x = _eps_for_method(xp.float64, xp.float64, method, xp=xp)
+        y = xp.asarray(relative_step[method], dtype=xp.float64)
+        xp_assert_close(
+            x,
+            y,
         )
+        assert x.dtype == xp.float64
 
     # check another FP size
-    EPS = np.finfo(np.float32).eps
+    EPS = xp.finfo(xp.float32).eps
     relative_step = {"2-point": EPS**0.5,
                     "3-point": EPS**(1/3),
                      "cs": EPS**0.5}
 
     for method in ['2-point', '3-point', 'cs']:
-        assert_allclose(
-            _eps_for_method(np.float64, np.float32, method),
-            relative_step[method]
+        x = _eps_for_method(xp.float64, xp.float32, method, xp=xp)
+        y = xp.asarray(relative_step[method], dtype=xp.float32)
+        xp_assert_close(
+            x,
+            y
         )
-        assert_allclose(
-            _eps_for_method(np.float32, np.float64, method),
-            relative_step[method]
+        assert x.dtype == xp.float32
+        x = _eps_for_method(xp.float32, xp.float64, method, xp=xp)
+        xp_assert_close(
+            x,
+            y
         )
-        assert_allclose(
-            _eps_for_method(np.float32, np.float32, method),
-            relative_step[method]
+        assert x.dtype == xp.float32
+        x = _eps_for_method(xp.float32, xp.float32, method, xp=xp)
+        xp_assert_close(
+            x,
+            y
         )
+        assert x.dtype == xp.float32
 
 
 class TestAdjustSchemeToBounds:
@@ -156,39 +169,106 @@ class TestAdjustSchemeToBounds:
         assert_equal(one_sided, np.array([False, True]))
 
 
-class TestApproxDerivativesDense:
+@make_xp_test_case(
+    approx_derivative
+)
+def test_xp_smoke(xp):
+    # a quick smoke test to check approx_derivative with different array-api
+    dtypes = [xp.float32, xp.float64]
+
+    def fun(x):
+        return xp.asarray(2*(x[0]**2 + x[1]**2 - 1) - x[0], dtype=x.dtype)
+
+    def grad(x):
+        return xp.stack([4*x[0]-1, 4*x[1]])
+
+    def hess(x):
+        return 4 * xp.eye(2, dtype=x.dtype)
+
+    for dtype, method, abs_step in product(
+        dtypes,
+        ['2-point', '3-point'],
+        [False, True]
+    ):
+        x0 = xp.asarray([3.0, 4.0], dtype=dtype)
+        f0 = fun(x0)
+
+        # we don't need to check specified rel_steps, as this is tested by
+        # test__compute_absolute_step
+        if abs_step:
+            _h = _compute_absolute_step(None, x0, f0, method, xp=xp)
+        else:
+            _h = None
+
+        g = approx_derivative(fun, x0, method=method, abs_step=_h)
+        xp_assert_close(g, grad(x0))
+
+        h = approx_derivative(grad, x0, method=method, abs_step=_h)
+        xp_assert_close(h, hess(x0))
+
+        # test bounds setting. If we set a lb/ub equal to x0, then
+        # _adjust_scheme_to_bounds is exercised.
+        _b = xp.asarray([3.0, 4.0], dtype=dtype)
+        g = approx_derivative(fun, x0, bounds=(-xp.inf, _b), method=method, abs_step=_h)
+        xp_assert_close(g, grad(x0))
+
+        h = approx_derivative(grad, x0, bounds=(_b, xp.inf), method=method, abs_step=_h)
+        xp_assert_close(h, hess(x0))
+
+
+class TestFunctions:
     def fun_scalar_scalar(self, x):
-        return np.sinh(x)
+        xp = array_namespace(x)
+        return xp.sinh(x)
 
     def jac_scalar_scalar(self, x):
-        return np.cosh(x)
+        xp = array_namespace(x)
+        return xp.cosh(x)
 
     def fun_scalar_vector(self, x):
-        return np.array([x[0]**2, np.tan(x[0]), np.exp(x[0])])
+        xp = array_namespace(x)
+        return xp.stack([x[0] ** 2, xp.tan(x[0]), xp.exp(x[0])])
 
     def jac_scalar_vector(self, x):
-        return np.array(
-            [2 * x[0], np.cos(x[0]) ** -2, np.exp(x[0])]).reshape(-1, 1)
+        xp = array_namespace(x)
+        return xp.reshape(
+            xp.stack([2 * x[0], xp.cos(x[0]) ** -2, xp.exp(x[0])]),
+            (-1, 1)
+        )
 
     def fun_vector_scalar(self, x):
-        return np.sin(x[0] * x[1]) * np.log(x[0])
+        xp = array_namespace(x)
+        return xp.sin(x[0] * x[1]) * xp.log(x[0])
+
+    def jac_vector_scalar(self, x):
+        xp = array_namespace(x)
+        return xp.stack([
+            x[1] * xp.cos(x[0] * x[1]) * xp.log(x[0]) +
+            xp.sin(x[0] * x[1]) / x[0],
+            x[0] * xp.cos(x[0] * x[1]) * xp.log(x[0])],
+        )
+
+    def fun_vector_vector(self, x):
+        xp = array_namespace(x)
+        return xp.stack([
+            x[0] * xp.sin(x[1]),
+            x[1] * xp.cos(x[0]),
+            x[0] ** 3 * x[1] ** -0.5]
+        )
+
+    def jac_vector_vector(self, x):
+        xp = array_namespace(x)
+        return xp.stack([
+            [xp.sin(x[1]), x[0] * xp.cos(x[1])],
+            [-x[1] * xp.sin(x[0]), xp.cos(x[0])],
+            [3 * x[0] ** 2 * x[1] ** -0.5, -0.5 * x[0] ** 3 * x[1] ** -1.5]],
+        )
+
+
+class TestApproxDerivativesDense(TestFunctions):
 
     def wrong_dimensions_fun(self, x):
         return np.array([x**2, np.tan(x), np.exp(x)])
-
-    def jac_vector_scalar(self, x):
-        return np.array([
-            x[1] * np.cos(x[0] * x[1]) * np.log(x[0]) +
-            np.sin(x[0] * x[1]) / x[0],
-            x[0] * np.cos(x[0] * x[1]) * np.log(x[0])
-        ])
-
-    def fun_vector_vector(self, x):
-        return np.array([
-            x[0] * np.sin(x[1]),
-            x[1] * np.cos(x[0]),
-            x[0] ** 3 * x[1] ** -0.5
-        ])
 
     def fun_vector_vector_with_arg(self, x, arg):
         """Used to test passing custom arguments with check_derivative()"""
@@ -197,13 +277,6 @@ class TestApproxDerivativesDense:
             x[0] * np.sin(x[1]),
             x[1] * np.cos(x[0]),
             x[0] ** 3 * x[1] ** -0.5
-        ])
-
-    def jac_vector_vector(self, x):
-        return np.array([
-            [np.sin(x[1]), x[0] * np.cos(x[1])],
-            [-x[1] * np.sin(x[0]), np.cos(x[0])],
-            [3 * x[0] ** 2 * x[1] ** -0.5, -0.5 * x[0] ** 3 * x[1] ** -1.5]
         ])
 
     def jac_vector_vector_with_arg(self, x, arg):
@@ -245,44 +318,55 @@ class TestApproxDerivativesDense:
         xp = np.asarray(x).item()
         return math.exp(xp)
 
-    def test_scalar_scalar(self):
-        x0 = 1.0
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_scalar_scalar(self, xp):
+        x0 = _item_for_scalar_function(xp.asarray(1.0, dtype=xp.float64))
         jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_scalar_scalar, x0)
         jac_diff_4 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='cs')
-        jac_true = self.jac_scalar_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        jac_true = xpx.atleast_nd(self.jac_scalar_scalar(x0), ndim=1, xp=xp)
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-9)
+        xp_assert_close(jac_diff_4, jac_true, rtol=1e-12)
 
-    def test_scalar_scalar_abs_step(self):
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_scalar_scalar_abs_step(self, xp):
         # can approx_derivative use abs_step?
-        x0 = 1.0
+        x0 = _item_for_scalar_function(xp.asarray(1.0, dtype=xp.float64))
         jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='2-point', abs_step=1.49e-8)
         jac_diff_3 = approx_derivative(self.fun_scalar_scalar, x0,
                                        abs_step=1.49e-8)
         jac_diff_4 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='cs', abs_step=1.49e-8)
-        jac_true = self.jac_scalar_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        jac_true = xpx.atleast_nd(self.jac_scalar_scalar(x0), ndim=1, xp=xp)
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-9)
+        xp_assert_close(jac_diff_4, jac_true, rtol=1e-12)
 
-    def test_scalar_vector(self):
-        x0 = 0.5
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_scalar_vector(self, xp):
+        x0 = _item_for_scalar_function(xp.asarray(0.5, dtype=xp.float64))
         with MapWrapper(1 if IS_WASM else 2) as mapper:
             jac_diff_2 = approx_derivative(self.fun_scalar_vector, x0,
                                            method='2-point', workers=mapper)
         jac_diff_3 = approx_derivative(self.fun_scalar_vector, x0, workers=map)
         jac_diff_4 = approx_derivative(self.fun_scalar_vector, x0,
                                        method='cs', workers=None)
-        jac_true = self.jac_scalar_vector(np.atleast_1d(x0))
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        jac_true = self.jac_scalar_vector(
+            xpx.atleast_nd(x0, ndim=1, xp=xp)
+        )
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-9)
+        xp_assert_close(jac_diff_4, jac_true, rtol=1e-12)
 
     @pytest.mark.fail_slow(5.0)
     def test_workers_evaluations_and_nfev(self):
@@ -320,44 +404,54 @@ class TestApproxDerivativesDense:
         assert_equal(md3, d3)
         assert_equal(md4, d4)
 
-    def test_vector_scalar(self):
-        x0 = np.array([100.0, -0.5])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_vector_scalar(self, xp):
+        x0 = xp.asarray([100.0, -0.5], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_vector_scalar, x0)
         jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='cs')
         jac_true = self.jac_vector_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-7)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-7)
+        xp_assert_close(jac_diff_4, jac_true, rtol=1e-12)
 
-    def test_vector_scalar_abs_step(self):
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_vector_scalar_abs_step(self, xp):
         # can approx_derivative use abs_step?
-        x0 = np.array([100.0, -0.5])
+        x0 = xp.asarray([100.0, -0.5], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='2-point', abs_step=1.49e-8)
         jac_diff_3 = approx_derivative(self.fun_vector_scalar, x0,
                                        abs_step=1.49e-8, rel_step=np.inf)
         jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='cs', abs_step=1.49e-8)
-        jac_true = self.jac_vector_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=3e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        jac_true = xp.asarray(self.jac_vector_scalar([100.0, -0.5]))
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_3, jac_true, rtol=3e-9)
+        xp_assert_close(jac_diff_4, jac_true, rtol=1e-12)
 
-    def test_vector_vector(self):
-        x0 = np.array([-100.0, 0.2])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_vector_vector(self, xp):
+        x0 = xp.asarray([-100.0, 0.2], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_vector_vector, x0)
         with MapWrapper(1 if IS_WASM else 2) as mapper:
             jac_diff_4 = approx_derivative(self.fun_vector_vector, x0,
                                            method='cs', workers=mapper)
-        jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-5)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        output = self.jac_vector_vector(np.array([-100.0, 0.2]))
+        jac_true = xp.asarray(output, dtype=xp.float64)
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-5)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-6)
+        xp_assert_close(jac_diff_4, jac_true, rtol=2e-8)
 
     def test_wrong_dimensions(self):
         x0 = 1.0
@@ -367,15 +461,18 @@ class TestApproxDerivativesDense:
         assert_raises(ValueError, approx_derivative,
                       self.wrong_dimensions_fun, x0, f0=f0)
 
-    def test_custom_rel_step(self):
-        x0 = np.array([-0.1, 0.1])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_custom_rel_step(self, xp):
+        x0 = xp.asarray([-0.1, 0.1], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
                                        method='2-point', rel_step=1e-4)
         jac_diff_3 = approx_derivative(self.fun_vector_vector, x0,
                                        rel_step=1e-4)
-        jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-2)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-4)
+        jac_true = xp.asarray(self.jac_vector_vector([-0.1, 0.1]))
+        xp_assert_close(jac_diff_2, jac_true, rtol=1e-2)
+        xp_assert_close(jac_diff_3, jac_true, rtol=1e-4)
 
     def test_options(self):
         x0 = np.array([1.0, 1.0])
@@ -395,41 +492,49 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
 
-    def test_with_bounds_2_point(self):
-        lb = -np.ones(2)
-        ub = np.ones(2)
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_with_bounds_2_point(self, xp):
+        lb = -xp.ones(2)
+        ub = xp.ones(2)
 
-        x0 = np.array([-2.0, 0.2])
+        x0 = xp.asarray([-2.0, 0.2], dtype=xp.float64)
         assert_raises(ValueError, approx_derivative,
                       self.fun_vector_vector, x0, bounds=(lb, ub))
 
-        x0 = np.array([-1.0, 1.0])
+        x0 = xp.asarray([-1.0, 1.0], dtype=xp.float64)
         jac_diff = approx_derivative(self.fun_vector_vector, x0,
                                      method='2-point', bounds=(lb, ub))
-        jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff, jac_true, rtol=1e-6)
+        jac_true = xp.asarray(self.jac_vector_vector([-1.0, 1.0]))
+        xp_assert_close(jac_diff, jac_true, rtol=1e-6)
 
-    def test_with_bounds_3_point(self):
-        lb = np.array([1.0, 1.0])
-        ub = np.array([2.0, 2.0])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_with_bounds_3_point(self, xp):
+        lb = xp.asarray([1.0, 1.0], dtype=xp.float64)
+        ub = xp.asarray([2.0, 2.0], dtype=xp.float64)
 
-        x0 = np.array([1.0, 2.0])
-        jac_true = self.jac_vector_vector(x0)
+        x0 = xp.asarray([1.0, 2.0], dtype=xp.float64)
+        jac_true = xp.asarray(
+            self.jac_vector_vector(np.array([1.0, 2.0])), dtype=xp.float64
+        )
 
         jac_diff = approx_derivative(self.fun_vector_vector, x0)
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+        xp_assert_close(jac_diff, jac_true, rtol=1e-9)
 
         jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     bounds=(lb, np.inf))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+                                     bounds=(lb, xp.inf))
+        xp_assert_close(jac_diff, jac_true, rtol=1e-9)
 
         jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     bounds=(-np.inf, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+                                     bounds=(-xp.inf, ub))
+        xp_assert_close(jac_diff, jac_true, rtol=1e-9)
 
         jac_diff = approx_derivative(self.fun_vector_vector, x0,
                                      bounds=(lb, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+        xp_assert_close(jac_diff, jac_true, rtol=1e-9)
 
     def test_tight_bounds(self):
         x0 = np.array([10.0, 10.0])
@@ -697,47 +802,13 @@ class TestApproxDerivativeSparse:
         assert_(accuracy < 1e-9)
 
 
-class TestApproxDerivativeLinearOperator:
+class TestApproxDerivativeLinearOperator(TestFunctions):
 
-    def fun_scalar_scalar(self, x):
-        return np.sinh(x)
-
-    def jac_scalar_scalar(self, x):
-        return np.cosh(x)
-
-    def fun_scalar_vector(self, x):
-        return np.array([x[0]**2, np.tan(x[0]), np.exp(x[0])])
-
-    def jac_scalar_vector(self, x):
-        return np.array(
-            [2 * x[0], np.cos(x[0]) ** -2, np.exp(x[0])]).reshape(-1, 1)
-
-    def fun_vector_scalar(self, x):
-        return np.sin(x[0] * x[1]) * np.log(x[0])
-
-    def jac_vector_scalar(self, x):
-        return np.array([
-            x[1] * np.cos(x[0] * x[1]) * np.log(x[0]) +
-            np.sin(x[0] * x[1]) / x[0],
-            x[0] * np.cos(x[0] * x[1]) * np.log(x[0])
-        ])
-
-    def fun_vector_vector(self, x):
-        return np.array([
-            x[0] * np.sin(x[1]),
-            x[1] * np.cos(x[0]),
-            x[0] ** 3 * x[1] ** -0.5
-        ])
-
-    def jac_vector_vector(self, x):
-        return np.array([
-            [np.sin(x[1]), x[0] * np.cos(x[1])],
-            [-x[1] * np.sin(x[0]), np.cos(x[0])],
-            [3 * x[0] ** 2 * x[1] ** -0.5, -0.5 * x[0] ** 3 * x[1] ** -1.5]
-        ])
-
-    def test_scalar_scalar(self):
-        x0 = 1.0
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_scalar_scalar(self, xp):
+        x0 = _item_for_scalar_function(xp.asarray(1.0, dtype=xp.float64))
         jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='2-point',
                                        as_linear_operator=True)
@@ -750,15 +821,21 @@ class TestApproxDerivativeLinearOperator:
         rng = np.random.default_rng(11290049580398)
         for i in range(10):
             p = rng.uniform(-10, 10, size=(1,))
-            assert_allclose(jac_diff_2.dot(p), jac_true*p,
+            p = xp.asarray(p, dtype=x0.dtype)
+
+            xp_assert_close(jac_diff_2.dot(p), jac_true*p,
                             rtol=1e-5)
-            assert_allclose(jac_diff_3.dot(p), jac_true*p,
+            xp_assert_close(jac_diff_3.dot(p), jac_true*p,
                             rtol=5e-6)
-            assert_allclose(jac_diff_4.dot(p), jac_true*p,
+            xp_assert_close(jac_diff_4.dot(p), jac_true*p,
                             rtol=5e-6)
 
-    def test_scalar_vector(self):
-        x0 = 0.5
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_scalar_vector(self, xp):
+        x0 = _item_for_scalar_function(xp.asarray(0.5, dtype=xp.float64))
+
         jac_diff_2 = approx_derivative(self.fun_scalar_vector, x0,
                                        method='2-point',
                                        as_linear_operator=True)
@@ -767,19 +844,26 @@ class TestApproxDerivativeLinearOperator:
         jac_diff_4 = approx_derivative(self.fun_scalar_vector, x0,
                                        method='cs',
                                        as_linear_operator=True)
-        jac_true = self.jac_scalar_vector(np.atleast_1d(x0))
+
+        jac_true = self.jac_scalar_vector(
+            xpx.atleast_nd(xp.asarray(x0, dtype=xp.float64), ndim=1, xp=xp)
+        )
         rng = np.random.default_rng(11290049580398)
         for i in range(10):
             p = rng.uniform(-10, 10, size=(1,))
-            assert_allclose(jac_diff_2.dot(p), jac_true.dot(p),
+            p = xp.asarray(p, dtype=x0.dtype)
+            xp_assert_close(jac_diff_2.dot(p), xp.tensordot(jac_true, p, axes=1),
                             rtol=1e-5)
-            assert_allclose(jac_diff_3.dot(p), jac_true.dot(p),
+            xp_assert_close(jac_diff_3.dot(p), xp.tensordot(jac_true, p, axes=1),
                             rtol=5e-6)
-            assert_allclose(jac_diff_4.dot(p), jac_true.dot(p),
+            xp_assert_close(jac_diff_4.dot(p), xp.tensordot(jac_true, p, axes=1),
                             rtol=5e-6)
 
-    def test_vector_scalar(self):
-        x0 = np.array([100.0, -0.5])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_vector_scalar(self, xp):
+        x0 = xp.asarray([100.0, -0.5], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='2-point',
                                        as_linear_operator=True)
@@ -788,19 +872,26 @@ class TestApproxDerivativeLinearOperator:
         jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='cs',
                                        as_linear_operator=True)
-        jac_true = self.jac_vector_scalar(x0)
+        jac_true = xp.asarray(self.jac_vector_scalar([100.0, -0.5]))
         rng = np.random.default_rng(11290049580398)
         for i in range(10):
             p = rng.uniform(-10, 10, size=x0.shape)
-            assert_allclose(jac_diff_2.dot(p), np.atleast_1d(jac_true.dot(p)),
+            p = xp.asarray(p, dtype=x0.dtype)
+            expected = xpx.atleast_nd(
+                xp.tensordot(jac_true, p, axes=1), ndim=1, xp=xp
+            )
+            xp_assert_close(jac_diff_2.dot(p), expected,
                             rtol=1e-5)
-            assert_allclose(jac_diff_3.dot(p), np.atleast_1d(jac_true.dot(p)),
+            xp_assert_close(jac_diff_3.dot(p), expected,
                             rtol=5e-6)
-            assert_allclose(jac_diff_4.dot(p), np.atleast_1d(jac_true.dot(p)),
+            xp_assert_close(jac_diff_4.dot(p), expected,
                             rtol=1e-7)
 
-    def test_vector_vector(self):
-        x0 = np.array([-100.0, 0.2])
+    @make_xp_test_case(
+        approx_derivative
+    )
+    def test_vector_vector(self, xp):
+        x0 = xp.asarray([-100.0, 0.2], dtype=xp.float64)
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
                                        method='2-point',
                                        as_linear_operator=True)
@@ -809,13 +900,20 @@ class TestApproxDerivativeLinearOperator:
         jac_diff_4 = approx_derivative(self.fun_vector_vector, x0,
                                        method='cs',
                                        as_linear_operator=True)
-        jac_true = self.jac_vector_vector(x0)
+        jac_true = xp.asarray(self.jac_vector_vector([-100.0, 0.2]))
         rng = np.random.default_rng(11290049580398)
         for i in range(10):
             p = rng.uniform(-10, 10, size=x0.shape)
-            assert_allclose(jac_diff_2.dot(p), jac_true.dot(p), rtol=1e-5)
-            assert_allclose(jac_diff_3.dot(p), jac_true.dot(p), rtol=1e-6)
-            assert_allclose(jac_diff_4.dot(p), jac_true.dot(p), rtol=1e-7)
+            p = xp.asarray(p, dtype=x0.dtype)
+            expected = xpx.atleast_nd(
+                xp.tensordot(jac_true, p, axes=1), ndim=1, xp=xp
+            )
+            x = jac_diff_2.dot(p)
+            xp_assert_close(x, expected, rtol=1e-5)
+            x = jac_diff_3.dot(p)
+            xp_assert_close(x, expected, rtol=1e-6)
+            x = jac_diff_4.dot(p)
+            xp_assert_close(x, expected, rtol=1.5e-7)
 
     def test_exception(self):
         x0 = np.array([-100.0, 0.2])
@@ -877,71 +975,80 @@ def test_absolute_step_sign():
     assert_allclose(grad, [-1.0, 1.0])
 
 
-def test__compute_absolute_step():
+@make_xp_test_case(
+    _compute_absolute_step
+)
+def test__compute_absolute_step(xp):
     # tests calculation of absolute step from rel_step
     methods = ['2-point', '3-point', 'cs']
 
-    x0 = np.array([1e-5, 0, 1, 1e5])
+    x0 = xp.asarray([1e-5, 0, 1, 1e5], dtype=xp.float64)
 
-    EPS = np.finfo(np.float64).eps
+    EPS = xp.finfo(xp.float64).eps
     relative_step = {
         "2-point": EPS**0.5,
         "3-point": EPS**(1/3),
         "cs": EPS**0.5
     }
-    f0 = np.array(1.0)
+    f0 = xp.asarray(1.0, dtype=xp.float64)
 
     for method in methods:
         rel_step = relative_step[method]
-        correct_step = np.array([rel_step,
-                                 rel_step * 1.,
-                                 rel_step * 1.,
-                                 rel_step * np.abs(x0[3])])
+        correct_step = xp.stack(
+            [xp.asarray(rel_step),
+             xp.asarray(rel_step * 1.),
+             xp.asarray(rel_step * 1.),
+             xp.asarray(rel_step * xp.abs(x0[3]))],
+        )
 
-        abs_step = _compute_absolute_step(None, x0, f0, method)
-        assert_allclose(abs_step, correct_step)
+        abs_step = _compute_absolute_step(None, x0, f0, method, xp=xp)
+        xp_assert_close(abs_step, correct_step)
 
-        sign_x0 = (-x0 >= 0).astype(float) * 2 - 1
-        abs_step = _compute_absolute_step(None, -x0, f0, method)
-        assert_allclose(abs_step, sign_x0 * correct_step)
+        sign_x0 = xp.astype(-x0 >= 0, xp.float64) * 2 - 1
+        abs_step = _compute_absolute_step(None, -x0, f0, method, xp=xp)
+        xp_assert_close(abs_step, sign_x0 * correct_step)
 
     # if a relative step is provided it should be used
-    rel_step = np.array([0.1, 1, 10, 100])
-    correct_step = np.array([rel_step[0] * x0[0],
-                             relative_step['2-point'],
-                             rel_step[2] * 1.,
-                             rel_step[3] * np.abs(x0[3])])
+    rel_step = xp.asarray([0.1, 1, 10, 100], dtype=xp.float64)
+    correct_step = xp.stack(
+        [xp.asarray(rel_step[0] * x0[0]),
+         xp.asarray(relative_step['2-point']),
+         xp.asarray(rel_step[2] * 1.),
+         xp.asarray(rel_step[3] * xp.abs(x0[3]))],
+    )
 
     abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
-    assert_allclose(abs_step, correct_step)
+    xp_assert_close(abs_step, correct_step)
 
-    sign_x0 = (-x0 >= 0).astype(float) * 2 - 1
+    sign_x0 = xp.astype(-x0 >= 0, xp.float64) * 2 - 1
     abs_step = _compute_absolute_step(rel_step, -x0, f0, '2-point')
-    assert_allclose(abs_step, sign_x0 * correct_step)
+    xp_assert_close(abs_step, sign_x0 * correct_step)
 
     # the dtype of absolute step should be the same as x0
     #def _compute_absolute_step(rel_step, x0, f0, method):
-    x0 = np.array([1e-5, 0, 1, 1e5], dtype=np.float32)
+    x0 = xp.asarray([1e-5, 0, 1, 1e5], dtype=xp.float32)
     abs_step = _compute_absolute_step(None, x0, f0, '3-point')
-    assert abs_step.dtype == np.float32
+    assert abs_step.dtype == xp.float32
     abs_step = _compute_absolute_step(None, x0, f0, '2-point')
-    assert abs_step.dtype == np.float32
+    assert abs_step.dtype == xp.float32
 
-    x0 = np.array([0.1, 0, 1, 50], dtype=np.float16)
-    abs_step = _compute_absolute_step(None, x0, f0, '3-point')
-    assert abs_step.dtype == np.float16
-    abs_step = _compute_absolute_step(None, x0, f0, '2-point')
-    assert abs_step.dtype == np.float16
+    # check for 16-bit x0 and f0
+    if hasattr(xp, "float16"):
+        x0 = xp.asarray([0.1, 0, 1, 50], dtype=xp.float16)
+        abs_step = _compute_absolute_step(None, x0, f0, '3-point')
+        assert abs_step.dtype == xp.float16
+        abs_step = _compute_absolute_step(None, x0, f0, '2-point')
+        assert abs_step.dtype == xp.float16
 
-    x0 = np.array([1e-3, 0, 1, 10], dtype=np.float64)
-    f0 = np.array(1.0, dtype=np.float16)
-    abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
-    assert abs_step.dtype == np.float64
+        x0 = xp.asarray([1e-3, 0, 1, 10], dtype=xp.float64)
+        f0 = xp.asarray(1.0, dtype=xp.float16)
+        abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
+        assert abs_step.dtype == xp.float64
 
-    x0 = np.array([1e-5, 0, 1, 1e5], dtype=np.float32)
-    abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
-    assert abs_step.dtype == np.float32
+        x0 = xp.asarray([1e-5, 0, 1, 1e5], dtype=xp.float32)
+        abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
+        assert abs_step.dtype == xp.float32
 
-    x0 = np.array([1e-3, 0, 1, 10], dtype=np.float16)
-    abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
-    assert abs_step.dtype == np.float16
+        x0 = xp.asarray([1e-3, 0, 1, 10], dtype=xp.float16)
+        abs_step = _compute_absolute_step(rel_step, x0, f0, '2-point')
+        assert abs_step.dtype == xp.float16

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -1,4 +1,5 @@
 import pytest
+import pickle
 import numpy as np
 
 from scipy._lib._testutils import IS_WASM
@@ -6,7 +7,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_equal, assert_, assert_allclose,
                            assert_equal)
 from scipy._lib._gcutils import assert_deallocated
-from scipy._lib._util import MapWrapper
+from scipy._lib._util import MapWrapper, xp_array_equal
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import LinearOperator
 from scipy.optimize._differentiable_functions import (ScalarFunction,
@@ -15,6 +16,8 @@ from scipy.optimize._differentiable_functions import (ScalarFunction,
                                                       IdentityVectorFunction)
 from scipy.optimize import rosen, rosen_der, rosen_hess
 from scipy.optimize._hessian_update_strategy import BFGS
+from scipy._lib._array_api import make_xp_test_case, array_namespace
+from scipy._lib._array_api_no_0d import xp_assert_close
 
 
 class ExScalarFunction:
@@ -30,14 +33,16 @@ class ExScalarFunction:
 
     def grad(self, x):
         self.ngev += 1
-        return np.array([4*x[0]-1, 4*x[1]])
+        xp = array_namespace(x)
+        return xp.asarray([4*x[0]-1, 4*x[1]])
 
     def hess(self, x):
         self.nhev += 1
-        return 4*np.eye(2)
+        xp = array_namespace(x)
+        return 4 * xp.eye(2)
 
 
-class TestScalarFunction(TestCase):
+class TestScalarFunction:
 
     def test_finite_difference_grad(self):
         ex = ExScalarFunction()
@@ -135,6 +140,17 @@ class TestScalarFunction(TestCase):
     @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         x0 = np.array([2.0, 0.3])
+        ex = ExScalarFunction()
+
+        # checking that the wrapped function is pickleable is a useful sentinel
+        # for deeper problems.
+        # When using a mapper the tests hang if ScalarFunction._wrapped_fun isn't pickleable
+        approx = ScalarFunction(ex.fun, x0, (), '2-point',
+                                ex.hess, None, (-np.inf, np.inf),
+                                )
+        pkl = pickle.dumps(approx._wrapped_fun)
+        _o = pickle.loads(pkl)
+
         ex = ExScalarFunction()
         ex2 = ExScalarFunction()
         with MapWrapper(1 if IS_WASM else 2) as mapper:
@@ -454,6 +470,32 @@ class TestScalarFunction(TestCase):
         assert fx.dtype == np.float32
         # check that the round trip cast works as intended
         assert_equal(fx, fun(x0))
+
+    @make_xp_test_case(
+        (ScalarFunction, "fun")
+    )
+    def test_xp_fun(self, xp):
+        dtypes = [xp.float32, xp.float64]
+
+        for dtype in dtypes:
+            ex = ExScalarFunction()
+            ex2 = ExScalarFunction()
+            x0 = xp.asarray([3.0, 4.0], dtype=dtype)
+            sf = ScalarFunction(
+                ex.fun,
+                x0,
+                (),
+                ex.grad,
+                ex.hess,
+            )
+            y = ex2.fun([3.0, 4.0])
+            xp_assert_close(
+                sf.fun(x0),
+                y,
+                check_namespace=False,
+                check_dtype=False
+            )
+            # assert y.dtype == dtype
 
 
 class ExVectorialFunction:

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -7,7 +7,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_equal, assert_, assert_allclose,
                            assert_equal)
 from scipy._lib._gcutils import assert_deallocated
-from scipy._lib._util import MapWrapper, xp_array_equal
+from scipy._lib._util import MapWrapper
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import LinearOperator
 from scipy.optimize._differentiable_functions import (ScalarFunction,
@@ -34,7 +34,7 @@ class ExScalarFunction:
     def grad(self, x):
         self.ngev += 1
         xp = array_namespace(x)
-        return xp.asarray([4*x[0]-1, 4*x[1]])
+        return xp.stack([4*x[0]-1, 4*x[1]])
 
     def hess(self, x):
         self.nhev += 1
@@ -144,7 +144,8 @@ class TestScalarFunction:
 
         # checking that the wrapped function is pickleable is a useful sentinel
         # for deeper problems.
-        # When using a mapper the tests hang if ScalarFunction._wrapped_fun isn't pickleable
+        # When using a mapper the tests hang if ScalarFunction._wrapped_fun isn't
+        # pickleable
         approx = ScalarFunction(ex.fun, x0, (), '2-point',
                                 ex.hess, None, (-np.inf, np.inf),
                                 )
@@ -488,14 +489,72 @@ class TestScalarFunction:
                 ex.grad,
                 ex.hess,
             )
-            y = ex2.fun([3.0, 4.0])
+            y = ex2.fun(xp.asarray([3.0, 4.0], dtype=xp.float64))
             xp_assert_close(
                 sf.fun(x0),
                 y,
-                check_namespace=False,
+                check_namespace=True,
                 check_dtype=False
             )
-            # assert y.dtype == dtype
+            assert sf.fun(x0).dtype == dtype
+
+    @make_xp_test_case(
+        (ScalarFunction, "grad")
+    )
+    def test_xp_grad(self, xp):
+        dtypes = [xp.float32, xp.float64]
+
+        for dtype in dtypes:
+            ex = ExScalarFunction()
+            ex2 = ExScalarFunction()
+            x0 = xp.asarray([3.0, 4.0], dtype=dtype)
+            sf = ScalarFunction(
+                ex.fun,
+                x0,
+                (),
+                ex.grad,
+                ex.hess,
+            )
+            y = ex2.grad(xp.asarray([3.0, 4.0], dtype=dtype))
+            xp_assert_close(
+                sf.grad(x0),
+                y,
+            )
+
+            sf = ScalarFunction(
+                ex.fun,
+                x0,
+                (),
+                '2-point',
+                ex.hess,
+            )
+            xp_assert_close(
+                sf.grad(x0),
+                y,
+            )
+
+    @make_xp_test_case(
+        (ScalarFunction, "hess")
+    )
+    def test_xp_hess(self, xp):
+        dtypes = [xp.float32, xp.float64]
+
+        for dtype in dtypes:
+            ex = ExScalarFunction()
+            ex2 = ExScalarFunction()
+            x0 = xp.asarray([3.0, 4.0], dtype=dtype)
+            sf = ScalarFunction(
+                ex.fun,
+                x0,
+                (),
+                '3-point',
+                ex.hess,
+            )
+            y = ex2.hess(xp.asarray([3.0, 4.0], dtype=dtype))
+            xp_assert_close(
+                sf.hess(x0),
+                y,
+            )
 
 
 class ExVectorialFunction:


### PR DESCRIPTION
Builds on #25606 to enable `ScalarFunction` to work in an array-api compatible manner. This is a necessary building block for enabling array-api compatibility in `optimize.minimize`. The changes in 25606 are contained in here, because this is a branch off of that feature branch.

c.f. #25583. @lorentzenchr, this is what I meant by a staged approach. I'd like to see `ScalarFunction` fully working, *and tested*, with array-api compatibility in mind before tackling any `minimize` methods.

#### What does this implement/fix?
Necessary building block for array-api compatibility in `minimize`.

#### AI Generation Disclosure
#25606 did use claude for creating the `item` function.