### PR TITLE
WIP: CI: `emscripten-wasm32` build with Pixi

### DIFF
--- a/.github/workflows/commit_message.yml
+++ b/.github/workflows/commit_message.yml
@@ -32,7 +32,7 @@ jobs:
         # and changing the output here based on the combination of tags (if desired).
         run: |
           set -xe
-          RUN="1"
+          RUN="0" # turn off other jobs for now
           # For running a job locally with Act (https://github.com/nektos/act),
           # always run the job rather than skip based on commit message
           if [[ $ACT != true ]]; then

--- a/.github/workflows/pixi-packages.yml
+++ b/.github/workflows/pixi-packages.yml
@@ -22,6 +22,27 @@ jobs:
     name: Get commit message
     uses: ./.github/workflows/commit_message.yml
 
+  emscripten_wasm32:
+    name: Build
+    # needs: get_commit_message
+    # if: >
+    #   needs.get_commit_message.outputs.message == 1
+    #   && (github.repository == 'scipy/scipy' || github.repository == '')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
+        with:
+          pixi-version: v0.72.2
+          run-install: false
+
+      - name: Build
+        run: pixi publish --path=pixi-packages/emscripten --target-platform=emscripten-wasm32
+
   build_packages:
     name: Build
     needs: get_commit_message

--- a/pixi-packages/emscripten/emscripten.meson.cross
+++ b/pixi-packages/emscripten/emscripten.meson.cross
@@ -1,0 +1,14 @@
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'
+
+[binaries]
+exe_wrapper = 'node'
+pkg-config = 'pkg-config'

--- a/pixi-packages/emscripten/pixi.toml
+++ b/pixi-packages/emscripten/pixi.toml
@@ -1,0 +1,50 @@
+[workspace]
+channels = ["https://prefix.dev/emscripten-forge-4x", "https://prefix.dev/conda-forge"]
+platforms = ["linux-64", "emscripten-wasm32"]
+preview = ["pixi-build"]
+
+[dependencies]
+python = "*"
+scipy.path = "."
+
+[workspace.build-variants]
+python = ["3.13.*"]
+
+[package]
+name = "scipy"
+version = "1.18.0"
+
+[package.build.backend]
+name = "pixi-build-python"
+
+[package.build.source]
+git = "https://github.com/ianthomas23/scipy"
+branch = "v1.18.0-emforge"
+
+[package.build.config]
+compilers = ["c", "cxx"]
+extra-args = [
+  '-Csetup-args="--cross-file=$RECIPE_DIR/emscripten.meson.cross"',
+  '-Csetup-args="-Duse-pythran=false"',
+  '-Csetup-args="-D_without-fortran=true"',
+  # '-Cbuild-dir="_build"', useful locally
+]
+installer = "pip" # no `uv` on emscripten-wasm32
+
+[package.build.config.env]
+# are these workarounds that can be removed at some point?
+PKG_CONFIG_PATH = "$PREFIX/lib/python3.13/site-packages/numpy/_core/lib/pkgconfig"
+LD_LIBRARY_PATH = "$BUILD_PREFIX/lib"
+
+[package.build-dependencies]
+python = "*"
+cross-python_emscripten-wasm32 = "*"
+cython = "*"
+meson-python = "*"
+numpy = "*"
+pkg-config = "*"
+
+[package.host-dependencies]
+numpy = "*"
+openblas = "*"
+pybind11 = "*"


### PR DESCRIPTION
Porting https://github.com/emscripten-forge/recipes/blob/main/recipes/recipes_emscripten/scipy/recipe.yaml to pixi-build-python.

TODO:
- this doesn't actually work yet at runtime (see `import scipy.linalg` failure at https://github.com/scipy/scipy/pull/25629#issuecomment-4971223329)
- reduce the amount of patches (https://github.com/emscripten-forge/recipes/blob/9809eeb778b804a5ac94f25234af9084c76645c2/recipes/recipes_emscripten/scipy/recipe.yaml#L12-L30) and figure out how to apply the rest
- tests

Non-replicated parts of the recipe that may be of interest:
- https://github.com/emscripten-forge/recipes/blob/9809eeb778b804a5ac94f25234af9084c76645c2/recipes/recipes_emscripten/scipy/recipe.yaml#L35-L44
- https://github.com/emscripten-forge/recipes/blob/9809eeb778b804a5ac94f25234af9084c76645c2/recipes/recipes_emscripten/scipy/build.sh#L18-L19