### PR TITLE
BUG: signal.{csd,peridogram}: Fix behavior when input signal(s)  are shorter than window

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1125,7 +1125,8 @@ class ShortTimeFFT:
         ----------
         x : np.ndarray
             The input signal as real or complex valued array. For complex values, the
-            property `fft_mode` must be set to 'twosided' or 'centered'.
+            property `fft_mode` must be set to 'twosided' or 'centered'. Its length,
+            i.e., ``x.shape[axis]``, must be at least half the window length.
         p0 : int | None
             The first element of the range of slices to calculate. If ``None``
             then it is set to :attr:`p_min`, which is the smallest possible
@@ -1187,7 +1188,8 @@ class ShortTimeFFT:
         ----------
         x : np.ndarray
             The input signal as real or complex valued array. For complex values, the
-            property `fft_mode` must be set to 'twosided' or 'centered'.
+            property `fft_mode` must be set to 'twosided' or 'centered'. Its length,
+            i.e., ``x.shape[axis]``, must be at least half the window length.
         detr : 'linear' |  'constant' |  Callable[[np.ndarray], np.ndarray] | None
             If 'constant', the mean is subtracted, if set to "linear", the linear
             trend is removed from each segment. This is achieved by calling
@@ -1279,11 +1281,13 @@ class ShortTimeFFT:
         ----------
         x : np.ndarray
             The input signal as real or complex valued array. For complex values, the
-            property `fft_mode` must be set to 'twosided' or 'centered'.
+            property `fft_mode` must be set to 'twosided' or 'centered'. Its length,
+            i.e., ``x.shape[axis]``, must be at least half the window length.
         y : np.ndarray
             The second input signal of the same shape as `x`. If ``None``, it is
             assumed to be `x`. For complex values, the property `fft_mode` must be
-            set to 'twosided' or 'centered'.
+            set to 'twosided' or 'centered'. Its length, i.e., ``y.shape[axis]``, must
+            be at least half the window length.
         detr : 'linear' |  'constant' |  Callable[[np.ndarray], np.ndarray] | None
             If 'constant', the mean is subtracted, if set to "linear", the linear
             trend is removed from each segment. This is achieved by calling

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -896,7 +896,7 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     if x is y:
         out_dtype = np.result_type(x, np.complex64)
     else:  # x is not y:
-        y = np.array(y)
+        y = np.asarray(y)
         out_dtype = np.result_type(x, y, np.complex64)
 
     n = max(x.shape[ax], y.shape[ax], nperseg)
@@ -924,9 +924,9 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
         return_onesided = False
 
     # Translate parameters to ShortTimeFFT's conventions:
-    SCALES = {"spectrum": "magnitude", "density": "psd"}
-    if (scale_to := SCALES.get(scaling, None)) is None:
-        raise ValueError(f"Parameter {scaling=} not in {SCALES}!")
+    SCALINGS = {"spectrum": "magnitude", "density": "psd"}
+    if (scale_to := SCALINGS.get(scaling, None)) is None:
+        raise ValueError(f"Parameter {scaling=} not in {SCALINGS}!")
     fft_mode = "onesided" if return_onesided else "twosided"
     if (n := x.shape[ax]) < nperseg:
         raise ValueError(f"Signal length {n=} ≥ nperseg={nperseg} does not hold!")

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -349,7 +349,8 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     Parameters
     ----------
     x : array_like
-        Time series of measurement values
+        Time series of measurement values. If its length (i.e., ``x.shape[axis]``) is
+        less than `nfft`, it is zero-padded to that length.
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
@@ -361,14 +362,14 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         of the axis over which the periodogram is computed. Defaults
         to 'boxcar'.
     nfft : int, optional
-        Length of the FFT used. If `None` the length of `x` will be
-        used.
-    detrend : str or function or `False`, optional
-        Specifies how to detrend each segment. If `detrend` is a
-        string, it is passed as the `type` argument to the `detrend`
-        function. If it is a function, it takes a segment and returns a
-        detrended segment. If `detrend` is `False`, no detrending is
-        done. Defaults to 'constant'.
+        Length of the FFT used. If ``None`` and `window` is a string or tuple, then
+        the length of `x` will be used. If ``None`` and `window` is an array, then
+        ``len(window)`` will be used. A ``ValueError`` will be raised if ``nfft < 1``.
+    detrend : 'linear' | 'constant' | Callable[[ndarray], ndarray] | False, optional
+        If not ``False`` then a trend is removed from each segment: If 'constant'
+        (default), the mean is subtracted. If 'linear', the linear trend is removed.
+        This is achieved by calling `detrend`. If *detrend* is a function with one
+        parameter, *detrend* is applied to each segment.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
         `False` return a two-sided spectrum. Defaults to `True`, but for
@@ -461,30 +462,19 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
 
     """
     x = np.asarray(x)
-
-    if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape)
-
     if window is None:
         window = 'boxcar'
-
+    elif not isinstance(window, str | tuple):
+        window = np.asarray(window)
     if nfft is None:
-        nperseg = x.shape[axis]
-    elif nfft == x.shape[axis]:
-        nperseg = nfft
-    elif nfft > x.shape[axis]:
-        nperseg = x.shape[axis]
-    elif nfft < x.shape[axis]:
-        s = [np.s_[:]]*len(x.shape)
-        s[axis] = np.s_[:nfft]
-        x = x[tuple(s)]
-        nperseg = nfft
-        nfft = None
-
-    if hasattr(window, 'size'):
-        if window.size != nperseg:
-            raise ValueError('the size of the window must be the same size '
-                             'of the input on the specified axis')
+        nfft = x.shape[axis] if isinstance(window, str | tuple) else len(window)
+    if not nfft > 0:
+        raise ValueError(f"Parameter {nfft=} not positive due to signal length " +
+                         "and/or window length being zero!")
+    nperseg = nfft if nfft <= x.shape[axis] else x.shape[axis]
+    if (not isinstance(window, str | tuple)) and window.shape != (nperseg,):
+        raise ValueError("Parameter `window` is not an 1d-array of length `nperseg`, " +
+                         f"but {window.shape=}!")
 
     return welch(x, fs=fs, window=window, nperseg=nperseg, noverlap=0,
                  nfft=nfft, detrend=detrend, return_onesided=return_onesided,
@@ -494,8 +484,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
 def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density',
           axis=-1, average='mean'):
-    r"""
-    Estimate power spectral density using Welch's method.
+    r"""Estimate power spectral density using Welch's method.
 
     Welch's method [1]_ computes an estimate of the power spectral
     density by dividing the data into overlapping segments, computing a
@@ -505,7 +494,9 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
     Parameters
     ----------
     x : array_like
-        Time series of measurement values
+        Input signal made up of ``n_x`` equidistant samples. If `x` is a
+        multidimensional array, then the time axis is defined by the `axis` parameter.
+        If needed, `x` is zero-padded to length `nperseg`.
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
@@ -513,39 +504,41 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
         passed to `get_window` to generate the window values, which are
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
-        directly as the window and its length must be nperseg. Defaults
-        to a periodic Hann window.
+        directly as the window, and it must be of shape ``(nperseg,)``.
+        Defaults to a periodic Hann window.
     nperseg : int, optional
-        Length of each segment. Defaults to None, but if window is str or
-        tuple, is set to 256, and if window is array_like, is set to the
-        length of the window.
+        Length of each segment. If ``None`` (default) and `window` is a str or a tuple,
+        it is set to 256. If ``None`` and `window` is an array then `nperseg` is set
+        to ``len(window)``. A ``ValueError`` is raised, if ``nperseg != len(window)`` or
+        if ``nperseg < 1``.
     noverlap : int, optional
-        Number of points to overlap between segments. If `None`,
-        ``noverlap = nperseg // 2``. Defaults to `None`.
+        Number of points to overlap between segments. If ``None`` (default),
+        ``noverlap = nperseg // 2``. It may not be greater than `nperseg`.
     nfft : int, optional
         Length of the FFT used, if a zero padded FFT is desired. If
-        `None`, the FFT length is `nperseg`. Defaults to `None`.
-    detrend : str or function or `False`, optional
-        Specifies how to detrend each segment. If `detrend` is a
-        string, it is passed as the `type` argument to the `detrend`
-        function. If it is a function, it takes a segment and returns a
-        detrended segment. If `detrend` is `False`, no detrending is
-        done. Defaults to 'constant'.
+        ``None``, the FFT length is `nperseg`. Defaults to ``None``.
+    detrend : 'linear' | 'constant' | Callable[[ndarray], ndarray] | False, optional
+        If not ``False`` then a trend is removed from each segment: If 'constant'
+        (default), the mean is subtracted. If 'linear', the linear trend is removed.
+        This is achieved by calling `detrend`. If *detrend* is a function with one
+        parameter, *detrend* is applied to each segment.
     return_onesided : bool, optional
-        If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for
+        If ``True``, return a one-sided spectrum for real data. If
+        ``False`` return a two-sided spectrum. Defaults to ``True``, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz and computing the squared magnitude
-        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        where `Pxx` has units of V²/Hz and computing the squared magnitude
+        spectrum ('spectrum') where `Pxx` has units of V², if `x`
         is measured in V and `fs` is measured in Hz. Defaults to
         'density'
     axis : int, optional
         Axis along which the periodogram is computed; the default is
         over the last axis (i.e. ``axis=-1``).
     average : { 'mean', 'median' }, optional
-        Method to use when averaging periodograms. Defaults to 'mean'.
+        Method to use when averaging periodograms. Since the spectrum is
+        complex-valued, the mean / median is computed separately for the real and
+        imaginary parts. Defaults to 'mean'.
 
         .. versionadded:: 1.2.0
 
@@ -554,7 +547,7 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
     f : ndarray
         Array of sample frequencies.
     Pxx : ndarray
-        Power spectral density or power spectrum of x.
+        Real-valued power spectral density or power spectrum of x.
 
     See Also
     --------
@@ -658,11 +651,8 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
     >>> plt.show()
 
     """
-    xp = (
-        array_namespace(x)
-        if isinstance(window, str | tuple)
-        else array_namespace(x, window)
-    )
+    xp = (array_namespace(x) if isinstance(window, str | tuple) else
+          array_namespace(x, window))
     device = xp_result_device(x, window)
     x_np = np.asarray(x)
     freqs_np, Pxx_np = csd(x_np, x_np, fs=fs, window=window, nperseg=nperseg,
@@ -677,15 +667,18 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
 def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density',
         axis=-1, average='mean'):
-    r"""
-    Estimate the cross power spectral density, Pxy, using Welch's method.
+    r"""Estimate the cross power spectral density, Pxy, using Welch's method.
 
     Parameters
     ----------
     x : array_like
-        Time series of measurement values
+        The first signal made up of ``n_x`` equidistant samples. If `x` is a
+        multidimensional array, then the time axis is defined by the `axis` parameter.
+        If needed, `x` is zero-padded to length ``n = max(n_x, n_y, nperseg)``.
     y : array_like
-        Time series of measurement values
+        The second signal made up of ``n_y`` equidistant samples. If `y` is a
+        multidimensional array, then the time axis is defined by the `axis` parameter.
+        If needed, `y` is zero-padded to length ``n = max(n_x, n_y, nperseg)``.
     fs : float, optional
         Sampling frequency of the `x` and `y` time series. Defaults
         to 1.0.
@@ -694,40 +687,39 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
         passed to `get_window` to generate the window values, which are
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
-        directly as the window and its length must be nperseg. Defaults
-        to a periodic Hann window.
+        directly as the window, and it must be of shape ``(nperseg,)``.
+        Defaults to a periodic Hann window.
     nperseg : int, optional
-        Length of each segment. Defaults to None, but if window is str or
-        tuple, is set to 256, and if window is array_like, is set to the
-        length of the window.
+        Length of each segment. If ``None`` (default) and `window` is a str or a tuple,
+        it is set to 256. If ``None`` and `window` is an array then `nperseg` is set
+        to ``len(window)``. A ``ValueError`` is raised, if ``nperseg != len(window)``
+        or if ``nperseg < 1``.
     noverlap : int, optional
-        Number of points to overlap between segments. If `None`,
-        ``noverlap = nperseg // 2``. Defaults to `None` and may
-        not be greater than `nperseg`.
+        Number of points to overlap between segments. If ``None`` (default),
+        ``noverlap = nperseg // 2``. It may not be greater than `nperseg`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired. If
-        `None`, the FFT length is `nperseg`. Defaults to `None`.
-    detrend : str or function or `False`, optional
-        Specifies how to detrend each segment. If `detrend` is a
-        string, it is passed as the `type` argument to the `detrend`
-        function. If it is a function, it takes a segment and returns a
-        detrended segment. If `detrend` is `False`, no detrending is
-        done. Defaults to 'constant'.
+        Length of the FFT used, if a zero padded or shortened FFT is desired. If
+        ``None``, the FFT length is `nperseg`. Defaults to ``None``.
+    detrend : 'linear' | 'constant' | Callable[[ndarray], ndarray] | False, optional
+        If not ``False`` then a trend is removed from each segment: If 'constant'
+        (default), the mean is subtracted. If 'linear', the linear trend is removed.
+        This is achieved by calling `detrend`. If *detrend* is a function with one
+        parameter, *detrend* is applied to each segment.
     return_onesided : bool, optional
-        If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for
+        If ``True``, return a one-sided spectrum for real data. If
+        ``False`` return a two-sided spectrum. Defaults to ``True``, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
-        where `Pxy` has units of V**2/Hz and computing the cross spectrum
-        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        where `Pxy` has units of V²/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V², if `x` and `y` are
         measured in V and `fs` is measured in Hz. Defaults to 'density'
     axis : int, optional
         Axis along which the CSD is computed for both inputs; the
         default is over the last axis (i.e. ``axis=-1``).
     average : { 'mean', 'median' }, optional
         Method to use when averaging periodograms. If the spectrum is
-        complex, the average is computed separately for the real and
+        complex, the mean / median is computed separately for the real and
         imaginary parts. Defaults to 'mean'.
 
         .. versionadded:: 1.2.0
@@ -737,7 +729,7 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     f : ndarray
         Array of sample frequencies.
     Pxy : ndarray
-        Cross spectral density or cross power spectrum of x,y.
+        Complex-valued cross spectral density or cross power spectrum of x,y.
 
     See Also
     --------
@@ -749,11 +741,11 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
 
     Notes
     -----
-    By convention, Pxy is computed with the conjugate FFT of X
-    multiplied by the FFT of Y.
-
-    If the input series differ in length, the shorter series will be
-    zero-padded to match.
+    By convention, `Pxy` is computed with the conjugate FFT of `x` multiplied by the
+    FFT of `y`. If the input signals differ in shape, first the time axis will be
+    zero-padded to the same length of ``n = max(n_x, n_y, nperseg)`` as required. Then
+    the FFTs will be calculated of each signal and the results will be broadcasted
+    together through multiplication.
 
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default Hann window an overlap of
@@ -767,8 +759,9 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     If `return_onesided` is ``True``, the values of the negative frequencies are added
     to values of the corresponding positive ones.
 
-    Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
-    for a discussion of the scalings of a spectral density and an (amplitude) spectrum.
+    Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide` for a
+    discussion of the possible scalings of a spectral density and an (amplitude)
+    spectrum.
 
     Welch's method may be interpreted as taking the average over the time slices of a
     (cross-) spectrogram. Internally, this function utilizes the  `ShortTimeFFT`  to
@@ -783,7 +776,7 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
       sensible interpretation.
     * `ShortTimeFFT` uses `float64` / `complex128` internally, which is due to the
       behavior of the utilized `~scipy.fft` module. Thus, those are the dtypes being
-      returned. The `csd` function casts the return values to `float32` / `complex64`
+      returned. The `csd` function casts the return values to `complex64`
       if the input is `float32` / `complex64` as well.
     * The `csd` function calculates ``np.conj(Sx[q,p]) * Sy[q,p]``, whereas
       `~ShortTimeFFT.spectrogram` calculates ``Sx[q,p] * np.conj(Sy[q,p])`` where
@@ -822,10 +815,11 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     >>> x += amp*np.sin(2*np.pi*freq*time)
     >>> y += rng.normal(scale=0.1*np.sqrt(noise_power), size=time.shape)
     ...
-    ... # Compute and plot the magnitude of the cross spectral density:
+    ... # Compute the cross spectral density:
     >>> nperseg, noverlap, win = 1024, 512, 'hann'
     >>> f, Pxy = signal.csd(x, y, fs, win, nperseg, noverlap)
-    >>> fig0, ax0 = plt.subplots(tight_layout=True)
+    ...
+    >>> fig0, ax0 = plt.subplots(tight_layout=True)  # do the plotting
     >>> ax0.set_title(f"CSD ({win.title()}-window, {nperseg=}, {noverlap=})")
     >>> ax0.set(xlabel="Frequency $f$ in kHz", ylabel="CSD Magnitude in V²/Hz")
     >>> ax0.semilogy(f/1e3, np.abs(Pxy))
@@ -851,76 +845,62 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     Note that the code snippet above can be easily adapted to determine other
     statistical properties than the mean value.
     """
-    # The following lines are resembling the behavior of the originally utilized
-    # `_spectral_helper()` function:
-    same_data, axis = y is x, int(axis)
-    x = np.asarray(x)
-
-    if not same_data:
-        y = np.asarray(y)
-        # Check if we can broadcast the outer axes together
-        x_outer, y_outer  = list(x.shape), list(y.shape)
-        x_outer.pop(axis)
-        y_outer.pop(axis)
-        try:
-            outer_shape = np.broadcast_shapes(x_outer, y_outer)
-        except ValueError as e:
-            raise ValueError('x and y cannot be broadcast together.') from e
-        if x.size == 0 or y.size == 0:
-            out_shape = outer_shape + (min([x.shape[axis], y.shape[axis]]),)
-            empty_out = np.moveaxis(np.empty(out_shape), -1, axis)
-            return empty_out, empty_out
-        out_dtype = np.result_type(x, y, np.complex64)
-    else:  # x is y:
-        if x.size == 0:
-            return np.empty(x.shape), np.empty(x.shape)
-        out_dtype = np.result_type(x, np.complex64)
-
-    n = x.shape[axis] if same_data else max(x.shape[axis], y.shape[axis])
-    if isinstance(window, str) or isinstance(window, tuple):
+    if isinstance(window, str | tuple): # use get_window():
         nperseg = int(nperseg) if nperseg is not None else 256
         if nperseg < 1:
-            raise ValueError(f"Parameter {nperseg=} is not a positive integer!")
-        elif n < nperseg:
-            warnings.warn(f"{nperseg=} is greater than signal length max(len(x), " +
-                          f"len(y)) = {n}, using nperseg = {n}", stacklevel=3)
-            nperseg = n
+            raise ValueError(f"Parameter nperseg={nperseg} is not a positive integer!")
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)
-        if nperseg is None:
-            nperseg = len(win)
-    if nperseg != len(win):
-        raise ValueError(f"{nperseg=} does not equal {len(win)=}")
+        if nperseg is not None and win.shape != (nperseg,):
+            raise ValueError("Invalid parameters: window.shape != (nperseg,) with " +
+                             f"{nperseg=}, {win.shape=}")
+        nperseg = len(win)
 
-    nfft = int(nfft) if nfft is not None else nperseg
-    if nfft < nperseg:
-        raise ValueError(f"{nfft=} must be greater than or equal to {nperseg=}!")
-    noverlap = int(noverlap) if noverlap is not None else nperseg // 2
-    if noverlap >= nperseg:
-        raise ValueError(f"{noverlap=} must be less than {nperseg=}!")
+    x, ax = np.asarray(x), int(axis)
+    if x is y:
+        out_dtype = np.result_type(x, np.complex64)
+    else:  # x is not y:
+        y = np.array(y)
+        out_dtype = np.result_type(x, y, np.complex64)
+
+    n = max(x.shape[ax], y.shape[ax], nperseg)
+    if x.shape[ax] < n:  # Zero-pad time-axis of `x` to length `n`:
+        pw_x = np.zeros((x.ndim, 2), dtype=np.intp)
+        pw_x[ax, 1] = max(n - x.shape[ax], 0)  # padding amount
+        x = np.pad(x, pw_x.tolist())
+    if x is not y:
+        if y.shape[ax] < n:  # Zero-pad time-axis of `y` to length `n`:
+            pw_y = np.zeros((y.ndim, 2), dtype=np.intp)
+            pw_y[ax, 1] = max(n - y.shape[ax], 0)  # padding amount
+            y = np.pad(y, pw_y.tolist())
+        try:  # Check if shapes are compatible:
+            np.broadcast_shapes(x.shape, y.shape)
+        except ValueError as e:
+            raise ValueError('x and y cannot be broadcasted together.') from e
+
+    mfft = int(nfft) if nfft is not None else nperseg
+    if mfft < nperseg:
+        raise ValueError(f"nfft={mfft} must be greater than or equal to {nperseg=}!")
+    n_overlap = int(noverlap) if noverlap is not None else nperseg // 2
+    if n_overlap >= nperseg:
+        raise ValueError(f"{n_overlap=} must be less than {nperseg=}!")
     if np.iscomplexobj(x) and return_onesided:
         return_onesided = False
 
-    if x.shape[axis] < y.shape[axis]:  # zero-pad x to shape of y:
-        z_shape = list(y.shape)
-        z_shape[axis] = y.shape[axis] - x.shape[axis]
-        x = np.concatenate((x, np.zeros(z_shape)), axis=axis)
-    elif y.shape[axis] < x.shape[axis]:  # zero-pad y to shape of x:
-        z_shape = list(x.shape)
-        z_shape[axis] = x.shape[axis] - y.shape[axis]
-        y = np.concatenate((y, np.zeros(z_shape)), axis=axis)
+    # Translate parameters to ShortTimeFFT's conventions:
+    SCALES = {"spectrum": "magnitude", "density": "psd"}
+    if (scale_to := SCALES.get(scaling, None)) is None:
+        raise ValueError(f"Parameter {scaling=} not in {SCALES}!")
+    fft_mode = "onesided" if return_onesided else "twosided"
+    if (n := x.shape[ax]) < nperseg:
+        raise ValueError(f"Signal length {n=} ≥ nperseg={nperseg} does not hold!")
 
-    fft_mode = 'onesided' if return_onesided else 'twosided'
-    if scaling not in (scales := {'spectrum': 'magnitude', 'density': 'psd'}):
-        raise ValueError(f"Parameter {scaling=} not in {scales}!")
-
-    SFT = ShortTimeFFT(win, nperseg - noverlap, fs, fft_mode=fft_mode, mfft=nfft,
-                       scale_to=scales[scaling], phase_shift=None)
+    SFT = ShortTimeFFT(win, nperseg - n_overlap, fs, fft_mode=fft_mode, mfft=mfft,
+                       scale_to=scale_to, phase_shift=None)
     # csd() calculates X.conj()*Y instead of X*Y.conj():
-    Pxy = SFT.spectrogram(y, x, detr=None if detrend is False else detrend,
-                          p0=0, p1=(n - noverlap) // SFT.hop, k_offset=nperseg // 2,
-                          axis=axis)
+    Pxy = SFT.spectrogram(y, x, detr=None if detrend is False else detrend, axis=ax,
+                          p0=0, p1=(n - n_overlap) // SFT.hop, k_offset=nperseg // 2)
 
     # Note:
     # 'onesided2X' scaling of ShortTimeFFT conflicts with the
@@ -928,17 +908,16 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     # which in the view of the ShortTimeFFT implementation does not make sense.
     # Hence, the doubling of the square is implemented here:
     if return_onesided:
-        f_axis = Pxy.ndim - 1 + axis if axis < 0 else axis
+        f_axis = Pxy.ndim - 1 + ax if ax < 0 else ax
         Pxy = np.moveaxis(Pxy, f_axis, -1)
         Pxy[..., 1:-1 if SFT.mfft % 2 == 0 else None] *= 2
         Pxy = np.moveaxis(Pxy, -1, f_axis)
 
-    # Average over windows.
+    # Average over time slices:
     if Pxy.shape[-1] > 1:
         if average == 'median':
-            # np.median must be passed real arrays for the desired result
             bias = _median_bias(Pxy.shape[-1])
-            if np.iscomplexobj(Pxy):
+            if np.iscomplexobj(Pxy):  # np.median ony works with real-valued arrays:
                 Pxy = (np.median(np.real(Pxy), axis=-1) +
                        np.median(np.imag(Pxy), axis=-1) * 1j)
             else:
@@ -953,8 +932,6 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
 
     # cast output type;
     Pxy = Pxy.astype(out_dtype)
-    if same_data:
-        Pxy = Pxy.real
     return SFT.f, Pxy
 
 
@@ -1920,9 +1897,13 @@ def coherence(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None,
     Parameters
     ----------
     x : array_like
-        Time series of measurement values
+        The first signal made up of ``n_x`` equidistant samples. If `x` is a
+        multidimensional array, then the time axis is defined by the `axis` parameter.
+        If needed, `x` is zero-padded to length ``n = max(n_x, n_y, nperseg)``.
     y : array_like
-        Time series of measurement values
+        The second signal made up of ``n_y`` equidistant samples. If `y` is a
+        multidimensional array, then the time axis is defined by the `axis` parameter.
+        If needed, `y` is zero-padded to length ``n = max(n_x, n_y, nperseg)``.
     fs : float, optional
         Sampling frequency of the `x` and `y` time series. Defaults
         to 1.0.
@@ -1931,24 +1912,25 @@ def coherence(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None,
         passed to `get_window` to generate the window values, which are
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
-        directly as the window and its length must be nperseg. Defaults
-        to a periodic Hann window.
+        directly as the window, and it must be of shape ``(nperseg,)``.
+        Defaults to a periodic Hann window.
     nperseg : int, optional
-        Length of each segment. Defaults to None, but if window is str or
-        tuple, is set to 256, and if window is array_like, is set to the
-        length of the window.
+        Length of each segment. If ``None`` (default) and `window` is a str or a tuple,
+        it is set to 256. If ``None`` and `window` is an array then `nperseg` is set
+        to ``len(window)``. A ``ValueError`` is raised, if ``nperseg != len(window)`` or
+        ``nperseg < 1``.
     noverlap : int, optional
-        Number of points to overlap between segments. If `None`,
-        ``noverlap = nperseg // 2``. Defaults to `None`.
+        Number of points to overlap between segments. If ``None``,
+        ``noverlap = nperseg // 2``. Defaults to ``None`` and may
+        not be greater than `nperseg`.
     nfft : int, optional
         Length of the FFT used, if a zero padded FFT is desired. If
-        `None`, the FFT length is `nperseg`. Defaults to `None`.
-    detrend : str or function or `False`, optional
-        Specifies how to detrend each segment. If `detrend` is a
-        string, it is passed as the `type` argument to the `detrend`
-        function. If it is a function, it takes a segment and returns a
-        detrended segment. If `detrend` is `False`, no detrending is
-        done. Defaults to 'constant'.
+        ``None``, the FFT length is `nperseg`. Defaults to ``None``.
+    detrend : 'linear' | 'constant' | Callable[[ndarray], ndarray] | False, optional
+        If not ``False`` then a trend is removed from each segment: If 'constant'
+        (default), the mean is subtracted. If 'linear', the linear trend is removed.
+        This is achieved by calling `detrend`. If *detrend* is a function with one
+        parameter, *detrend* is applied to each segment.
     axis : int, optional
         Axis along which the coherence is computed for both inputs; the
         default is over the last axis (i.e. ``axis=-1``).
@@ -2016,17 +1998,15 @@ def coherence(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None,
     >>> plt.show()
 
     """
-    freqs, Pxx = welch(x, fs=fs, window=window, nperseg=nperseg,
-                       noverlap=noverlap, nfft=nfft, detrend=detrend,
-                       axis=axis)
-    _, Pyy = welch(y, fs=fs, window=window, nperseg=nperseg, noverlap=noverlap,
-                   nfft=nfft, detrend=detrend, axis=axis)
-    _, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
-                 noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axis)
+    kw = dict(fs=fs, window=window, nperseg=nperseg, noverlap=noverlap, nfft=nfft,
+              detrend=detrend, axis=axis)
 
-    Cxy = np.abs(Pxy)**2 / Pxx / Pyy
+    f, Pxx = welch(x, **kw)
+    _, Pyy = welch(y, **kw)
+    _, Pxy = csd(x, y, **kw)
 
-    return freqs, Cxy
+    Cxy = (Pxy.real**2 + Pxy.imag**2) / Pxx / Pyy
+    return f, Cxy
 
 
 def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -408,6 +408,17 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     for a discussion of the scalings of the power spectral density and
     the magnitude (squared) spectrum.
 
+    .. versionchanged:: 1.19.0
+
+        From this version on, signals which are shorter than `nperseg` are always
+        zero-padded to the appropriate length. Before:
+
+        * If signal `x` had no elements, the returned `f` and `Pxy` had zero size.
+        * If `window` was a string or tuple and if `x` was shorter than the window
+          length (i.e., `nfft`), the window length was shortened.
+        * If `window` was an array and if `x` was shorter than `nfft`, a
+          ``ValueError`` was raised.
+
     .. versionadded:: 0.12.0
 
     Examples
@@ -574,6 +585,18 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
     for a discussion of the scalings of the power spectral density and
     the (squared) magnitude spectrum.
 
+    .. versionchanged:: 1.19.0
+
+        From this version on, signals which are shorter than `nperseg` are always
+        zero-padded to the appropriate length. Before:
+
+        * If signal `x` had no elements, the returned `f` and `Pxy` had zero size.
+        * If `window` was a string or tuple and if `x` was shorter than the window
+          length (i.e., `nperseg`), the window length was shortened.
+        * If `window` was an array and if `x` was shorter than `nperseg`, a
+          ``ValueError`` was raised.
+
+
     .. versionadded:: 0.12.0
 
     References
@@ -713,7 +736,7 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
         Selects between computing the cross spectral density ('density')
         where `Pxy` has units of V²/Hz and computing the cross spectrum
         ('spectrum') where `Pxy` has units of V², if `x` and `y` are
-        measured in V and `fs` is measured in Hz. Defaults to 'density'
+        measured in V and `fs` is measured in Hz. Defaults to 'density'.
     axis : int, optional
         Axis along which the CSD is computed for both inputs; the
         default is over the last axis (i.e. ``axis=-1``).
@@ -783,6 +806,18 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
       ``Sx[q,p]``, ``Sy[q,p]`` are the STFTs of `x` and `y`. Also, the window
       positioning is different.
 
+    .. versionchanged:: 1.19.0
+
+        From this version on, signals which are shorter than `nperseg` are always
+        zero-padded to the appropriate length. Before:
+
+        * If either `x` or `y` had no elements, the returned `f` and `Pxy` had zero
+          size.
+        * If `window` was a string or tuple and if `x` and `y` were shorter than the
+          window length (i.e., `nperseg`), the window length was shortened.
+        * If `window` was an array and if `x` and `y` were shorter than `nperseg`, a
+          ``ValueError`` was raised.
+
     .. versionadded:: 0.16.0
 
     References
@@ -842,8 +877,8 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     the code snippet above and the `csd` function may deviate due to implementation
     details.
 
-    Note that the code snippet above can be easily adapted to determine other
-    statistical properties than the mean value.
+    Note that the code snippet above can be easily adapted to determine
+    statistical properties other than the mean value.
     """
     if isinstance(window, str | tuple): # use get_window():
         nperseg = int(nperseg) if nperseg is not None else 256
@@ -1956,6 +1991,18 @@ def coherence(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None,
     50% is a reasonable trade-off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
+
+    .. versionchanged:: 1.19.0
+
+        From this version on, signals which are shorter than `nperseg` are always
+        zero-padded to the appropriate length. Before:
+
+        * If either `x` or `y` had no elements, the returned `f` and `Pxy` had zero
+          size.
+        * If `window` was a string or tuple and if `x` and `y` were shorter than the
+          window length (i.e., `nperseg`), the window length was shortened.
+        * If `window` was an array and if `x` and `y` were shorter than `nperseg`, a
+          ``ValueError`` was raised.
 
     .. versionadded:: 0.16.0
 

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -385,6 +385,7 @@ class TestWelch:
         xp_assert_close(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
 
     @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
+    @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_window_external(self, xp):
         x = xp.zeros((16,), dtype=xp.float64)
         x = xpx.at(x)[0].set(1)
@@ -404,6 +405,7 @@ class TestWelch:
         assert p1.shape == (17,)
 
     @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
+    @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_empty_input(self, xp):
         f, p = welch(xp.asarray([]))
         assert f.shape == (129,)
@@ -415,6 +417,7 @@ class TestWelch:
             assert p.shape == tuple(shape)
 
     @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
+    @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_empty_input_other_axis(self, xp):
         for shape in [[3,0], [0,5,2]]:
             f, p = welch(xp.empty(shape), axis=1)
@@ -423,6 +426,7 @@ class TestWelch:
             assert p.shape == tuple(shape)
 
     @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
+    @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_short_data(self, xp):
         x = xp.zeros((8,), dtype=xp.float64)
         x = xpx.at(x)[0].set(1)
@@ -437,6 +441,7 @@ class TestWelch:
         assert p2.shape == (5,)
 
     @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
+    @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_window_long_or_nd(self, xp):
         f0, p0 = welch(xp.zeros((4,)), 1, xp.asarray([1,1,1,1,1]))
         xp_assert_close(f0, xp.asarray([0., 0.2, 0.4]))

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -20,6 +20,8 @@ from scipy.signal._spectral_py import _spectral_helper
 from scipy.signal.tests._scipy_spectral_test_shim import stft_compare as stft
 from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 
+xfail_xp_backends = pytest.mark.xfail_xp_backends  # short-hand
+
 
 class TestPeriodogram:
     def test_real_onesided_even(self):
@@ -153,19 +155,21 @@ class TestPeriodogram:
         assert_array_equal(pp.shape, (17,))
 
     def test_empty_input(self):
-        f, p = periodogram([])
-        assert_array_equal(f.shape, (0,))
-        assert_array_equal(p.shape, (0,))
-        for shape in [(0,), (3,0), (0,5,2)]:
-            f, p = periodogram(np.empty(shape))
-            assert_array_equal(f.shape, shape)
-            assert_array_equal(p.shape, shape)
+        with pytest.raises(ValueError, match="^Parameter nfft=0 not positive"):
+            periodogram([])
+        for shape in [(0,), (3, 0)]:
+            with pytest.raises(ValueError, match="^Parameter nfft=0 not positive"):
+                periodogram(np.empty(shape))
+        f, p = welch(np.empty((0,5,2)))
+        assert f.shape == (129,)
+        assert p.shape == (0, 5, 129)
 
     def test_empty_input_other_axis(self):
-        for shape in [(3,0), (0,5,2)]:
-            f, p = periodogram(np.empty(shape), axis=1)
-            assert_array_equal(f.shape, shape)
-            assert_array_equal(p.shape, shape)
+        with pytest.raises(ValueError, match="^Parameter nfft=0 not positive"):
+            periodogram(np.empty((3,0)), axis=1)
+        f, p = periodogram(np.empty((0,5,2)), axis=1)
+        assert f.shape == (3,)
+        assert p.shape == (0, 3, 2)
 
     def test_short_nfft(self):
         x = np.zeros(18)
@@ -190,11 +194,11 @@ class TestPeriodogram:
         assert_allclose(p, q)
 
     def test_real_onesided_even_32(self):
-        x = np.zeros(16, 'f')
+        x = np.zeros(16, dtype=np.float32)
         x[0] = 1
         f, p = periodogram(x)
         assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9, 'f')
+        q = np.ones(9, dtype=np.float32)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
@@ -202,32 +206,32 @@ class TestPeriodogram:
         assert_(p.dtype == q.dtype)
 
     def test_real_onesided_odd_32(self):
-        x = np.zeros(15, 'f')
+        x = np.zeros(15, dtype=np.float32)
         x[0] = 1
         f, p = periodogram(x)
         assert_allclose(f, np.arange(8.0)/15.0)
-        q = np.ones(8, 'f')
+        q = np.ones(8, dtype=np.float32)
         q[0] = 0
         q *= 2.0/15.0
         assert_allclose(p, q, atol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_real_twosided_32(self):
-        x = np.zeros(16, 'f')
+        x = np.zeros(16, dtype=np.float32)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 1/16.0, 'f')
+        q = np.full(16, 1/16.0, dtype=np.float32)
         q[0] = 0
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
     def test_complex_32(self):
-        x = np.zeros(16, 'F')
+        x = np.zeros(16, dtype=np.complex64)
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 5.0/16.0, 'f')
+        q = np.full(16, 5.0/16.0, dtype=np.float32)
         q[0] = 0
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
@@ -236,11 +240,9 @@ class TestPeriodogram:
         x = np.zeros(16)
         x[0] = 1
         win = signal.get_window('hann', 10)
-        expected_msg = ('the size of the window must be the same size '
-                        'of the input on the specified axis')
-        with assert_raises(ValueError, match=expected_msg):
-            periodogram(x, window=win)
-
+        f, p = periodogram(x, window=win)
+        assert f.shape == (6,)
+        assert p.shape == (6,)
 
 @make_xp_test_case(welch)
 class TestWelch:
@@ -382,6 +384,7 @@ class TestWelch:
         f0, p0 = welch(x[:,0,0], nperseg=10)
         xp_assert_close(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
 
+    @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
     def test_window_external(self, xp):
         x = xp.zeros((16,), dtype=xp.float64)
         x = xpx.at(x)[0].set(1)
@@ -395,49 +398,51 @@ class TestWelch:
         assert pe.shape == (5,)
         assert_raises(ValueError, welch, x,
                       10, win, nperseg=4)  # because nperseg != win.shape[-1]
-        win_err = xp.asarray(signal.get_window('hann', 32))
-        assert_raises(ValueError, welch, x,
-                      10, win_err, nperseg=None)  # win longer than signal
+        win1 = xp.asarray(signal.get_window('hann', 32))
+        f1, p1 = welch(x, 10, win1, nperseg=None)
+        assert f1.shape == (17,)
+        assert p1.shape == (17,)
 
+    @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
     def test_empty_input(self, xp):
         f, p = welch(xp.asarray([]))
-        assert f.shape == (0,)
-        assert p.shape == (0,)
-        for shape in [(0,), (3,0), (0,5,2)]:
+        assert f.shape == (129,)
+        assert p.shape == (129,)
+        for shape in [[0,], [3,0], [0,5,2]]:
             f, p = welch(xp.empty(shape))
-            assert f.shape == shape
-            assert p.shape == shape
+            shape[-1] = 129
+            assert f.shape == (129,)
+            assert p.shape == tuple(shape)
 
+    @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
     def test_empty_input_other_axis(self, xp):
-        for shape in [(3,0), (0,5,2)]:
+        for shape in [[3,0], [0,5,2]]:
             f, p = welch(xp.empty(shape), axis=1)
-            assert f.shape == shape
-            assert p.shape == shape
+            shape[1] = 129
+            assert f.shape == (129,)
+            assert p.shape == tuple(shape)
 
+    @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
     def test_short_data(self, xp):
         x = xp.zeros((8,), dtype=xp.float64)
         x = xpx.at(x)[0].set(1)
-        #for string-like window, input signal length < nperseg value gives
-        #UserWarning, sets nperseg to x.shape[-1]
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                r"nperseg\s*=?\s*256 is greater than "
-                r"(?:input_length|input length|signal).*",
-                UserWarning,
-            )
-            f, p = welch(x, window="hann")  # default nperseg
-            f1, p1 = welch(x, window="hann", nperseg=256)  # user-specified nperseg
-        f2, p2 = welch(x, nperseg=8)  # valid nperseg, doesn't give warning
-        xp_assert_close(f, f2)
-        xp_assert_close(p, p2)
-        xp_assert_close(f1, f2)
-        xp_assert_close(p1, p2)
 
+        f0, p0 = welch(x, window="hann")  # default nperseg
+        f1, p1 = welch(x, window="hann", nperseg=256)  # user-specified nperseg
+
+        xp_assert_close(f0, f1)
+        xp_assert_close(p0, p1)
+        f2, p2 = welch(x, nperseg=8)  # valid nperseg, doesn't give warning
+        assert f2.shape == (5,)
+        assert p2.shape == (5,)
+
+    @xfail_xp_backends('jax.numpy', reason="Backend not updated yet.")
     def test_window_long_or_nd(self, xp):
-        assert_raises(ValueError, welch, xp.zeros((4,)), 1, xp.asarray([1,1,1,1,1]))
-        assert_raises(ValueError, welch, xp.zeros((4,)), 1,
-                      xp.reshape(xp.arange(6), (2,3)))
+        f0, p0 = welch(xp.zeros((4,)), 1, xp.asarray([1,1,1,1,1]))
+        xp_assert_close(f0, xp.asarray([0., 0.2, 0.4]))
+        xp_assert_close(p0, xp.asarray([0., 0., 0.]))
+        with pytest.raises(ValueError, match="^Parameter win must be 1d,"):
+            welch(xp.zeros((4,)), 1, xp.reshape(xp.arange(6), (2,3)))
 
     def test_nondefault_noverlap(self, xp):
         x = xp.zeros((64,), dtype=xp.float64)
@@ -788,72 +793,71 @@ class TestCSD:
         assert_array_almost_equal_nulp(f, fe)
         assert_array_equal(fe.shape, (5,))  # because win length used as nperseg
         assert_array_equal(pe.shape, (5,))
-        assert_raises(ValueError, csd, x, x,
-                      10, win, nperseg=256)  # because nperseg != win.shape[-1]
-        win_err = signal.get_window('hann', 32)
-        assert_raises(ValueError, csd, x, x,
-              10, win_err, nperseg=None)  # because win longer than signal
+
+        win1 = signal.get_window('hann', 32)
+        f1, p1 = csd(x, x, 1, win1, nperseg=None)
+        assert_equal(f1.shape, (17, ))
+        assert_equal(p1.shape, (17, ))
+
         with pytest.raises(ValueError, match="Parameter nperseg=0.*"):
             csd(x, x, 0, nperseg=0)
 
     def test_empty_input(self):
         f, p = csd([],np.zeros(10))
-        assert_array_equal(f.shape, (0,))
-        assert_array_equal(p.shape, (0,))
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (129,))
 
         f, p = csd(np.zeros(10),[])
-        assert_array_equal(f.shape, (0,))
-        assert_array_equal(p.shape, (0,))
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (129,))
 
-        for shape in [(0,), (3,0), (0,5,2)]:
+        for shape in [[0,], [3, 0], [0, 5, 2]]:
             f, p = csd(np.empty(shape), np.empty(shape))
-            assert_array_equal(f.shape, shape)
+            shape[-1] = 129
+            assert_array_equal(f.shape, (129,))
             assert_array_equal(p.shape, shape)
 
         f, p = csd(np.ones(10), np.empty((5,0)))
-        assert_array_equal(f.shape, (5,0))
-        assert_array_equal(p.shape, (5,0))
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (5, 129))
 
         f, p = csd(np.empty((5,0)), np.ones(10))
-        assert_array_equal(f.shape, (5,0))
-        assert_array_equal(p.shape, (5,0))
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (5, 129))
 
     def test_empty_input_other_axis(self):
-        for shape in [(3,0), (0,5,2)]:
+        for shape in [[3, 0], [0, 5, 2]]:
             f, p = csd(np.empty(shape), np.empty(shape), axis=1)
-            assert_array_equal(f.shape, shape)
+            shape[1] = 129
+            assert_array_equal(f.shape, (129,))
             assert_array_equal(p.shape, shape)
 
-        f, p = csd(np.empty((10,10,3)), np.zeros((10,0,1)), axis=1)
-        assert_array_equal(f.shape, (10,0,3))
-        assert_array_equal(p.shape, (10,0,3))
+        f, p = csd(np.empty((10, 10, 3)), np.zeros((10, 0, 1)), axis=1)
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (10, 129 ,3))
 
-        f, p = csd(np.empty((10,0,1)), np.zeros((10,10,3)), axis=1)
-        assert_array_equal(f.shape, (10,0,3))
-        assert_array_equal(p.shape, (10,0,3))
+        f, p = csd(np.empty((10, 0, 1)), np.zeros((10, 10, 3)), axis=1)
+        assert_array_equal(f.shape, (129,))
+        assert_array_equal(p.shape, (10, 129, 3))
 
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
 
-        #for string-like window, input signal length < nperseg value gives
-        #UserWarning, sets nperseg to x.shape[-1]
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", "nperseg=256 is greater than signal length.*", UserWarning)
-            f, p = csd(x, x, window='hann')  # default nperseg
-            f1, p1 = csd(x, x, window='hann', nperseg=256)  # user-specified nperseg
-        f2, p2 = csd(x, x, nperseg=8)  # valid nperseg, doesn't give warning
-        assert_allclose(f, f2)
-        assert_allclose(p, p2)
-        assert_allclose(f1, f2)
-        assert_allclose(p1, p2)
+        f0, p0 = csd(x, x, window='hann')  # default nperseg=256
+        f1, p1 = csd(x, x, window='hann', nperseg=256)  # user-specified nperseg
+        assert_allclose(f0, f1)
+        assert_allclose(p0, p1)
+        f2, p2 = csd(x, x, nperseg=8)  # valid nperseg
+        assert f2.shape == (5,)
+        assert p2.shape == (5,)
 
     def test_window_long_or_nd(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
-                      np.array([1,1,1,1,1]))
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
-                      np.arange(6).reshape((2,3)))
+        f0, p0 = csd(np.zeros(4), np.ones(4), 1, np.array([1,1,1,1,1]))
+        assert_allclose(f0, np.array([0., 0.2, 0.4]))
+        assert_allclose(p0, np.array([0., 0., 0.]))
+        with pytest.raises(ValueError, match="^Parameter win must be 1d,"):
+            csd(np.zeros(4), np.ones(4), 1, np.arange(6).reshape((2,3)))
 
     def test_nondefault_noverlap(self):
         x = np.zeros(64)
@@ -877,50 +881,49 @@ class TestCSD:
 
 
     def test_real_onesided_even_32(self):
-        x = np.zeros(16, 'f')
+        x = np.zeros(16, dtype=np.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111], 'f')
+                      0.11111111], dtype=np.complex64)
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_real_onesided_odd_32(self):
-        x = np.zeros(16, 'f')
+        x = np.zeros(16, dtype=np.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         q = np.array([0.12477458, 0.23430935, 0.17072113, 0.17072116,
-                      0.17072113], 'f')
+                      0.17072113], dtype=np.complex64)
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_real_twosided_32(self):
-        x = np.zeros(16, 'f')
+        x = np.zeros(16, dtype=np.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.11111111,
-                      0.07638889], 'f')
+                      0.07638889], dtype=np.complex64)
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_complex_32(self):
-        x = np.zeros(16, 'F')
+        x = np.zeros(16, dtype=np.complex64)
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
-                      0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
+        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 0.55555558,
+                      0.55555552, 0.55555552, 0.38194442], dtype=np.complex64)
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype,
-                f'dtype mismatch, {p.dtype}, {q.dtype}')
+        assert_(p.dtype == q.dtype,f'dtype mismatch, {p.dtype}, {q.dtype}')
 
     def test_padded_freqs(self):
         x = np.zeros(12)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -444,8 +444,8 @@ class TestWelch:
     @xfail_xp_backends("cupy", reason="Backend not updated yet.")
     def test_window_long_or_nd(self, xp):
         f0, p0 = welch(xp.zeros((4,)), 1, xp.asarray([1,1,1,1,1]))
-        xp_assert_close(f0, xp.asarray([0., 0.2, 0.4]))
-        xp_assert_close(p0, xp.asarray([0., 0., 0.]))
+        xp_assert_close(f0, xp.asarray([0., 0.2, 0.4], dtype=f0.dtype))
+        xp_assert_close(p0, xp.asarray([0., 0., 0.], dtype=p0.dtype))
         with pytest.raises(ValueError, match="^Parameter win must be 1d,"):
             welch(xp.zeros((4,)), 1, xp.reshape(xp.arange(6), (2,3)))
 


### PR DESCRIPTION
As reported in issue #25608, if the `csd`'s input signal is shorter than the window length, a warning is displayed and the window is shortened to the signal length. This behavior is not documented (but reflected in the unit tests) and only works when `get_window` (i.e., a window name is passed) is used. This behavior was adopted due to trying to reproduce the behavior of the (now legacy) `_spectral_helper()` function. 

I took a closer look at the `csd()` function and found further inconsistencies for short signals:

```python
>>> import numpy as np
... from scipy.signal import get_window, welch, csd
...
>>> n, m = 8, 16
>>> x = np.ones(n), 
>>> P0, f0 = csd(x, x, nperseg=m, return_onesided=False)  # prints warning
UserWarning: nperseg=16 is greater than signal length max(len(x), len(y)) = 8, using nperseg = 8
>>> print(f"{P0.shape=}, {f0.shape=}")  # expectation: len(f0) = 16
P0.shape=(8,), f0.shape=(8,)
>>> win = get_window('hann', m)
>>> P1, f1 = csd(x, x, window=win, return_onesided=False)  # raises exception
ValueError: Invalid Parameter ...
```
For empty input, empty output is returned in spite of `nperseg=16`, i.e.:

```python
>>> P, f = csd([], [], nperseg=16, return_onesided=False)
>>> print(f"{P.shape=}, {f.shape=}")  # no zero-padding 
P.shape=(0,), f.shape=(0,)
```

On the other hand, if the input signals have different length, zero-padding is used. Except when one signal has length zero, i.e.:

```python
>>> x, y = np.ones(8), np.ones(16)
>>> P0, f0 = csd(x, y, nperseg=16, return_onesided=False)
>>> print(f"{P0.shape=}, {f0.shape=}")  # x is zero-padded to length 16
P.shape=(16,), f.shape=(16,)
>>> P1, f1 = csd(x, [], nperseg=16, return_onesided=False)
>>> print(f"{P1.shape=}, {f1.shape=}")  # no zero-padding
P1.shape=(0,), f1.shape=(0,)
```

This PR fixes `csd()` to adapt a consistent strategy for short signals: Always zero-pad to be able to return a power spectrum. This has the positive effect that the frequency values are independent of the input signals. Since `welch()`, `coherence()` and `periodogram()` utilize `csd()`, their docstr are adapted as well. `periodogram()` also required refactoring to make its behavior consistent. Note that the main purpose of those functions is averaging. Hence, using those function with short signals where the average size is one, is a corner case and typically not very useful.


Furthermore:

* Make `csd()` always return a complex-valued spectrum as requested by issue #24285.

* The unit tests were minimally refactored to accommodate for the changed behavior (Note that there's a lot of redundancy in those tests. In a future PR they could be refactored to be more concise).

* Document in `ShortTimeFFT` the minimum required length of input signal.

[xpx.pad]: https://github.com/data-apis/array-api-extra/blob/5a63dd892f730136d284c1e24fb3c090e7015173/src/array_api_extra/_delegation.py#L809
[ShortTimeFFT]: https://github.com/scipy/scipy/blob/75aedcaae44102a9abaeba389cf3a0f87ff4f61f/scipy/signal/_short_time_fft.py#L1109


#### For the Release Notes:

* The behavior of `csd`, `welch`, `coherence` and `periodogram` was made more consistent when dealing with input signals shorter than the segment length: Now the input signals are always zero-padded to the segment length. Before, either the segment length was shortened or an exception was raised.

* The `csd` function now returns always returns a complex-valued cross-spectrum, whereas in earlier versions ``csd(x,x)`` returned a real-valued spectrum. 

Closes #25608, closes #24285
Supersedes PR #24302, PR #25608

PS: [xpx.pad] currently only supports `mode='constant'` (issue https://github.com/data-apis/array-api-extra/issues/811). [ShortTimeFFT] requires `mode in ['zeros', 'edge', 'even', 'odd']` (and in future perhaps `'wrap'`), which inhibits the Array API adoption.


#### AI Generation Disclosure
No AI was used in this PR.
