### PR TITLE
BUG: interpolate: fix BivariateSpline(grid=False) scalar output shape

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1411,12 +1411,14 @@ class _BivariateSplineBase:
         >>> ax2.imshow(zdata_interp)
         >>> plt.show()
         """
-        x = np.atleast_1d(np.asarray(x))
-        y = np.atleast_1d(np.asarray(y))
+        x = np.asarray(x)
+        y = np.asarray(y)
 
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
         if grid:
+            x = np.atleast_1d(x)
+            y = np.atleast_1d(y)
             if x.size == 0 or y.size == 0:
                 return np.zeros((x.size, y.size), dtype=self.tck[2].dtype)
 
@@ -1439,8 +1441,8 @@ class _BivariateSplineBase:
                 x, y = np.broadcast_arrays(x, y)
 
             shape = x.shape
-            x = x.ravel()
-            y = y.ravel()
+            x = np.atleast_1d(x).ravel()
+            y = np.atleast_1d(y).ravel()
             if x.size == 0 or y.size == 0:
                 return np.zeros(shape, dtype=self.tck[2].dtype)
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1073,6 +1073,28 @@ class TestRectBivariateSpline:
         xp_assert_close(
             _ndbspline_call_like_bivariate(lut_custom, x, y), z.astype(np.float64))
 
+    def test_scalar_grid_false_gh25471(self):
+        # gh-25471: evaluating with grid=False at scalar coordinates must
+        # return a 0-d array (as in <= 1.17), not a (1,)-shaped array, while
+        # array inputs keep their broadcast shape.
+        x = np.arange(6.0)
+        lut = RectBivariateSpline(x, x, np.outer(x, x))
+
+        r = lut(2.5, 3.5, grid=False)
+        assert np.ndim(r) == 0
+        assert np.shape(r) == ()
+
+        # ev() forwards to grid=False and must agree
+        xp_assert_equal(lut.ev(2.5, 3.5), r)
+
+        # 1-d and broadcast inputs keep their shape
+        assert lut([2.5, 1.5], [3.5, 2.5], grid=False).shape == (2,)
+        assert lut(2.5, [3.5, 2.5], grid=False).shape == (2,)
+
+        # grid=True behaviour is unchanged
+        assert lut(2.5, 3.5, grid=True).shape == (1, 1)
+        assert lut([1.5, 2.5], [2.5, 3.5], grid=True).shape == (2, 2)
+
     @pytest.mark.parametrize("k", [3, 4])
     def test_interpolated_offgrid_points(self, k):
         # Setup


### PR DESCRIPTION
Evaluating a 2-D *BivariateSpline with grid=False at scalar coordinates returned a (1,)-shaped array instead of the 0-d array returned by 1.17 and earlier (gh-25471). The __call__ wrapper applied np.atleast_1d to the inputs before recording the output shape, so scalar inputs were promoted to shape (1,).

Keep the inputs as-is when computing the broadcast output shape for grid=False (only ravel a local copy for the low-level evaluator), so scalar inputs again produce a 0-d result while array inputs keep their broadcast shape. grid=True behaviour is unchanged.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-25471.

#### What does this implement/fix?
Since 1.18.0, evaluating a 2-D `*BivariateSpline` with `grid=False` at scalar
coordinates returned a `(1,)`-shaped array instead of the 0-d array returned by
1.17 and earlier (a regression). The low-level `bisplev` evaluator was
unaffected, confirming the problem was at the Python wrapper level.

Root cause is in `_BivariateSplineBase.__call__`: the inputs were promoted with
`np.atleast_1d` *before* the output shape was recorded, so scalar inputs became
shape `(1,)` and the result was reshaped to `(1,)`.

The fix records the broadcast output shape from the inputs as given, and only
promotes/ravels a local copy for the low-level FITPACK evaluator:

```python
x = np.asarray(x); y = np.asarray(y)
if grid:
    x = np.atleast_1d(x); y = np.atleast_1d(y)   # grid path unchanged
    ...
else:
    if x.shape != y.shape:
        x, y = np.broadcast_arrays(x, y)
    shape = x.shape                                # () for scalars
    x = np.atleast_1d(x).ravel()
    y = np.atleast_1d(y).ravel()
    ...
    z = z.reshape(shape)                           # 0-d for scalars
```

Effect (matching <= 1.17):

| call | before | after |
| --- | --- | --- |
| `spl(2.5, 3.5, grid=False)` | `(1,)` | `()` |
| `spl.ev(2.5, 3.5)` | `(1,)` | `()` |
| `spl([a, b], [c, d], grid=False)` | `(2,)` | `(2,)` |
| `spl(2.5, 3.5, grid=True)` | `(1, 1)` | `(1, 1)` |

This affects `RectBivariateSpline`, `SmoothBivariateSpline`, `LSQBivariateSpline`
and the `SphereBivariateSpline` classes that delegate to the shared base, plus
`ev()` which forwards to `grid=False`.

#### Additional information
A regression test (`TestRectBivariateSpline::test_scalar_grid_false_gh25471`)
covers scalar 0-d output, `ev()` agreement, preserved 1-d/broadcast shapes, and
unchanged `grid=True` behaviour. The full `scipy/interpolate/tests/` suite
passes locally.

#### AI Generation Disclosure
This PR was prepared with the assistance of Devin (an AI software engineering
agent). The AI identified the root cause, wrote the fix in
`scipy/interpolate/_fitpack2.py` and the regression test in
`scipy/interpolate/tests/test_fitpack2.py`, and ran the test suite. All changes
were reviewed for correctness.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
