### PR TITLE
TST: sparse.linalg: skip tfqmr/rand-sym-pd-F on all platforms

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -37,10 +37,6 @@ _SOLVERS = [bicg, bicgstab, cg, cgs, gcrotmk, gmres, lgmres,
 CB_TYPE_FILTER = ".*called without specifying `callback_type`.*"
 
 
-def _is_32bit():
-    return np.intp(0).itemsize < 8
-
-
 def _assert_success(*, A, x, b, xp, rtol=1.0, atol=0.0, less_equal=False):
     Ax = xp.squeeze(A @ x[..., xp.newaxis], axis=-1)
     residual = Ax - b
@@ -323,8 +319,11 @@ def test_maxiter(case, xp, batch_A, batch_b):
 def test_convergence(case, xp, batch_A, batch_b):
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Struggles to converge with single precision on some platforms")
-    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
-        pytest.skip("Fails to converge on i686 (32-bit) linux")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
+        # Numerical stability is borderline for single precision, tfqmr stagnates at a
+        # relative residual ||b - Ax||/||b|| of ~2e-2, failure yes/no depends on
+        # platform-specific rounding behavior (see, e.g., scipy#25522)
+        pytest.skip("Fails to converge with single precision on some platforms")
 
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     A = case.A
@@ -357,8 +356,9 @@ def test_precond_dummy(case, xp, batch_A, batch_b):
         pytest.skip("Struggles to converge with single precision")
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Hits divide-by-zero with single precision")
-    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
-        pytest.skip("Fails to converge on i686 (32-bit) linux")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
+        # Numerical stability is borderline for float32 (see, scipy#25522)
+        pytest.skip("Fails to converge with single precision on some platforms")
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
 


### PR DESCRIPTION
In single precision, `tfqmr` stagnates at a relative residual of ~2e-2 on this fairly ill-conditioned test matrix (condition number ~4e3), and whether that lands under the test tolerance depends on platform rounding behavior: it passes on x86-64 but fails on i686 (already skipped), linux-aarch64 (locally, and as reported in gh-25522 for Nix builds), as well as in open PRs for ASan and WASM.

So, widen the existing 32-bit-only skip to all platforms.

Closes gh-25522


#### AI Generation Disclosure

I used Claude Fable 5 during the debugging process to monitor the convergence behavior of `tmfqr` after reproducing the failure locally, which helped show what the problem was. 