### PR TITLE
BUG: interpolate: restore interp1d degenerate extrapolation behaviour

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -510,10 +510,21 @@ class interp1d(_Interpolator1D):
 
         # Note that the following expression relies on the specifics of the
         # broadcasting semantics.
+        dx = (x_hi - x_lo)[:, None]
         y_new = (
-            ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
-            + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
+            ((x_new - x_lo)[:, None]/dx) * y_hi
+            + ((x_hi - x_new)[:, None]/dx) * y_lo
             )
+
+        # Degenerate (repeated x) intervals make de Boor's weights infinite,
+        # yielding nan everywhere. Fall back to the slope form there to keep
+        # the historical extrapolation behaviour (+/-inf away from the node,
+        # nan on it) for such vertical inputs.
+        degenerate = (dx == 0)
+        if degenerate.any():
+            slope = (y_hi - y_lo) / dx
+            y_slope = slope * (x_new - x_lo)[:, None] + y_lo
+            y_new = np.where(degenerate, y_slope, y_new)
 
         return y_new
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -251,6 +251,23 @@ class TestInterp1D:
         xp_assert_close(yp, y, atol=1e-20)
         assert np.all(yp >= 0) # less stable computations give yp[1,1] = -5e-20
 
+    def test_linear_degenerate_extrapolation(self):
+        # regression test for gh-25503: extrapolating over degenerate
+        # (repeated x, i.e. vertical) input must return +/-inf away from the
+        # node and nan on it, not nan everywhere (regression from gh-24282).
+        with np.errstate(divide='ignore', invalid='ignore'):
+            f = interp1d([2, 2], [3, 4], kind='linear', fill_value='extrapolate')
+            xp_assert_equal(f([1, 2, 3]),
+                            np.array([-np.inf, np.nan, np.inf]))
+
+            # multi-dimensional y is handled the same way column-wise
+            f2 = interp1d([2, 2], [[3, 30], [4, 40]], axis=0, kind='linear',
+                          fill_value='extrapolate')
+            xp_assert_equal(f2([1, 2, 3]),
+                            np.array([[-np.inf, -np.inf],
+                                      [np.nan, np.nan],
+                                      [np.inf, np.inf]]))
+
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with
         # float32 inputs


### PR DESCRIPTION
Extrapolating an interp1d(kind='linear', fill_value='extrapolate') built from degenerate (repeated x, i.e. vertical) input returned nan for every query point since gh-24282, which switched _call_linear to de Boor's weighted form. For a zero-width interval both weights are infinite, so the result is nan everywhere.

Keep the numerically stable de Boor form for regular intervals, but fall back to the slope form on degenerate intervals so such inputs again extrapolate to +/-inf away from the node and nan on it (gh-25503).

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-25503.

#### What does this implement/fix?
Since gh-24282 (numerical-stability fix), evaluating an
`interp1d(kind='linear', fill_value='extrapolate')` built from *degenerate*
input — repeated `x` values, i.e. a vertical line — returned `nan` for **every**
query point. Previously points to the left extrapolated to `-inf`, points to the
right to `+inf`, and points exactly on the node to `nan`.

Root cause: gh-24282 rewrote `_call_linear` to de Boor's weighted form:

```python
y_new = ((x_new - x_lo)/(x_hi - x_lo)) * y_hi + ((x_hi - x_new)/(x_hi - x_lo)) * y_lo
```

For a zero-width interval (`x_hi == x_lo`) both weights are infinite, so
`inf*y_hi + (-inf)*y_lo == nan` regardless of the query point.

Fix: keep the numerically stable de Boor form for regular intervals (so the
gh-24281 endpoint-exactness / non-negativity guarantee is preserved), but fall
back to the historical slope form on degenerate intervals only:

```python
dx = (x_hi - x_lo)[:, None]
y_new = ((x_new - x_lo)[:, None]/dx) * y_hi + ((x_hi - x_new)[:, None]/dx) * y_lo
degenerate = (dx == 0)
if degenerate.any():
    slope = (y_hi - y_lo) / dx
    y_new = np.where(degenerate, slope*(x_new - x_lo)[:, None] + y_lo, y_new)
```

This restores the pre-1.18 behaviour for vertical inputs:

```python
interp1d([2, 2], [3, 4], kind='linear', fill_value='extrapolate')([1, 2, 3])
# -> [-inf, nan, inf]   (was [nan, nan, nan])
```

#### Additional information
New regression test `TestInterp1D::test_linear_degenerate_extrapolation` covers
the scalar and multi-dimensional-`y` cases; the existing
`test_linear_numerical_stability` (gh-24281) still passes, and the full
`scipy/interpolate/tests/test_interpolate.py` suite passes locally.

#### AI Generation Disclosure
This PR was prepared with the assistance of Devin (an AI software engineering
agent): it identified the regressing commit, implemented the fix in
`scipy/interpolate/_interpolate.py`, added the regression test, and ran the
suite. All changes were reviewed for correctness.
