### PR TITLE
BUG: stats: Fix Poisson logpmf large cancellation for large mu

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -998,8 +998,25 @@ class poisson_gen(rv_discrete):
         return random_state.poisson(mu, size)
 
     def _logpmf(self, k, mu):
-        Pk = special.xlogy(k, mu) - gamln(k + 1) - mu
-        return Pk
+        # Loader (2000) saddle-point form avoids cancellation in
+        # xlogy(k, mu) - gammaln(k+1) - mu when k is close to mu and is large:
+        # logpmf = -stirlerr(k) - bd0(k, mu) - 0.5*log(2*pi*k)
+        # Special cases (log of Loader's dpois()): k = 0 evaluates to -mu,
+        # mu = 0 and k > 0 evaluates to -inf (probability 0)
+        return xpx.apply_where(
+            k == 0,
+            (k, mu),
+            lambda k, mu: -mu,
+            lambda k, mu: xpx.apply_where(
+                mu > 0,
+                (k, mu),
+                lambda k, mu: (
+                    -self._stirlerr(k) - self._bd0(k, mu)
+                    - 0.5 * log(2 * np.pi * k)
+                ),
+                fill_value=-np.inf,
+            ),
+        )
 
     def _pmf(self, k, mu):
         # poisson.pmf(k) = exp(-mu) * mu**k / k!
@@ -1034,6 +1051,50 @@ class poisson_gen(rv_discrete):
         g1 = xpx.apply_where(mu_nonzero, tmp, lambda x: sqrt(1.0/x), fill_value=np.inf)
         g2 = xpx.apply_where(mu_nonzero, tmp, lambda x: 1.0/x, fill_value=np.inf)
         return mu, var, g1, g2
+
+    def _stirlerr(self, n):
+        # Stirling remainder is log(n!) - (n*log(n) - n + 0.5*log(2*pi*n))
+        # For small n, evaluate directly using gamln.
+        # For large n, use asymptotic series with coefficients from Loader (2000).
+        S0, S1, S2, S3, S4 = 1/12, 1/360, 1/1260, 1/1680, 1/1188
+        n = np.asarray(n)
+        small = n < 15
+
+        # Dummy n=1 on unused branch to avoid log(0)
+        n_safe = np.where(small & (n > 0), n, 1)
+        exact = (gamln(n_safe + 1)
+                 - (n_safe * log(n_safe) - n_safe
+                    + 0.5 * log(2 * np.pi * n_safe)))
+
+        n2 = n**2
+        # Asymptotic series approximation
+        approx = (S0 - (S1 - (S2 - (S3 - S4/n2)/n2)/n2)/n2)/n
+        return np.where(small, exact, approx)
+
+    def _bd0(self, k, mu):
+        # Deviance term k*log(k/mu) + mu - k from Loader (2000).
+        # Direct form cancels when k is approximately equal to mu, so
+        # use Loader's v-series for |v| < 0.1
+        # where v = (k - mu) / (k + mu).
+        k = np.asarray(k)
+        mu = np.asarray(mu)
+
+        close = np.abs(k - mu) < 0.1 * (k + mu)
+
+        v = (k - mu) / (k + mu)
+        # First term of series expansion
+        series_term = (k - mu)**2 / (k + mu)
+        v2 = v**2
+        term = 2 * k * v
+
+        # Use first ten terms of series expansion,
+        # enough for |v| < 0.1
+        for i in range(1, 11):
+            term *= v2
+            series_term += term / (2 * i + 1)
+
+        direct = special.xlogy(k, k / mu) + mu - k
+        return np.where(close, series_term, direct)
 
 
 poisson = poisson_gen(name="poisson", longname='A Poisson')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3152,9 +3152,7 @@ class TestPoisson:
         mu = 1e15  # scalar mu against array k
         result = stats.poisson.logpmf(k, mu)
         expected = np.array([stats.poisson.logpmf(k_i, mu) for k_i in k])
-        assert_allclose(result, expected)
-        assert result.shape == k.shape
-
+        assert_allclose(result, expected, strict=True)
 
 class TestKSTwo:
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3103,6 +3103,58 @@ class TestPoisson:
         assert_allclose(stats.poisson.logsf(k, mu), logsf_reference,
                         rtol=1e-15, atol=1e-300)
 
+    def test_logpmf_large_mu(self):
+        # This test checks output of the parameters used in gh-25625
+        # and compares to expected output.
+        # reference values were computed with mpmath with 1000 digits of precision:
+        # mp.dps = 1000
+        # k, mu = mp.mpf(k), mp.mpf(mu)
+        # if k == 0:
+        #     return float(-mu)
+        # return float(k*mp.log(mu) - mu - mp.loggamma(k + 1))
+        k = 5e15
+        mu = 5e15
+        expected = -18.993045686877064
+        assert_allclose(stats.poisson.logpmf(k, mu), expected)
+
+    @pytest.mark.parametrize("k, mu, expected",
+        [(14, 14, -2.244418568125061),
+        (18, 20, -2.472264284061216),
+        (1300000, 1000000, -41081.501683746894),
+        (8e7, 1e8, -2148525.91257035),
+        (105e9, 1e10, -151894402015.7727),
+        (8e14, 1e15, -21485158948650.273), # |v| > 0.1 boundary
+        (12e14, 1e15, -18785868152763.832),  # |v| < 0.1 boundary
+        (1e16, 1e16, -19.339619277157038)]) # old formula returns 0.0 here
+    def test_logpmf_accuracy_vs_reference(self, k, mu, expected):
+        # reference values computed with mpmath at 1000 digits of precision
+        # (same procedure as test_logpmf_large_mu)
+        assert_allclose(stats.poisson.logpmf(k, mu), expected, rtol=1e-14)
+
+    def test_logpmf_no_reg_moderate_mu(self):
+        # Checks that the saddle-point approach doesn't deviate significantly
+        # from the original formula used
+        mu = np.array([10, 50, 100, 500, 1e3, 1e4, 1e5, 1e6])
+        k = mu
+        old = special.xlogy(k, mu) - special.gammaln(k + 1) - mu
+        new = stats.poisson.logpmf(k, mu)
+        assert_allclose(old, new, rtol=1e-11, atol=1e-9)
+
+    @pytest.mark.parametrize("k, mu, expected",
+        [(0, 0, 0.0),
+        (3, 0, -np.inf),
+        (0, 5, -5.0)])
+    def test_logpmf_special_cases(self, k, mu, expected):
+        assert_allclose(stats.poisson.logpmf(k, mu), expected)
+
+    def test_logpmf_broadcasting(self):
+        k = np.array([1e15, 1e16, 1e14])
+        mu = 1e15  # scalar mu against array k
+        result = stats.poisson.logpmf(k, mu)
+        expected = np.array([stats.poisson.logpmf(k_i, mu) for k_i in k])
+        assert_allclose(result, expected)
+        assert result.shape == k.shape
+
 
 class TestKSTwo:
 


### PR DESCRIPTION
#### Reference issue
Closes gh-25625

#### What does this implement/fix?
In `scipy.stats._discrete_distns.py`, the previous implementation in the `_logpmf()` function used:
```
logpmf(k, mu) = xlogy(k, mu) - gamln(k + 1) - mu
```
and when `k` and `mu` are near each other and both are large, the individual terms nearly cancel, so float64 loses all significant digits. At the reported point as seen in gh-25625 (`k=mu=5e15`), SciPy returned 0.0 instead of the expected value (-18.993045686877064). 

This PR implements Catherine Loader's saddle-point/Stirling decomp for the Poisson PMF (as seen in Fast and Accurate Computation of Binomial Probabilities, 2000). When taking the log, it becomes:
```
logpmf(k, mu) = -stirlerr(k) - bd0(k, mu) - 0.5 * log(2 * pi * k)   # when k > 0
logpmf(0, mu) = -mu
```
with a special case at `mu=0` and `k > 0` -> `-np.inf` (since probability is 0). These are simply the log equivalents of Loader's `dpois()` edge cases. Negative/non-int `k`s are already handled by the `rv_discrete` class.

Two helper methods were implemented:
- **`_stirlerr(n)`**
This method implements the Stirling remainder `log(n!) - (n*log(n) - n + 0.5*log(2*pi*n))`. For `n<15`, it is evaluated directly via `gamln`, and for larger `n`, five terms of the asymptotic series are used.
- **`_bd0(k, mu)`**
This method represents the deviance function `k*log(k/mu) + mu - k`. When `|v| < 0.1`, Loader's convergent series (10 terms) is used. Otherwise, it is just evaluated directly.

Added tests:
- Specified case in linked issue vs hardcoded mpmath reference
- Accuracy vs mpmath across scales/`|v|` boundaries
- Comparison to the old formula (no large drift at values where expected behavior occurs)
- Special cases that Loader's `dpois()` covers (like `mu=0` and `k > 0`, etc.)
- Broadcasting, ensuring array functionality still exists

All tests (including existing) for Poisson pass with
```
spin test -t scipy.stats.tests.test_distributions::TestPoisson
```

#### Additional information
The algorithm follows Loader (2000) and Loader’s original (and permissive) `dpois` implementation in `dbinom.c`.
Paper: https://www.r-project.org/doc/reports/CLoader-dbinom-2002.pdf
Archived original code: https://web.archive.org/web/20011227233957/http://cm.bell-labs.com/cm/ms/departments/sia/catherine/dbinom/dbinom.c

#### AI Generation Disclosure
Grok 4.5 was used for codebase navigation and for discussing considerations with each approach to evaluating the function for ranges of values. The implementations of `_logpmf`, `_stirlerr`, and `_bd0` were written and verified by me against Loader's code and the results generated by mpmath. I also designed and implemented the test cases.
