### PR TITLE
BUG: special.stdtr: fix df=1 accuracy regression near t=0 (gh-25667)

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -13,6 +13,7 @@
 #include "boost/math/special_functions/hypergeometric_pFq.hpp"
 
 #include "boost/math/distributions.hpp"
+#include <boost/math/constants/constants.hpp>
 #include <boost/math/distributions/inverse_gaussian.hpp>
 
 typedef boost::math::policies::policy<
@@ -1624,6 +1625,23 @@ t_cdf_wrap(const Real v, const Real x)
     }
     if (std::isinf(x)) {
         return  (x > 0) ? 1.0 : 0.0;
+    }
+    if (v == 1) {
+        /* One degree of freedom is just the standard Cauchy distribution, so
+           use its closed-form CDF, 0.5 + atan(x)/pi. We don't go through Boost
+           here because for df == 1 it takes an arcsine shortcut that evaluates
+           asin(sqrt(1 - z)) with z = x*x/(1 + x*x). Near x = 0 that 1 - z rounds
+           away everything below 2**-53, and asin close to 1 magnifies it, so the
+           answer ends up quantized and pinned to exactly 0.5 for |x| under about
+           7e-9 (gh-25667). The closed form doesn't have that problem.
+
+           For x < -1 we rewrite it as -atan(1/x)/pi, which is the same value but
+           avoids losing precision to cancellation as the CDF heads toward 0. */
+        const Real pi = boost::math::constants::pi<Real>();
+        if (x < -1) {
+            return -std::atan(1 / x) / pi;
+        }
+        return 0.5 + std::atan(x) / pi;
     }
     Real y;
     try {

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -452,6 +452,40 @@ def test_stdtr_stdtrit_neg_inf():
     assert np.all(np.isnan(sp.stdtrit(-np.inf, [0.0, 0.25, 0.5, 0.75, 1.0])))
 
 
+def test_stdtr_df1_small_x_gh25667():
+    # gh-25667: for df=1 (the Cauchy distribution) the Boost path used to
+    # quantize stdtr near x = 0 and return a flat 0.5 for every |x| below
+    # ~7e-9, so the result stopped tracking x at all. df=1 has the closed form
+    # 0.5 + atan(x)/pi; the reference values below come from mpmath at 60 digits.
+    x_pos = np.array([
+        1e-10, 1e-9, 3e-9, 7.45e-9, 2.0**-27, 1e-8, 1e-7, 1e-5, 1e-3,
+        1.0, 1e2, 1e5, 1e8,
+    ])
+    ref_pos = np.array([
+        0.500000000031831, 0.5000000003183099, 0.5000000009549297,
+        0.5000000023714086, 0.5000000023715935, 0.5000000031830989,
+        0.5000000318309886, 0.5000031830988617, 0.5003183097800805,
+        0.75, 0.9968170072350917, 0.9999968169011383, 0.9999999968169011,
+    ])
+    ref_neg = np.array([
+        0.499999999968169, 0.4999999996816901, 0.49999999904507036,
+        0.4999999976285914, 0.4999999976284065, 0.49999999681690116,
+        0.4999999681690114, 0.4999968169011383, 0.4996816902199194,
+        0.25, 0.003182992764908255, 3.1830988617318035e-06,
+        3.1830988618379066e-09,
+    ])
+
+    x = np.concatenate([-x_pos[::-1], [0.0], x_pos])
+    expected = np.concatenate([ref_neg[::-1], [0.5], ref_pos])
+    got = sp.stdtr(1, x)
+    assert_allclose(got, expected, rtol=2e-15, atol=0.0)
+
+    # The bug collapsed the result to exactly 0.5 across a whole neighbourhood
+    # of the origin; stdtr(1, x) is strictly increasing, so guard against that.
+    assert sp.stdtr(1, 0.0) == 0.5
+    assert np.all(np.diff(got) > 0)
+
+
 def test_bdtrik_nbdtrik_inf():
     y = np.array(
         [np.nan,-np.inf,-10.0, -1.0, 0.0, .00001, .5, 0.9999, 1.0, 10.0, np.inf])


### PR DESCRIPTION
Closes gh-25667.

### Problem
Since 1.17.0, `special.stdtr(1, t)` is inaccurate for small `|t|`: the output is
quantized in steps of ~`2**-26/pi` and is exactly `0.5` for all `|t|` below
~`7.45e-9`, carrying no information about `t`. Only df=1 is affected. This came
from the migration to `boost::math::cdf(students_t_distribution(df), t)` in
gh-22962: for df=1 Boost takes the arcsine special case, computing
`asin(sqrt(1 - z))` with `z = t*t/(1 + t*t)`, and `1 - z` loses `t` below the
`2**-53` quantum.

### Fix
df=1 is the standard Cauchy distribution, so I compute its closed form
`0.5 + atan(t)/pi` directly. The lower tail (`t < -1`) uses `-atan(1/t)/pi` to
avoid cancellation as the CDF approaches 0.

### Testing
- New regression test `test_stdtr_df1_small_x_gh25667` (reference values from
  mpmath at 60 digits; also asserts `stdtr(1, ·)` is strictly increasing through
  the origin, which the bug violated).
- Verified against a 60-digit mpmath reference: `<=1.014` ulp across
  `±1e-12 … ±1e15` (vs up to `2.1e7` ulp before). df>=2 is untouched.