### PR TITLE
ENH: signal: add full Array API support for sawtooth

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -486,7 +486,7 @@ def savgol_filter_signature(x, *args, **kwds):
 
 
 def sawtooth_signature(t, width=1):
-    return array_namespace(t)
+    return array_namespace(t, width)
 
 
 def sepfir2d_signature(input, hrow, hcol):

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -318,8 +318,6 @@ capabilities_overrides = {
     "savgol_filter": xp_capabilities(cpu_only=True, exceptions=["cupy"],
                                      jax_jit=False,
                                      reason="convolve1d is cpu-only"),
-    "sawtooth": xp_capabilities(jax_jit=False,
-                                skip_backends=[("dask.array", "dask tests fail")]),
     "sos2zpk": xp_capabilities(cpu_only=True, exceptions=["cupy"], jax_jit=False,
                                allow_dask_compute=True),
     "sos2tf": xp_capabilities(cpu_only=True, exceptions=["cupy"], jax_jit=False,

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -61,20 +61,22 @@ def sawtooth(t, width=1.):
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)
-    y = xpx.at(y, mask1).set(xp.nan)
+    y = xp.where(mask1, xp.nan, y)
 
     # take t modulo 2*pi
     tmod = t % (2*xp.pi)
 
     # on the interval 0 to width*2*pi function is tmod / (pi*w) - 1
     mask2 = ~mask1 & (tmod < w*2*xp.pi)
-    y = xpx.at(y, mask2).set(tmod[mask2]/(xp.pi*w[mask2]) - 1)
+    one = xp.asarray(1, dtype=t.dtype)
+    safe_w = xp.where(w == 0, one, w)
+    y = xp.where(mask2, (tmod - xp.pi*safe_w)/(xp.pi*safe_w), y)
 
     # on the interval width*2*pi to 2*pi function is (pi*(w+1)-tmod) / (pi*(1-w))
     mask3 = ~(mask1 | mask2)
-    y = xpx.at(y, mask3).set(
-        (xp.pi*(w[mask3] + 1) - tmod[mask3])/(xp.pi*(1 - w[mask3]))
-    )
+    safe_1mw = xp.where(w == 1, one, 1 - w)
+    y = xp.where(mask3, (xp.pi*(w + 1) - tmod)/(xp.pi*safe_1mw), y)
+
     return y
 
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -61,7 +61,7 @@ def sawtooth(t, width=1.):
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)
-    y = xp.where(mask1, xp.nan, y)
+    y = xpx.at(y, mask1).set(xp.nan)
 
     # take t modulo 2*pi
     tmod = t % (2*xp.pi)

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import asarray, zeros, pi, log, sqrt, \
     exp, cos, sin, polyval, polyint
 
-from scipy._lib._array_api import array_namespace, xp_promote
+from scipy._lib._array_api import array_namespace, xp_device, xp_promote
 import scipy._external.array_api_extra as xpx
 
 
@@ -68,7 +68,7 @@ def sawtooth(t, width=1.):
 
     # on the interval 0 to width*2*pi function is tmod / (pi*w) - 1
     mask2 = ~mask1 & (tmod < w*2*xp.pi)
-    one = xp.asarray(1, dtype=t.dtype)
+    one = xp.asarray(1, dtype=t.dtype, device=xp_device(t))
     safe_w = xp.where(w == 0, one, w)
     y = xp.where(mask2, (tmod - xp.pi*safe_w)/(xp.pi*safe_w), y)
 

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -392,7 +392,7 @@ class TestSawtoothWaveform:
         t_dtype = getattr(xp, t_dtype)
         width_dtype = getattr(xp, width_dtype)
         waveform = sawtooth(
-            xp.asarray(1, dtype=t_dtype), width=xp.asarray(1, dtype=width_dtype)
+            xp.asarray(1, dtype=t_dtype), width=xp.asarray(0.5, dtype=width_dtype)
         )
         assert waveform.dtype == xp.result_type(t_dtype, width_dtype)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Add full Array API support for `signal.sawtooth`. 

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex suggested a few simplifications.