### PR TITLE
DOC: special: add Examples section for riccati_jn and riccati_yn

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1314,6 +1314,36 @@ def riccati_jn(n, x):
     .. [2] NIST Digital Library of Mathematical Functions.
            https://dlmf.nist.gov/10.51.E1
 
+    Examples
+    --------
+    In practical applications, frequently the logarithmic derivative of the
+    Riccati-Bessel functions is needed. We determine the logarithmic derivative
+    of the Riccati-Bessel function of the first kind for order 5 and argument 1.2.
+
+    >>> from scipy.special import riccati_jn
+    >>> n = 5
+    >>> z = 1.2
+    >>> psi_n, psi_n_p = riccati_jn(n, z)
+    >>> psi_n
+    array([9.32039086e-01, 4.14341484e-01, 1.03814624e-01, 1.82194479e-02,
+           2.46548893e-03, 2.71719094e-04])
+    >>> psi_n_p
+    array([0.36235775, 0.58675452, 0.24131711, 0.058266  , 0.01000115,
+           0.00133333])
+    >>> psi_n_p[5]/psi_n[5]
+    np.float64(4.9070016327063115)
+
+    Alternatively, the logarithmic derivative of the Riccati-Bessel functions
+    could be obtained from the corresponding spherical Bessel functions by making
+    use of the definition of the Riccati-Bessel function in terms of the
+    spherical Bessel function.
+
+    >>> from scipy.special import spherical_jn
+    >>> jn = spherical_jn(n, z)
+    >>> jnp = spherical_jn(n, z, derivative=True)
+    >>> jnp/jn + 1/z
+    np.float64(4.907001632706311)
+
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
@@ -1370,6 +1400,36 @@ def riccati_yn(n, x):
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
            https://dlmf.nist.gov/10.51.E1
+
+    Examples
+    --------
+    In practical applications, frequently the logarithmic derivative of the
+    Riccati-Bessel functions is needed. We determine the logarithmic derivative
+    of the Riccati-Bessel function of the second kind for order 5 and argument 1.2.
+
+    >>> from scipy.special import riccati_yn
+    >>> n = 5
+    >>> z = 1.2
+    >>> chi_n, chi_n_p = riccati_yn(n, z)
+    >>> chi_n
+    array([-3.62357754e-01, -1.23400388e+00, -2.72265195e+00, -1.01103792e+01,
+           -5.62545603e+01, -4.11798823e+02])
+    >>> chi_n_p
+    array([9.32039086e-01, 6.65978813e-01, 3.30374937e+00, 2.25532961e+01,
+           1.77404822e+02, 1.65957387e+03])
+    >>> chi_n_p[5]/chi_n[5]
+    np.float64(-4.030059767479337)
+
+    Alternatively, the logarithmic derivative of the Riccati-Bessel functions
+    could be obtained from the corresponding spherical Bessel functions by making
+    use of the definition of the Riccati-Bessel function in terms of the
+    spherical Bessel function.
+
+    >>> from scipy.special import spherical_yn
+    >>> yn = spherical_yn(n, z)
+    >>> ynp = spherical_yn(n, z, derivative=True)
+    >>> ynp/yn + 1/z
+    np.float64(-4.030059767479337)
 
     """
     if not (isscalar(n) and isscalar(x)):

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1319,6 +1319,8 @@ def riccati_jn(n, x):
     In practical applications, frequently the logarithmic derivative of the
     Riccati-Bessel functions is needed. We determine the logarithmic derivative
     of the Riccati-Bessel function of the first kind for order 5 and argument 1.2.
+    The logarithmic derivative is obtained by dividing the derivative of the
+    Riccati-Bessel function by the Riccati-Bessel function itself.
 
     >>> from scipy.special import riccati_jn
     >>> n = 5
@@ -1336,7 +1338,7 @@ def riccati_jn(n, x):
     Alternatively, the logarithmic derivative of the Riccati-Bessel functions
     could be obtained from the corresponding spherical Bessel functions by making
     use of the definition of the Riccati-Bessel function in terms of the
-    spherical Bessel function.
+    spherical Bessel function as given above.
 
     >>> from scipy.special import spherical_jn
     >>> jn = spherical_jn(n, z)
@@ -1406,6 +1408,8 @@ def riccati_yn(n, x):
     In practical applications, frequently the logarithmic derivative of the
     Riccati-Bessel functions is needed. We determine the logarithmic derivative
     of the Riccati-Bessel function of the second kind for order 5 and argument 1.2.
+    The logarithmic derivative is obtained by dividing the derivative of the
+    Riccati-Bessel function by the Riccati-Bessel function itself.
 
     >>> from scipy.special import riccati_yn
     >>> n = 5
@@ -1423,7 +1427,7 @@ def riccati_yn(n, x):
     Alternatively, the logarithmic derivative of the Riccati-Bessel functions
     could be obtained from the corresponding spherical Bessel functions by making
     use of the definition of the Riccati-Bessel function in terms of the
-    spherical Bessel function.
+    spherical Bessel function as given above.
 
     >>> from scipy.special import spherical_yn
     >>> yn = spherical_yn(n, z)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
gh-7168

#### What does this implement/fix?
This PR adds Examples sections to the Riccati-Bessel functions in scipy.special. Specifically, the logarithmic derivatives are considered as they are useful in applications and allow to point out different approaches based either on the Riccati-Bessel functions or on the corresponding spherical Bessel functions.

#### AI Generation Disclosure
No AI tools used