### PR TITLE
BUG: ndimage: resolve writeback on output arrays that NumPy had to copy

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -1201,6 +1201,8 @@ static PyObject *Py_DistanceTransformOnePass(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_DistanceTransformOnePass(strct, distances, features);
+    PyArray_ResolveWritebackIfCopy(distances);
+    PyArray_ResolveWritebackIfCopy(features);
 
 exit:
     Py_XDECREF(strct);
@@ -1221,6 +1223,7 @@ static PyObject *Py_EuclideanFeatureTransform(PyObject *obj,
         goto exit;
 
     NI_EuclideanFeatureTransform(input, sampling, features);
+    PyArray_ResolveWritebackIfCopy(features);
 
 exit:
     Py_XDECREF(input);
@@ -1314,6 +1317,7 @@ static PyObject *Py_BinaryErosion2(PyObject *obj, PyObject *args)
     else {
         PyErr_SetString(PyExc_RuntimeError, "cannot convert CObject");
     }
+    PyArray_ResolveWritebackIfCopy(array);
 exit:
     Py_XDECREF(array);
     Py_XDECREF(strct);

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -3133,8 +3133,6 @@ def test_byte_order_output_writeback(call):
     C code rather than left for NumPy to clean up during deallocation.
     """
     data = np.zeros((5, 5), dtype=np.uint8)
-    data[1, 1] = 1
-    data[3, 3] = 1
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
         call(data)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from scipy._lib._array_api import (
     is_cupy, is_numpy,
@@ -3105,3 +3106,38 @@ def test_distance_transform_cdt_invalid_metric(xp):
     with pytest.raises(ValueError, match=msg):
         ndimage.distance_transform_cdt(xp.ones((5, 5)),
                                        metric="garbage")
+
+
+# NumPy-only because byte order is numpy-specific
+def _swapped_int32(shape):
+    return np.zeros(shape, dtype=np.dtype(np.int32).newbyteorder())
+
+
+@pytest.mark.parametrize('call', [
+    pytest.param(
+        lambda a: ndimage.distance_transform_cdt(
+            a, distances=_swapped_int32((5, 5))),
+        id='distance_transform_cdt'),
+    pytest.param(
+        lambda a: ndimage.distance_transform_edt(
+            a, return_indices=True, indices=_swapped_int32((2, 5, 5))),
+        id='distance_transform_edt'),
+    pytest.param(
+        lambda a: ndimage.binary_erosion(
+            a, output=_swapped_int32((5, 5)), iterations=2),
+        id='binary_erosion'),
+])
+def test_byte_order_output_writeback(call):
+    """Regression test for gh-25641: an output array that NumPy has to copy
+    (here, because of non-native byte order) must be written back by the
+    C code rather than left for NumPy to clean up during deallocation.
+    """
+    data = np.zeros((5, 5), dtype=np.uint8)
+    data[1, 1] = 1
+    data[3, 3] = 1
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        call(data)
+    leaked = [str(w.message) for w in rec
+              if issubclass(w.category, RuntimeWarning)]
+    assert leaked == []


### PR DESCRIPTION
Closes gh-25641

`NI_ObjectToOutputArray` requests `NPY_ARRAY_WRITEBACKIFCOPY`. If the output array a user passes isn't well-behaved (say, non-native byte order), NumPy hands back a temporary copy the caller has to resolve. Most wrappers in `nd_image.c` do. These three didn't:

* `Py_DistanceTransformOnePass` (`distances`, `features`)
* `Py_EuclideanFeatureTransform` (`features`)
* `Py_BinaryErosion2` (`array`)

Reachable via `distance_transform_cdt(distances=...)`, `distance_transform_edt(indices=...)` and `binary_erosion(output=...)`.

On Linux/x86_64, Python 3.12, NumPy 2.5.0: all three warn before the change, none after. Values are the same either way since NumPy resolves the copy itself after warning. No segfault here, so I'm not claiming this fixes the macOS one. Looks warning-level, but callers are the ones meant to resolve.

The `features` resolve isn't reachable from Python today, `_morphology.py` builds that array itself. Happy to drop it. Resolves go after the compute calls to match the existing pattern, so they're skipped on an early `goto`, same as all 16 existing sites.

The test checks for the warning since values don't change. Fails all three without the C fix.

Disclosure:I used Claude while working through the numpy internals on this. The testing and conclusions are mine.