### PR TITLE
BUG: linalg.signm: preserve input dtype for defective matrices

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -827,7 +827,7 @@ def signm(A):
     # min_nonzero_sv = vals[(vals>max_sv*errtol).tolist().count(1)-1]
     # c = 0.5/min_nonzero_sv
     c = 0.5/max_sv
-    S0 = A + c*np.identity(A.shape[0])
+    S0 = A + c*np.identity(A.shape[0], dtype=A.dtype)
     prev_errest = errest
     for i in range(100):
         iS0 = inv(S0)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -88,6 +88,17 @@ class TestSignM:
         signm(a)
         #XXX: what would be the correct result?
 
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64,
+                                       np.complex64, np.complex128])
+    def test_signm_dtype_preservation(self, dtype):
+        # gh-25657: signm upcast float32/complex64 for defective matrices
+        # (the iterative fall-through branch) while the non-defective branch
+        # preserved dtype. Output dtype must depend on input dtype, not values.
+        non_defective = np.array([[2, 1], [0, 3]], dtype=dtype)  # distinct eigs
+        defective = np.array([[2, 1], [0, 2]], dtype=dtype)      # repeated eig
+        assert signm(non_defective).dtype == dtype
+        assert signm(defective).dtype == dtype
+
 
 class TestLogM:
     @pytest.mark.filterwarnings("ignore:.*inaccurate.*:RuntimeWarning")


### PR DESCRIPTION

Closes gh-25657

#### What does this implement/fix?

Right now `signm` doesn't always keep the input's data type. If you pass in a
`float32` matrix, you sometimes get `float32` back and sometimes `float64`,
and it depends on the actual numbers in the matrix rather than its type. That
makes the output type hard to predict.

The reason is one line in the branch that handles defective matrices:
`S0 = A + c*np.identity(...)`. `np.identity` gives back `float64` by default,
so the whole calculation gets bumped up to `float64`. Regular matrices don't
go through this branch, which is why the type seemed random.

The fix tells `np.identity` to use the input's own type (`dtype=A.dtype`), so
the type stays the same all the way through. This is how `expm` and `sqrtm`
already behave.

#### Additional information

For `float32`/`complex64` defective matrices the result is now worked out in
that type instead of `float64`, and it stays within the function's accuracy
tolerance. I also added a test that checks the type is kept for both branches,
across `float32`, `float64`, `complex64`, and `complex128`.

## AI Generation Disclosure

Used Claude to verify few shell commands