### PR TITLE
BUG: `make_splprep` does not validate periodic endpoints at `s = 0`

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1157,6 +1157,8 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
 
     # postprocess: squeeze out the last dimension: was added to simplify the internals.
     spl.c = spl.c[:, 0]
+    # make periodic if needed
+    spl.extrapolate = "periodic" if periodic else True
     return spl
 
 
@@ -1329,6 +1331,9 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     # posprocess: `axis=1` so that spl(u).shape == np.shape(x)
     # when `x` is a list of 1D arrays (cf original splPrep)
     cc = spl.c.T
-    spl1 = BSpline(spl.t, cc, spl.k, axis=1)
+    spl1 = BSpline(
+        spl.t, cc, spl.k, axis=1,
+        extrapolate='periodic' if periodic else True
+    )
 
     return spl1, xp.asarray(u)

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1315,7 +1315,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     if s == 0:
         if t is not None or w is not None or nest is not None:
             raise ValueError("s==0 is for interpolation only")
-        return make_interp_spline(u, x.T, k=k, axis=1), u
+        return make_interp_spline(u, x.T, k=k, bc_type=bc_type, axis=1), u
 
     u, x, w, k, s, ub, ue = _validate_inputs(u, x, w, k, s, ub, ue,
                                              parametric=True, periodic=periodic)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4054,6 +4054,22 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
             xp_assert_close(spl.t, tck[0])
         xp_assert_close(np.r_[spl.c, [0]*(spl.k+1)],
                         tck[1])
+    
+    @pytest.mark.parametrize("s", [1, 1e-8, 42])
+    def test_spline_endpoints_match(self, s):
+        """make_splrep with bc_type='periodic' must produce a periodic
+        spline."""
+        theta = np.linspace(0, 1, 11)
+        y = np.cos(2*np.pi*theta)
+        
+        spl = make_splrep(theta, y, s=s, bc_type="periodic")
+        
+        xp_assert_close(spl(theta[0]), spl(theta[-1]), atol=1e-12)
+        assert spl.extrapolate == 'periodic'
+        
+        # check wraparound: spl(u + delta) = spl(u + 2 * delta)
+        xp_assert_close(spl(theta[-1] + 0.2), spl(theta[0] + 0.2), atol=1e-12)
+        xp_assert_close(spl(theta[0] - 0.2), spl(theta[-1] - 0.2), atol=1e-12)
 
     @pytest.mark.parametrize("k_fp", [(1, -0.0001), (2, -0.0001), (3, -8.62e-05)])
     @pytest.mark.parametrize("s", [1e-4])
@@ -4078,7 +4094,6 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
         y_check = bs(x_check)
 
         xp_assert_close(y_check[0], y_check[1])
-
 
 @make_xp_test_case(make_splprep)
 class TestMakeSplprep:
@@ -4221,10 +4236,10 @@ class TestMakeSplprepPeriodic:
         xp_assert_close(spl(u), BSpline(t, c, k, axis=1)(u),
                         atol=1e-06, rtol=1e-06)
     
-    @pytest.mark.parametrize("s", [0, 1e-8, 1, 42])
-    def test_periodic_endpoints_match(self, s):
-        """make_splprep with bc_type='periodic' must evaluate to same values at
-        endpoints."""
+    @pytest.mark.parametrize("s", [1, 1e-8, 42])
+    def test_spline_endpoints_match(self, s):
+        """make_splprep with bc_type='periodic' must produce a periodic 
+        spline: matching endpoint values, extrapolate='periodic'."""
         theta = np.linspace(0, 1, 11)
         x = np.sin(2*np.pi*theta)
         y = np.cos(2*np.pi*theta)
@@ -4232,6 +4247,11 @@ class TestMakeSplprepPeriodic:
         spl, u = make_splprep([x, y], u=theta, s=s, bc_type="periodic")
         
         xp_assert_close(spl(u[0]), spl(u[-1]), atol=1e-12)
+        assert spl.extrapolate == 'periodic'
+        
+        # check wraparound: spl(u + delta) = spl(u + 2 * delta)
+        xp_assert_close(spl(u[-1] + 0.2), spl(u[0] + 0.2), atol=1e-12)
+        xp_assert_close(spl(u[0] - 0.2), spl(u[-1] - 0.2), atol=1e-12)
 
     @pytest.mark.parametrize('s', [0, 1e-4, 1e-5, 1e-6])
     def test_array_not_list(self, s):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4320,6 +4320,35 @@ class TestMakeSplprepPeriodic:
         assert spl(u).shape == (1, 8)
         xp_assert_close(spl(u), [x], atol=1e-15)
 
+    @pytest.mark.parametrize("bc_type", [None, "not-a-knot", "periodic"])
+    @pytest.mark.parametrize("matching_endpoints", [True, False])
+    def test_bc_type_delegation_s0(self, bc_type, matching_endpoints):
+        # make_splprep at s=0 must delegate bc_type correctly to
+        # make_interp_spline, for every bc_type, endpoint-matching
+        theta = np.linspace(0, 1, 11)
+        x = np.sin(2*np.pi*theta)
+        y = np.cos(2*np.pi*theta)
+
+        if not matching_endpoints:
+            x = x.copy()
+            x[-1] = 1  
+
+        periodic = (bc_type == "periodic")
+        should_raise = periodic and not matching_endpoints
+
+        xy = np.column_stack([x, y])
+
+        if should_raise:
+            with assert_raises(ValueError):
+                make_splprep([x, y], u=theta, s=0, bc_type=bc_type)
+            with assert_raises(ValueError):
+                make_interp_spline(theta, xy, bc_type=bc_type)
+        else:
+            spl, u = make_splprep([x, y], u=theta, s=0, bc_type=bc_type)
+            expected = make_interp_spline(theta, xy, bc_type=bc_type)
+            xp_assert_close(spl.c, expected.c, atol=1e-12)
+            xp_assert_close(spl.t, expected.t, atol=1e-12)
+            assert spl.extrapolate == expected.extrapolate
 
 class BatchSpline:
     # BSpline-line class with reference batch behavior

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4116,7 +4116,7 @@ class TestMakeSplprep:
         # values: note axis=1
         xp_assert_close(spl(u),
                         BSpline(t, c, k, axis=1)(u), atol=1e-15)
-
+    
     @pytest.mark.parametrize('s', [0, 0.1, 1e-3, 1e-5])
     def test_array_not_list(self, s):
         # the argument of splPrep is either a list of arrays or a 2D array (sigh)
@@ -4205,7 +4205,7 @@ class TestMakeSplprepPeriodic:
         y = [np.sin(x), np.cos(x)]
 
         # the number of knots depends on `s` (this is by construction)
-        num_knots = {0: 14, 1e-4: 16, 1e-5: 16, 1e-6: 16}
+        num_knots = {0: 16, 1e-4: 16, 1e-5: 16, 1e-6: 16}
 
         # construct the splines
         (t, c, k), u_ = splprep(y, s=s, per=1)
@@ -4220,6 +4220,18 @@ class TestMakeSplprepPeriodic:
         # values: note axis=1
         xp_assert_close(spl(u), BSpline(t, c, k, axis=1)(u),
                         atol=1e-06, rtol=1e-06)
+    
+    @pytest.mark.parametrize("s", [0, 1e-8, 1, 42])
+    def test_periodic_endpoints_match(self, s):
+        """make_splprep with bc_type='periodic' must evaluate to same values at
+        endpoints."""
+        theta = np.linspace(0, 1, 11)
+        x = np.sin(2*np.pi*theta)
+        y = np.cos(2*np.pi*theta)
+        
+        spl, u = make_splprep([x, y], u=theta, s=s, bc_type="periodic")
+        
+        xp_assert_close(spl(u[0]), spl(u[-1]), atol=1e-12)
 
     @pytest.mark.parametrize('s', [0, 1e-4, 1e-5, 1e-6])
     def test_array_not_list(self, s):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4116,7 +4116,6 @@ class TestMakeSplprep:
         # values: note axis=1
         xp_assert_close(spl(u),
                         BSpline(t, c, k, axis=1)(u), atol=1e-15)
-    
     @pytest.mark.parametrize('s', [0, 0.1, 1e-3, 1e-5])
     def test_array_not_list(self, s):
         # the argument of splPrep is either a list of arrays or a 2D array (sigh)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4054,7 +4054,7 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
             xp_assert_close(spl.t, tck[0])
         xp_assert_close(np.r_[spl.c, [0]*(spl.k+1)],
                         tck[1])
-    
+
     @pytest.mark.parametrize("s", [1, 1e-8, 42])
     def test_spline_endpoints_match(self, s):
         """make_splrep with bc_type='periodic' must produce a periodic
@@ -4236,10 +4236,10 @@ class TestMakeSplprepPeriodic:
         # values: note axis=1
         xp_assert_close(spl(u), BSpline(t, c, k, axis=1)(u),
                         atol=1e-06, rtol=1e-06)
-    
+
     @pytest.mark.parametrize("s", [1, 1e-8, 42])
     def test_spline_endpoints_match(self, s):
-        """make_splprep with bc_type='periodic' must produce a periodic 
+        """make_splprep with bc_type='periodic' must produce a periodic
         spline: matching endpoint values, extrapolate='periodic'."""
         theta = np.linspace(0, 1, 11)
         x = np.sin(2*np.pi*theta)
@@ -4335,8 +4335,8 @@ class TestMakeSplprepPeriodic:
 
         if not matching_endpoints:
             x = x.copy()
-            x[-1] = 1  
-        
+            x[-1] = 1
+
         periodic = (bc_type == "periodic")
         should_raise = periodic and not matching_endpoints
         xy = np.column_stack([x, y])

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4061,15 +4061,17 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
         spline."""
         theta = np.linspace(0, 1, 11)
         y = np.cos(2*np.pi*theta)
-        
         spl = make_splrep(theta, y, s=s, bc_type="periodic")
-        
         xp_assert_close(spl(theta[0]), spl(theta[-1]), atol=1e-12)
         assert spl.extrapolate == 'periodic'
-        
         # check wraparound: spl(u + delta) = spl(u + 2 * delta)
         xp_assert_close(spl(theta[-1] + 0.2), spl(theta[0] + 0.2), atol=1e-12)
         xp_assert_close(spl(theta[0] - 0.2), spl(theta[-1] - 0.2), atol=1e-12)
+        # check k-derivatives
+        nus = np.arange(spl.k)
+        vals_right = np.array([spl(theta[-1] + 0.2, nu) for nu in nus])
+        vals_left = np.array([spl(theta[0] + 0.2, nu) for nu in nus])
+        xp_assert_close(vals_right, vals_left, atol=1e-10)
 
     @pytest.mark.parametrize("k_fp", [(1, -0.0001), (2, -0.0001), (3, -8.62e-05)])
     @pytest.mark.parametrize("s", [1e-4])
@@ -4242,15 +4244,17 @@ class TestMakeSplprepPeriodic:
         theta = np.linspace(0, 1, 11)
         x = np.sin(2*np.pi*theta)
         y = np.cos(2*np.pi*theta)
-        
         spl, u = make_splprep([x, y], u=theta, s=s, bc_type="periodic")
-        
         xp_assert_close(spl(u[0]), spl(u[-1]), atol=1e-12)
         assert spl.extrapolate == 'periodic'
-        
         # check wraparound: spl(u + delta) = spl(u + 2 * delta)
         xp_assert_close(spl(u[-1] + 0.2), spl(u[0] + 0.2), atol=1e-12)
         xp_assert_close(spl(u[0] - 0.2), spl(u[-1] - 0.2), atol=1e-12)
+        # check k-derivatives match
+        nus = np.arange(spl.k)
+        vals_right = np.array([spl(u[-1] + 0.2, nu) for nu in nus])
+        vals_left = np.array([spl(u[0] + 0.2, nu) for nu in nus])
+        xp_assert_close(vals_right, vals_left, atol=1e-10)
 
     @pytest.mark.parametrize('s', [0, 1e-4, 1e-5, 1e-6])
     def test_array_not_list(self, s):
@@ -4322,8 +4326,8 @@ class TestMakeSplprepPeriodic:
 
     @pytest.mark.parametrize("bc_type", [None, "not-a-knot", "periodic"])
     @pytest.mark.parametrize("matching_endpoints", [True, False])
-    def test_bc_type_delegation_s0(self, bc_type, matching_endpoints):
-        # make_splprep at s=0 must delegate bc_type correctly to
+    def test_bc_type_match_s0(self, bc_type, matching_endpoints):
+        # make_splprep at s=0 must match bc_type correctly to
         # make_interp_spline, for every bc_type, endpoint-matching
         theta = np.linspace(0, 1, 11)
         x = np.sin(2*np.pi*theta)
@@ -4332,12 +4336,10 @@ class TestMakeSplprepPeriodic:
         if not matching_endpoints:
             x = x.copy()
             x[-1] = 1  
-
+        
         periodic = (bc_type == "periodic")
         should_raise = periodic and not matching_endpoints
-
         xy = np.column_stack([x, y])
-
         if should_raise:
             with assert_raises(ValueError):
                 make_splprep([x, y], u=theta, s=0, bc_type=bc_type)


### PR DESCRIPTION
#### Reference issue
`make_splprep` with `bc_type='periodic'` and `s=0` produces a non-periodic spline instead of validating that the endpoints match. 

#### What does this implement/fix?

In `make_splprep`'s `s == 0` branch, `bc_type` is computed but never propogated to the underlying `make_interp_spline` call.

#### Additional information
N/A

#### AI Generation Disclosure
No AI.
