### PR TITLE
BUG: signal.decimate: check zeros for complex coeffs, not poles twice

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -5415,7 +5415,7 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
             b, a = system.num, system.den
             ftype = 'fir'
         elif (any(np.iscomplex(system.poles))
-              or any(np.iscomplex(system.poles))
+              or any(np.iscomplex(system.zeros))
               or np.iscomplex(system.gain)):
             # sosfilt & sosfiltfilt don't handle complex coeffs
             iir_use_sos = False

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3246,8 +3246,7 @@ class TestDecimate:
 
         xp_assert_close(yzp, yzpref, rtol=1e-10, atol=1e-13)
 
-    @skip_xp_backends(np_only=True, reason="dlti")
-    def test_complex_zeros_real_poles_iir_dlti(self, xp):
+    def test_complex_zeros_real_poles_iir_dlti(self):  # np only as dlti
         # A complex filter whose poles are real but zeros are complex must
         # still take the (complex-capable) lfilter path. Previously the guard
         # tested ``system.poles`` twice and never ``system.zeros``, so such a

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3247,6 +3247,26 @@ class TestDecimate:
         xp_assert_close(yzp, yzpref, rtol=1e-10, atol=1e-13)
 
     @skip_xp_backends(np_only=True, reason="dlti")
+    def test_complex_zeros_real_poles_iir_dlti(self, xp):
+        # A complex filter whose poles are real but zeros are complex must
+        # still take the (complex-capable) lfilter path. Previously the guard
+        # tested ``system.poles`` twice and never ``system.zeros``, so such a
+        # filter was forced through ``zpk2sos`` and raised.
+        system = signal.dlti([0.5j], [0.5], 1.0)
+        rng = np.random.default_rng(1234)
+        u = rng.standard_normal(200)
+
+        z, p, k = system.zeros, system.poles, system.gain
+
+        ynzp = signal.decimate(u, 2, ftype=system, zero_phase=False)
+        ynzpref = signal.lfilter(*signal.zpk2tf(z, p, k), u)[::2]
+        xp_assert_close(ynzp, ynzpref, rtol=1e-10, atol=1e-13)
+
+        yzp = signal.decimate(u, 2, ftype=system, zero_phase=True)
+        yzpref = signal.filtfilt(*signal.zpk2tf(z, p, k), u)[::2]
+        xp_assert_close(yzp, yzpref, rtol=1e-10, atol=1e-13)
+
+    @skip_xp_backends(np_only=True, reason="dlti")
     def test_complex_fir_dlti(self, xp):
         # centre frequency for filter [Hz]
         fcentre = 50


### PR DESCRIPTION
Refs gh-17881.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Related: gh-17881 (which introduced this guard).

#### What does this implement/fix?
The check that detects complex-coefficient filters looks at the poles but not the zeros, so filters with complex zeros are not recognized as complex and end up raising an error.

#### Additional information
Reproducer (real poles, complex zeros) on released scipy 1.18.0:

    import numpy as np
    from scipy import signal
    x = np.random.default_rng(0).standard_normal(200)
    filt = signal.dlti([0.5j], [0.5], 1.0)   # real pole, complex zero
    signal.decimate(x, 2, ftype=filt)        # -> ValueError: complex value with no matching conjugate

With the fix, such a filter takes the `lfilter`/`filtfilt` path and returns correctly. A regression test (`test_complex_zeros_real_poles_iir_dlti`) is included.

#### AI Generation Disclosure
Claude (Anthropic) was used as an AI code-audit assistant to locate this bug and to draft the one-line fix and the regression test; I reviewed, ran, and verified them (the reproducer triggers the crash on scipy 1.18.0 and passes with the fix). The "What does this fix?" text is my own, translated from Italian with AI assistance.
