### PR TITLE
BUG: signal: accept scalar initial conditions in lfiltic

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2348,7 +2348,7 @@ def lfiltic(b, a, y, x=None):
     N = a.shape[0] - 1
     M = b.shape[0] - 1
     K = max(M, N)
-    y = xp.asarray(y)
+    y = xpx.atleast_nd(xp.asarray(y), ndim=1, xp=xp)
 
     if N < 0:
         raise ValueError("There must be at least one `a` coefficient.")
@@ -2359,7 +2359,7 @@ def lfiltic(b, a, y, x=None):
             result_type = xp.float64
         x = xp.zeros(M, dtype=result_type)
     else:
-        x = xp.asarray(x)
+        x = xpx.atleast_nd(xp.asarray(x), ndim=1, xp=xp)
 
         result_type = xp.result_type(b, a, y, x)
         if xp.isdtype(result_type, ('bool', 'integral')):  #'bui':

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2230,6 +2230,21 @@ class _TestLinearFilter:
         check_dtype_arg = {} if self.dtype == object else {'check_dtype': False}
         xp_assert_equal(zi, zi_2, **check_dtype_arg)
 
+    @make_xp_test_case(lfiltic)
+    def test_lfiltic_scalar_ic(self, xp):
+        # regression test for gh-14664: scalar initial conditions must be
+        # accepted and give the same result as the equivalent length-1 array,
+        # independently of the filter length (a short filter used to raise).
+        b = xp.asarray([1 - 0.2])
+        a = xp.asarray([1.0, -0.2])
+        xp_assert_close(lfiltic(b, a, 3.0), lfiltic(b, a, xp.asarray([3.0])))
+
+        # a scalar `x` (with M > 0) is likewise accepted
+        b2 = xp.asarray([1.0, 0.5, 0.25])
+        a2 = xp.asarray([1.0, -0.3])
+        xp_assert_close(lfiltic(b2, a2, 2.0, 1.0),
+                        lfiltic(b2, a2, xp.asarray([2.0]), xp.asarray([1.0])))
+
     @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_short_x_FIR(self, xp):
         # regression test for #5116


### PR DESCRIPTION
lfiltic converted the initial-condition arguments y (and x) with np.asarray, so a scalar produced a 0-d array. Depending on the filter length this then raised on slicing or concatenation instead of being treated as a length-1 sequence, so lfiltic(b, a, 0.0) failed for short filters. Promote y and x with atleast_nd, matching how a and b are already handled, so scalar initial conditions behave like length-1 arrays (gh-14664).

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
`scipy.signal.lfiltic(b, a, y, x=None)` documents `y` (and `x`) as *array_like*,
but converted them with a bare `xp.asarray`, so a Python/NumPy scalar became a
**0-d** array. Depending on the filter length this 0-d array was then either
sliced (`y[:N-m]`) or concatenated (`xp.concat`), both of which fail on 0-d
input. The result was an inconsistency: a scalar initial condition worked for
some filters and raised for others, e.g.

```python
from scipy.signal import lfiltic, butter
import numpy as np

b, a = butter(5, 0.5)
lfiltic(b, a, 0.0)          # long filter

be, ae = np.array([1 - 0.2]), np.array([1.0, -0.2])
lfiltic(be, ae, 0.0)        # short filter -> raised
```

On current `main` both calls raise (`zero-dimensional arrays cannot be
concatenated`); on older releases only the short-filter case raised.

Fix: promote `y` and `x` with `xpx.atleast_nd(..., ndim=1)`, matching how the
filter coefficients `a` and `b` are already normalized a few lines above. A
scalar initial condition now behaves exactly like the equivalent length-1
sequence.

```python
lfiltic(be, ae, 0.0)        # -> array([0.])
lfiltic(be, ae, 3.0)        # -> array([0.6]) == lfiltic(be, ae, [3.0])
```

#### Additional information
New regression test `TestLinearFilter::test_lfiltic_scalar_ic` checks that a
scalar `y` (and a scalar `x`) give the same result as the length-1 array form
for both short and long filters. The existing `lfiltic` tests still pass, as
does the wider `lfilter`/FIR test set.

#### AI Generation Disclosure
This PR was prepared with the assistance of Devin (an AI software engineering
agent): it identified the root cause in `lfiltic`, implemented the fix in
`scipy/signal/_signaltools.py`, and added the regression test. All changes were
reviewed for correctness.
