### PR TITLE
ENH: special: Add negative m for Jacobi elliptic functions

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -3044,8 +3044,8 @@ const char *ellipj_doc = R"(
 
     Jacobi elliptic functions.
 
-    Calculates the Jacobi elliptic functions of parameter `m` between
-    0 and 1, and real argument `u`.
+    Calculates the Jacobi elliptic functions of parameter `m` less than or equal to
+    1, and real argument `u`.
 
     Parameters
     ----------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1690,6 +1690,34 @@ class TestEllip:
         rel = [sin(0.2),cos(0.2),1.0,0.20]
         assert_allclose(el, rel, atol=1.5e-13, rtol=0)
 
+    @pytest.mark.parametrize(
+        "u, m, expected",
+        [
+            (
+                20,
+                -0.0001,
+                [0.91314537820787445, 0.40763404943355497, 1.0000416908550234],
+            ),
+            (
+                20,
+                -1,
+                [-0.89393389569287096, 0.44819882879294476, 1.3413119733561736],
+            ),
+            (
+                20,
+                -251.18864315095823,
+                [0.19646166026649953, 0.98051150734977632, 3.2703477287623963],
+            ),
+        ],
+    )
+    def test_ellipj_negative_m(self, u, m, expected):
+        sn, cn, dn, ph = special.ellipj(u, m)
+
+        assert_allclose([sn, cn, dn], expected, rtol=1e-8, atol=0)
+        assert_allclose(sn**2 + cn**2, 1, rtol=1e-12, atol=0)
+        assert_allclose(dn**2 + m * sn**2, 1, rtol=1e-12, atol=0)
+        assert_allclose(special.ellipkinc(ph, m), u, rtol=1e-8, atol=0)
+
     def test_ellipk(self):
         elk = special.ellipk(.2)
         assert_allclose(elk, 1.659623598610528, atol=1.5e-11, rtol=0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/21415

#### What does this implement/fix?
Following https://github.com/scipy/xsf/pull/88, this PR allows for negative m in `special.ellipj`

#### Additional information
- Added a small test reusing some values from https://github.com/scipy/xsf/blob/main/tests/xsf_tests/test_ellpj.cpp. Do we want to add more as we already have those over at xsf.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex for a review.