### PR TITLE
MAINT: interpolate: do not include Python.h where not needed

### DIFF
--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -1,5 +1,4 @@
-#include <Python.h>
-/* __fitpack.h includes Python.h */
+#include <cstring>  /* for memcpy */
 #include <string>
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
We included Python.h for `npy_cblas.h`, which we replaced with `scipy_blas_defines.h`, and which does not include `Python.h`. Since then, the include was only to transitively declare `memcpy`. Thus replace the include by `cstring`

This is a drive-by clean-up prompted by https://github.com/scipy/scipy/issues/25648 even though it's unrelated in the end, as there are no `malloc` calls in `__fitpack.{h,cc}`.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
