### PR TITLE
TYP: spatial.transform: drop `NotImplementedType` from operator return types

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1450,9 +1450,7 @@ class RigidTransform:
 
         self._matrix = self._backend.setitem(self._matrix, indexer, value.as_matrix())
 
-    def __mul__(
-        self, other: RigidTransform | Rotation
-    ) -> RigidTransform:
+    def __mul__(self, other: RigidTransform | Rotation) -> RigidTransform:
         """Compose this transform with the other.
 
         If ``p`` and ``q`` are two transforms, then the composition of '``q``

--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
-from types import EllipsisType, GenericAlias, ModuleType, NotImplementedType
+from types import EllipsisType, GenericAlias, ModuleType
 from collections.abc import Callable
 
 import numpy as np
@@ -1452,7 +1452,7 @@ class RigidTransform:
 
     def __mul__(
         self, other: RigidTransform | Rotation
-    ) -> RigidTransform | NotImplementedType:
+    ) -> RigidTransform:
         """Compose this transform with the other.
 
         If ``p`` and ``q`` are two transforms, then the composition of '``q``
@@ -1553,7 +1553,7 @@ class RigidTransform:
             matrix = matrix[0, ...]
         return RigidTransform(matrix, normalize=True, copy=False)
 
-    def __rmul__(self, other: Rotation) -> RigidTransform | NotImplementedType:
+    def __rmul__(self, other: Rotation) -> RigidTransform:
         """Compose a rotation with this transform (rotation applied second).
 
         See `__mul__` for more details.

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from types import EllipsisType, GenericAlias, ModuleType, NotImplementedType
+from types import EllipsisType, GenericAlias, ModuleType
 
 import numpy as np
 
@@ -1712,7 +1712,7 @@ class Rotation:
             return result[0, ...]
         return result
 
-    def __mul__(self, other: Rotation) -> Rotation | NotImplementedType:
+    def __mul__(self, other: Rotation) -> Rotation:
         """Compose this rotation with the other.
 
         If `p` and `q` are two rotations, then the composition of 'q followed


### PR DESCRIPTION
#### Reference issue
None.

#### What does this implement/fix?
Narrows the return annotations of the operator dunders in `spatial.transform` to the success type only.

This matches how typeshed annotates such dunders (e.g. `int.__mul__ -> int`) and the ~55 other `return NotImplemented` sites in SciPy, none of which annotate `NotImplementedType`.

#### AI Generation Disclosure
Claude (via Claude Code) was used to trace the annotations' origin, confirm their scope, and draft the change. The edits are AI-generated and reviewed by me; they are annotation-only with no runtime change.