### PR TITLE
DOC/MAINT: Make "Array API Standard Support" part a dropdown in docstrs

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -810,27 +810,31 @@ def _make_capabilities_note(fun_name, capabilities, extra_note=None):
 
     # Note: deliberately not documenting array-api-strict
     note = f"""
-    **Array API Standard Support**
 
-    `{fun_name}` has experimental support for Python Array API Standard compatible
-    backends in addition to NumPy. Please consider testing these features
-    by setting an environment variable ``SCIPY_ARRAY_API=1`` and providing
-    CuPy, PyTorch, JAX, or Dask arrays as array arguments. The following
-    combinations of backend and device (or other capability) are supported.
+    .. dropdown:: Array API Standard Support
+        :color: primary
 
-    ====================  ====================  ====================
-    Library               CPU                   GPU
-    ====================  ====================  ====================
-    NumPy                 {capabilities['numpy']                   }
-    CuPy                  {capabilities['cupy']                    }
-    PyTorch               {capabilities['torch']                   }
-    JAX                   {capabilities['jax.numpy']               }
-    Dask                  {capabilities['dask.array']              }
-    ====================  ====================  ====================
+        `{fun_name}` has experimental support for Python Array API Standard compatible
+        backends in addition to NumPy. Please consider testing these features
+        by setting an environment variable ``SCIPY_ARRAY_API=1`` and providing
+        CuPy, PyTorch, JAX, or Dask arrays as array arguments. The following
+        combinations of backend and device (or other capability) are supported.
 
-    {marray_note or ""}
-    {extra_note or ""}
-    See :ref:`dev-arrayapi` for more information.
+        ====================  ====================  ====================
+        Library               CPU                   GPU
+        ====================  ====================  ====================
+        NumPy                 {capabilities['numpy']                   }
+        CuPy                  {capabilities['cupy']                    }
+        PyTorch               {capabilities['torch']                   }
+        JAX                   {capabilities['jax.numpy']               }
+        Dask                  {capabilities['dask.array']              }
+        ====================  ====================  ====================
+
+    {textwrap.indent(marray_note or "", ' '*4)}
+    {textwrap.indent(extra_note or "",  ' '*4)}
+
+        See :ref:`dev-arrayapi` for more information.
+
     """
 
     return textwrap.dedent(note)

--- a/tools/refguide/refguide_check.py
+++ b/tools/refguide/refguide_check.py
@@ -307,7 +307,7 @@ def validate_rst_syntax(text, name, dots=True):
         'obj', 'versionadded', 'versionchanged', 'module', 'class', 'meth',
         'ref', 'func', 'toctree', 'moduleauthor', 'deprecated',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv',
-        'versionremoved', 'math:numref'
+        'versionremoved', 'math:numref', 'dropdown'
     ])
 
     # Run through docutils


### PR DESCRIPTION
To limit the strain on the scroll wheels a little bit: This PR converts the dynamically generated "Array API Standard Support" sections into a dropdown block in each docstr. Consult Pydata Sphinx Theme's [Dropdowns documentation] for more information on the layout. 

[Dropdowns documentation]: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/web-components.html#dropdowns

### After:
<img width="736" height="171" alt="image" src="https://github.com/user-attachments/assets/5b2e9fa7-8cec-4fe8-8a15-7c2c271b8fe9" />

### Before:
<img width="736" height="742" alt="image" src="https://github.com/user-attachments/assets/973d829b-1b78-41b4-be1c-088bfe3d740f" />

The Reasoning: When writing a program, the information contained in the "Array API Standard Support" section is typically consulted zero or one time, since the supported backends are normally selected once. Whereas the example section might be consulted multiple times due to usually containing more relevant details on using a function. Hence, the "Array API Standard Support" section can be hidden to obtain a more compact docstr.


[docs only]


#### AI Generation Disclosure
No AI was used for this PR.