### PR TITLE
Read Py_TYPE(self) before destructor in _uarray dealloc handlers

### DIFF
--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -312,8 +312,9 @@ struct BackendState {
   bool use_thread_local_globals = true;
 
   static void dealloc(BackendState * self) {
+    PyTypeObject * type = Py_TYPE(self);
     self->~BackendState();
-    Py_TYPE(self)->tp_free(self);
+    type->tp_free(self);
   }
 
   static PyObject * new_(
@@ -764,8 +765,9 @@ struct SetBackendContext {
 
   static void dealloc(SetBackendContext * self) {
     PyObject_GC_UnTrack(self);
+    PyTypeObject * type = Py_TYPE(self);
     self->~SetBackendContext();
-    Py_TYPE(self)->tp_free(self);
+    type->tp_free(self);
   }
 
   static PyObject * new_(
@@ -862,8 +864,9 @@ struct SkipBackendContext {
 
   static void dealloc(SkipBackendContext * self) {
     PyObject_GC_UnTrack(self);
+    PyTypeObject * type = Py_TYPE(self);
     self->~SkipBackendContext();
-    Py_TYPE(self)->tp_free(self);
+    type->tp_free(self);
   }
 
   static PyObject * new_(
@@ -1087,8 +1090,9 @@ struct Function {
 
   static void dealloc(Function * self) {
     PyObject_GC_UnTrack(self);
+    PyTypeObject * type = Py_TYPE(self);
     self->~Function();
-    Py_TYPE(self)->tp_free(self);
+    type->tp_free(self);
   }
 
   static PyObject * new_(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Each dealloc does self->~T() and then Py_TYPE(self)->tp_free(self). The destructor ends the object's lifetime, so reading Py_TYPE(self) afterwards is a use-after-destructor; under -fsanitize-memory-use-after-dtor the destructor poisons the object storage, and the subsequent Py_TYPE(self) read is reported as reading destroyed memory.
Cache the type pointer before running the destructor in all four handlers (BackendState, SetBackendContext, SkipBackendContext, Function).

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used
