### PR TITLE
ENH: _lib/cluster: device-propagation machinery for the array API

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -543,30 +543,6 @@ def xp_result_type(*args, force_floating=False, xp):
                 float_args.append(arg)
         return xp.result_type(*float_args, xpx.default_dtype(xp))
 
-def _has_own_device(arg):
-    """Whether `arg` is an array that carries its own device.
-
-    NumPy arrays and scalars report ``device='cpu'`` but are *host data*:
-    converting them to another namespace places them on that namespace's
-    *default* device, so for device propagation they must be treated like
-    python scalars and created on the inferred common device (see gh-22680).
-
-    This never forwards a device across libraries: arguments reaching the
-    device-anchoring call sites have been validated by `array_namespace` at
-    the function boundary, which raises for arrays from multiple libraries.
-    The only foreign arrays that legitimately appear alongside another
-    library's arrays are NumPy arrays and scalars (e.g. numeric parameters
-    computed with NumPy), and those are excluded here. A device returned
-    for an argument with ``_has_own_device(arg) == True`` therefore always
-    belongs to the namespace whose creation functions consume it.
-
-    Backends whose arrays lack the ``.device`` attribute (e.g. Dask; see
-    the workarounds in ``array_api_compat.device``) are treated like host
-    data. They are effectively single-device, so creating on the backend
-    default -- what a `None` anchor means -- is correct for them.
-    """
-    return hasattr(arg, "device") and not isinstance(arg, (np.ndarray, np.generic))
-
 
 def xp_promote(*args, broadcast=False, force_floating=False, xp):
     """
@@ -594,7 +570,6 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     if not args:
         return args
 
-    # Infer the common device from the (first of the) array arguments
     _, devices = _xp_result_devices(*args)
 
     # prevent double conversion of iterable to array
@@ -677,16 +652,16 @@ def xp_compat_namespace(xp: ModuleType | None) -> ModuleType:
 
 def xp_result_device(*args):
     """Return the device for the result of a function with inputs `args`,
-    for the purpose of input-output device propagation.
 
-    Arguments that do not carry a device -- python scalars, NumPy arrays
-    and scalars (host data), and arrays of backends without a ``.device``
-    attribute; see `_has_own_device` -- do not determine the result device
-    and are skipped: the device of the *first* device-carrying argument is
-    returned (combining arrays across devices raises inside the backend
-    anyway). Return `None` if no argument carries a device; creation
-    functions then use the backend's default device, which is the correct
-    result device for NumPy and for purely host-data inputs.
+    The purpose of this function is to be used for input-output device propagation.
+
+    Arguments that do not carry a device - python scalars, NumPy arrays and
+    scalars (host data), and arrays of backends without a ``.device`` attribute
+    - do not determine the result device and are skipped: the device of the
+    first device-carrying argument is returned (combining arrays across devices
+    raises inside the backend anyway). Return ``None`` if no argument carries
+    a device; creation functions then use the backend's default device, which
+    is the correct result device for NumPy and for purely host-data inputs.
     """
     return _xp_result_devices(*args)[0]
 
@@ -694,10 +669,35 @@ def xp_result_device(*args):
 def _xp_result_devices(*args):
     """Like `xp_result_device`, but return ``(device, devices)``.
 
-    ``devices[i]`` is the device to create argument `i` on: `None` for
-    arguments that carry their own device (which creation functions
-    preserve), the common `device` for python scalars and host data.
+    ``devices[i]`` is the device on which to create argument `i`: `None` for
+    arguments that carry their own device (which creation functions preserve),
+    the common `device` for Python scalars and host data.
     """
+    def _has_own_device(arg):
+        """Whether `arg` is an array that carries its own device.
+
+        NumPy arrays and scalars report ``device='cpu'`` but are *host data*:
+        converting them to another namespace places them on that namespace's
+        *default* device, so for device propagation they must be treated like
+        python scalars and created on the inferred common device (see gh-22680).
+
+        This never forwards a device across libraries: arguments reaching the
+        device-anchoring call sites have been validated by `array_namespace` at
+        the function boundary, which raises for arrays from multiple libraries.
+        The only foreign arrays that legitimately appear alongside another
+        library's arrays are NumPy arrays and scalars (e.g. numeric parameters
+        computed with NumPy), and those are excluded here. A device returned
+        for an argument with ``_has_own_device(arg) == True`` therefore always
+        belongs to the namespace whose creation functions consume it.
+
+        Backends whose arrays lack the ``.device`` attribute (e.g. Dask; see
+        the workarounds in ``array_api_compat.device``) are treated like host
+        data. They are effectively single-device, so creating on the backend
+        default -- what a `None` anchor means -- is correct for them.
+        """
+        return hasattr(arg, "device") and not isinstance(arg, (np.ndarray, np.generic))
+
+
     device = next((xp_device(arg) for arg in args if _has_own_device(arg)), None)
     devices = [None if _has_own_device(arg) else device for arg in args]
     return device, devices

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -594,10 +594,8 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     if not args:
         return args
 
-    # Infer the common device from the array arguments; `devices[i]` is the
-    # device to create argument `i` on (None to keep an array's own device).
-    device = xp_result_device(*args)
-    devices = [None if _has_own_device(arg) else device for arg in args]
+    # Infer the common device from the (first of the) array arguments
+    _, devices = _xp_result_devices(*args)
 
     # prevent double conversion of iterable to array
     # avoid `np.iterable` for torch arrays due to pytorch/pytorch#143334
@@ -684,13 +682,25 @@ def xp_result_device(*args):
     Arguments that do not carry a device -- python scalars, NumPy arrays
     and scalars (host data), and arrays of backends without a ``.device``
     attribute; see `_has_own_device` -- do not determine the result device
-    and are skipped. If the remaining arguments live on multiple devices,
-    return an arbitrary one (combining arrays across devices raises inside
-    the backend anyway). Return `None` if no argument carries a device;
-    creation functions then use the backend's default device, which is the
-    correct result device for NumPy and for purely host-data inputs.
+    and are skipped: the device of the *first* device-carrying argument is
+    returned (combining arrays across devices raises inside the backend
+    anyway). Return `None` if no argument carries a device; creation
+    functions then use the backend's default device, which is the correct
+    result device for NumPy and for purely host-data inputs.
     """
-    return next((xp_device(arg) for arg in args if _has_own_device(arg)), None)
+    return _xp_result_devices(*args)[0]
+
+
+def _xp_result_devices(*args):
+    """Like `xp_result_device`, but return ``(device, devices)``.
+
+    ``devices[i]`` is the device to create argument `i` on: `None` for
+    arguments that carry their own device (which creation functions
+    preserve), the common `device` for python scalars and host data.
+    """
+    device = next((xp_device(arg) for arg in args if _has_own_device(arg)), None)
+    devices = [None if _has_own_device(arg) else device for arg in args]
+    return device, devices
 
 
 # np.r_ replacement
@@ -698,16 +708,14 @@ def concat_1d(xp: ModuleType | None, *arrays: Iterable[ArrayLike]) -> Array:
     """A replacement for `np.r_` as `xp.concat` does not accept python scalars
        or 0-D arrays.
 
-    Python scalars and host data are created on the device of the array
-    arguments, not on the backend's default device (see gh-22680).
+    Python scalars and host data are created on the device of the first
+    array argument, not on the backend's default device; array arguments
+    keep their own device (see gh-22680).
     """
+    _, devices = _xp_result_devices(*arrays)
     arys = [
-        xpx.atleast_nd(
-            # each array keeps its own device; python scalars and host data
-            # are created on the device of the (first) array argument
-            xp.asarray(a, device=xp_result_device(a, *arrays)),  # type:ignore[union-attr]
-            ndim=1, xp=xp)
-        for a in arrays
+        xpx.atleast_nd(xp.asarray(a, device=d), ndim=1, xp=xp)  # type:ignore[union-attr]
+        for a, d in zip(arrays, devices)
     ]
     return xp.concat(arys)  # type:ignore[union-attr]
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -56,9 +56,10 @@ __all__ = [
     'np_compat', 'get_native_namespace_name',
     'SCIPY_ARRAY_API', 'SCIPY_DEVICE', 'scipy_namespace_for',
     'xp_assert_close', 'xp_assert_equal', 'xp_assert_less',
-    'xp_copy', 'xp_device', 'xp_ravel', 'xp_size',
+    'xp_compat_namespace', 'xp_copy', 'xp_device',
+    'xp_ravel', 'xp_size',
     'xp_unsupported_param_msg', 'xp_vector_norm', 'xp_capabilities',
-    'xp_result_type', 'xp_promote',
+    'xp_result_type', 'xp_result_device', 'xp_promote',
     'make_xp_test_case', 'make_xp_pytest_marks', 'make_xp_pytest_param',
 ]
 
@@ -82,6 +83,7 @@ def _asarray(
         xp: ModuleType | None = None,
         check_finite: bool = False,
         subok: bool = False,
+        device: Any = None,
     ) -> Array:
     """SciPy-specific replacement for `np.asarray` with `order`, `check_finite`, and
     `subok`.
@@ -96,6 +98,9 @@ def _asarray(
 
     `subok` is included to allow this function to preserve the behaviour of
     `np.asanyarray` for NumPy based inputs.
+
+    `device` places the result on the given device. It is ignored for NumPy
+    based inputs, where the only device is the (default) CPU.
     """
     if xp is None:
         xp = array_namespace(array)
@@ -109,10 +114,12 @@ def _asarray(
             array = np.asarray(array, order=order, dtype=dtype)
     else:
         try:
-            array = xp.asarray(array, dtype=dtype, copy=copy)
+            array = xp.asarray(array, dtype=dtype, copy=copy, device=device)
         except TypeError:
-            coerced_xp = array_namespace(xp.asarray(3))
-            array = coerced_xp.asarray(array, dtype=dtype, copy=copy)
+            # `xp` lacks features SciPy relies on (e.g. the `device` keyword)
+            # so retry with the compat namespace
+            coerced_xp = xp_compat_namespace(xp)
+            array = coerced_xp.asarray(array, dtype=dtype, copy=copy, device=device)
 
     if check_finite:
         _check_finite(array, xp)
@@ -536,6 +543,30 @@ def xp_result_type(*args, force_floating=False, xp):
                 float_args.append(arg)
         return xp.result_type(*float_args, xpx.default_dtype(xp))
 
+def _has_own_device(arg):
+    """Whether `arg` is an array that carries its own device.
+
+    NumPy arrays and scalars report ``device='cpu'`` but are *host data*:
+    converting them to another namespace places them on that namespace's
+    *default* device, so for device propagation they must be treated like
+    python scalars and created on the inferred common device (see gh-22680).
+
+    This never forwards a device across libraries: arguments reaching the
+    device-anchoring call sites have been validated by `array_namespace` at
+    the function boundary, which raises for arrays from multiple libraries.
+    The only foreign arrays that legitimately appear alongside another
+    library's arrays are NumPy arrays and scalars (e.g. numeric parameters
+    computed with NumPy), and those are excluded here. A device returned
+    for an argument with ``_has_own_device(arg) == True`` therefore always
+    belongs to the namespace whose creation functions consume it.
+
+    Backends whose arrays lack the ``.device`` attribute (e.g. Dask; see
+    the workarounds in ``array_api_compat.device``) are treated like host
+    data. They are effectively single-device, so creating on the backend
+    default -- what a `None` anchor means -- is correct for them.
+    """
+    return hasattr(arg, "device") and not isinstance(arg, (np.ndarray, np.generic))
+
 
 def xp_promote(*args, broadcast=False, force_floating=False, xp):
     """
@@ -551,6 +582,11 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     to the namespace's arrays before result type calculation. Consequently, the
     result dtype may be different when an argument is `1.` vs `[1.]`.
 
+    Scalars and array-like iterables are converted onto the device of the first
+    array argument (if any), so that e.g. a scalar default promoted alongside a
+    non-default-device array does not land on the default device (see gh-22680).
+    Array arguments always keep their own device.
+
     See Also
     --------
     xp_result_type
@@ -558,16 +594,23 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     if not args:
         return args
 
+    # Infer the common device from the array arguments; `devices[i]` is the
+    # device to create argument `i` on (None to keep an array's own device).
+    device = xp_result_device(*args)
+    devices = [None if _has_own_device(arg) else device for arg in args]
+
     # prevent double conversion of iterable to array
     # avoid `np.iterable` for torch arrays due to pytorch/pytorch#143334
     # don't use `array_api_compat.is_array_api_obj` as it returns True for NumPy scalars
-    args = [(_asarray(arg, subok=True, xp=xp) if is_torch_array(arg) or np.iterable(arg)
-            else arg) for arg in args]
+    args = [(_asarray(arg, subok=True, xp=xp, device=d)
+             if is_torch_array(arg) or np.iterable(arg)
+             else arg) for arg, d in zip(args, devices)]
 
     dtype = xp_result_type(*args, force_floating=force_floating, xp=xp)
 
-    args = [(_asarray(arg, dtype=dtype, subok=True, xp=xp) if arg is not None else arg)
-            for arg in args]
+    args = [(_asarray(arg, dtype=dtype, subok=True, xp=xp, device=d)
+             if arg is not None else arg)
+            for arg, d in zip(args, devices)]
 
     if not broadcast:
         return args[0] if len(args)==1 else tuple(args)
@@ -619,26 +662,53 @@ def xp_float_to_complex(arr: Array, xp: ModuleType | None = None) -> Array:
     return arr
 
 
-def xp_result_device(*args):
-    """Return the device of an array in `args`, for the purpose of
-    input-output device propagation.
-    If there are multiple devices, return an arbitrary one.
-    If there are no arrays, return None (this typically happens only on NumPy).
+def xp_compat_namespace(xp: ModuleType | None) -> ModuleType:
+    """Return the array-api-compat(ible) namespace corresponding to `xp`.
+
+    A user-provided `xp` may be a "raw" namespace (e.g. bare `numpy` or `torch`) that
+    lacks features SciPy relies on (such as the `device` keyword of creation functions
+    on CuPy <=14.1, xref cupy#9848); resolve it through `array_namespace` with a
+    throwaway array. `None` maps to the compat NumPy namespace.
     """
-    for arg in args:
-        # Do not do a duck-type test for the .device attribute, as many backends today
-        # don't have it yet. See workarouunds in array_api_compat.device().
-        if is_array_api_obj(arg):
-            return xp_device(arg)
-    return None
+    if xp is None:
+        return np_compat
+    # the probe array is a throwaway used only to resolve the namespace;
+    # its device is irrelevant
+    return array_namespace(xp.empty(0))  # skip device check
+
+
+def xp_result_device(*args):
+    """Return the device for the result of a function with inputs `args`,
+    for the purpose of input-output device propagation.
+
+    Arguments that do not carry a device -- python scalars, NumPy arrays
+    and scalars (host data), and arrays of backends without a ``.device``
+    attribute; see `_has_own_device` -- do not determine the result device
+    and are skipped. If the remaining arguments live on multiple devices,
+    return an arbitrary one (combining arrays across devices raises inside
+    the backend anyway). Return `None` if no argument carries a device;
+    creation functions then use the backend's default device, which is the
+    correct result device for NumPy and for purely host-data inputs.
+    """
+    return next((xp_device(arg) for arg in args if _has_own_device(arg)), None)
 
 
 # np.r_ replacement
 def concat_1d(xp: ModuleType | None, *arrays: Iterable[ArrayLike]) -> Array:
     """A replacement for `np.r_` as `xp.concat` does not accept python scalars
        or 0-D arrays.
+
+    Python scalars and host data are created on the device of the array
+    arguments, not on the backend's default device (see gh-22680).
     """
-    arys = [xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp) for a in arrays]  # type:ignore[union-attr]
+    arys = [
+        xpx.atleast_nd(
+            # each array keeps its own device; python scalars and host data
+            # are created on the device of the (first) array argument
+            xp.asarray(a, device=xp_result_device(a, *arrays)),  # type:ignore[union-attr]
+            ndim=1, xp=xp)
+        for a in arrays
+    ]
     return xp.concat(arys)  # type:ignore[union-attr]
 
 

--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -15,7 +15,7 @@
 import math
 import numpy as np
 from ._util import _RichResult, _call_callback_maybe_halt
-from ._array_api import array_namespace, xp_size, xp_result_type
+from ._array_api import array_namespace, xp_size, xp_result_type, xp_device
 import scipy._external.array_api_extra as xpx
 
 _ESIGNERR = -1
@@ -145,7 +145,9 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
     ----------
     work : _RichResult
         All variables that need to be retained between iterations. Must
-        contain attributes `nit`, `nfev`, and `success`. All arrays are
+        contain attributes `nit`, `nfev`, `success`, and `status` (an array
+        on the device of the input arrays, which anchors the device of the
+        result and bookkeeping arrays). All arrays are
         subject to being "compressed" if `preserve_shape is False`; nest
         arrays that should not be compressed inside another object (e.g.
         `dict` or `_RichResult`).
@@ -192,7 +194,6 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
     preserve_shape : bool, default: False
         Whether to compress the attributes of `work` (to avoid unnecessary
         computation on elements that have already converged).
-
     Returns
     -------
     res : _RichResult
@@ -215,13 +216,16 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
     cb_terminate = False
 
     # Initialize the result object and active element index array
+    device = xp_device(work.status)
     n_elements = math.prod(shape)
-    active = xp.arange(n_elements)  # in-progress element indices
-    res_dict = {i: xp.zeros(n_elements, dtype=dtype) for i, j in res_work_pairs}
-    res_dict['success'] = xp.zeros(n_elements, dtype=xp.bool)
-    res_dict['status'] = xp.full(n_elements, xp.asarray(_EINPROGRESS), dtype=xp.int32)
-    res_dict['nit'] = xp.zeros(n_elements, dtype=xp.int32)
-    res_dict['nfev'] = xp.zeros(n_elements, dtype=xp.int32)
+    active = xp.arange(n_elements, device=device)  # in-progress element indices
+    res_dict = {i: xp.zeros(n_elements, dtype=dtype, device=device)
+                for i, j in res_work_pairs}
+    res_dict['success'] = xp.zeros(n_elements, dtype=xp.bool, device=device)
+    res_dict['status'] = xp.full(n_elements, _EINPROGRESS, dtype=xp.int32,
+                                 device=device)
+    res_dict['nit'] = xp.zeros(n_elements, dtype=xp.int32, device=device)
+    res_dict['nfev'] = xp.zeros(n_elements, dtype=xp.int32, device=device)
     res = _RichResult(res_dict)
     work.args = args
 
@@ -252,7 +256,7 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
         if preserve_shape:
             x = xp.reshape(x, (shape + (-1,)))
         f = func(x, *work.args)
-        f = xp.asarray(f, dtype=dtype)
+        f = xp.asarray(f, dtype=dtype, device=device)
         if preserve_shape:
             x = xp.reshape(x, x_shape)
             f = xp.reshape(f, x_shape)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -393,6 +393,14 @@ def test_xp_promote_device(xp, devices):
         scalar, x2 = xp_promote(2, x, force_floating=True, xp=xp)
         assert xp_device(scalar) == xp_device(x)
 
+        # with arrays on several devices, the *first* array argument is the
+        # anchor for scalars; each array keeps its own device
+        y = xp.asarray([4., 5., 6.])  # on the default device
+        scalar, x2, y2 = xp_promote(2, x, y, force_floating=True, xp=xp)
+        assert xp_device(scalar) == xp_device(x)
+        assert xp_device(x2) == xp_device(x)
+        assert xp_device(y2) == xp_device(y)
+
         # None passes through; remaining args still promoted on device
         x2, none, scalar = xp_promote(x, None, 0.5, xp=xp)
         assert none is None
@@ -430,6 +438,13 @@ def test_xp_result_device(xp, devices):
         assert xp_result_device(1.5, None, x) == expected
         assert xp_result_device(np.float64(0.5), x) == expected
         assert xp_result_device(np.asarray([1.0]), x) == expected
+
+        # the *first* device-carrying argument is the anchor
+        y = xp.asarray([3., 4.])  # on the default device
+        expected_y = None if host_like else xp_device(y)
+        assert xp_result_device(x, y) == expected
+        assert xp_result_device(y, x) == expected_y
+        assert xp_result_device(1.5, y, x) == expected_y
     assert xp_result_device() is None
     assert xp_result_device(1.5, None) is None
     assert xp_result_device(np.asarray([1.0])) is None

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -273,9 +273,6 @@ class TestArrayAPI:
         xp_assert_equal_no_0d(0., xp.asarray(0.))
         xp_assert_equal_no_0d(42, xp.asarray(42))
 
-    def test_default_dtype(self, xp):
-        assert xpx.default_dtype(xp) == xp.asarray(1.).dtype
-
 
 scalars = [1, 1., 1. + 1j]
 lists = [[1], [1.], [1. + 1j]]

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -5,7 +5,8 @@ import pytest
 
 from scipy._lib._array_api import (
     SCIPY_ARRAY_API, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
-    np_compat, xp_result_type, is_torch, _xp_copy_to_numpy
+    np_compat, xp_device, xp_promote, xp_result_device,
+    xp_result_type, is_torch, _xp_copy_to_numpy
 )
 from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
@@ -161,7 +162,7 @@ class TestArrayAPI:
             # Ensure y is a copy when xp is numpy.
             assert id(x) != id(y)
 
-    
+
     @pytest.mark.parametrize('dtype', ['int32', 'int64', 'float32', 'float64'])
     @pytest.mark.parametrize('shape', [(), (3,)])
     def test_strict_checks(self, xp, dtype, shape):
@@ -272,6 +273,9 @@ class TestArrayAPI:
         xp_assert_equal_no_0d(0., xp.asarray(0.))
         xp_assert_equal_no_0d(42, xp.asarray(42))
 
+    def test_default_dtype(self, xp):
+        assert xpx.default_dtype(xp) == xp.asarray(1.).dtype
+
 
 scalars = [1, 1., 1. + 1j]
 lists = [[1], [1.], [1. + 1j]]
@@ -366,3 +370,66 @@ def test_xp_result_type_force_floating(x, y, xp):
 
     dtype_res = xp_result_type(x, y, force_floating=True, xp=xp)
     assert dtype_res == dtype_ref
+
+
+@pytest.mark.uses_xp_capabilities(False, reason="not applicable")
+def test_xp_promote_device(xp, devices):
+    # Scalars and array-like iterables promoted alongside an array are
+    # created on that array's device; array arguments keep their own device.
+    # See gh-22680.
+    for device in devices:
+        x = xp.asarray([1., 2., 3.], device=device)
+
+        # scalar rides along on the array's device
+        x2, scalar = xp_promote(x, 1.5, xp=xp)
+        assert xp_device(x2) == xp_device(x)
+        assert xp_device(scalar) == xp_device(x)
+
+        # so does a list, and broadcasting preserves the device
+        x2, lst = xp_promote(x, [1., 2., 3.], broadcast=True, xp=xp)
+        assert xp_device(lst) == xp_device(x)
+
+        # order does not matter: device comes from the (first) array argument
+        scalar, x2 = xp_promote(2, x, force_floating=True, xp=xp)
+        assert xp_device(scalar) == xp_device(x)
+
+        # None passes through; remaining args still promoted on device
+        x2, none, scalar = xp_promote(x, None, 0.5, xp=xp)
+        assert none is None
+        assert xp_device(scalar) == xp_device(x)
+
+        # an array argument keeps its own device
+        x2 = xp_promote(x, force_floating=True, xp=xp)
+        assert xp_device(x2) == xp_device(x)
+
+        # NumPy scalars and arrays report device 'cpu' but are *host data*:
+        # they must ride along on the array argument's device like python
+        # scalars do (they land on the default device otherwise). This mix
+        # is user-reachable: `array_namespace` rejects NumPy *sample* arrays
+        # mixed with another backend's arrays, but NumPy scalars arrive as
+        # numeric keyword parameters that are not validated as arrays, e.g.
+        # `differentiate(f, x_gpu, initial_step=1/np.sqrt(2))`.
+        x2, np_scalar = xp_promote(x, np.float64(0.5), xp=xp)
+        assert xp_device(np_scalar) == xp_device(x)
+        x2, np_arr = xp_promote(x, np.asarray([1.0, 2.0, 3.0]), xp=xp)
+        assert xp_device(np_arr) == xp_device(x)
+
+
+@pytest.mark.uses_xp_capabilities(False, reason="not applicable")
+def test_xp_result_device(xp, devices):
+    # `xp_result_device` anchors the result device on the first argument
+    # that carries a device, skipping python scalars and NumPy host data.
+    # No device-carrying argument -> None (create on the backend default).
+    # NumPy arrays, and arrays of backends without a `.device` attribute
+    # (e.g. Dask), are treated like host data: always None.
+    for device in devices:
+        x = xp.asarray([1., 2.], device=device)
+        host_like = is_numpy(xp) or not hasattr(x, "device")
+        expected = None if host_like else xp_device(x)
+        assert xp_result_device(x) == expected
+        assert xp_result_device(1.5, None, x) == expected
+        assert xp_result_device(np.float64(0.5), x) == expected
+        assert xp_result_device(np.asarray([1.0]), x) == expected
+    assert xp_result_device() is None
+    assert xp_result_device(1.5, None) is None
+    assert xp_result_device(np.asarray([1.0])) is None

--- a/scipy/_lib/tests/test_xp_capabilities.py
+++ b/scipy/_lib/tests/test_xp_capabilities.py
@@ -2,7 +2,8 @@ import pytest
 
 from scipy._lib._array_api import np_compat as np
 from scipy._lib._array_api import (
-    array_namespace, make_xp_pytest_param, xp_assert_close, xp_capabilities
+    array_namespace, make_xp_pytest_param, xp_assert_close, xp_capabilities,
+    xp_device, _has_own_device
 )
 
 local_capabilities_table = {}  # type:ignore[var-annotated]
@@ -24,11 +25,13 @@ class A:
     def __init__(self, x):
         xp = array_namespace(x)
         self._xp = xp
+        # the NumPy round-trip must return results on the input's device
+        self._device = xp_device(x) if _has_own_device(x) else None
         self.x = np.asarray(x)
 
     def f(self, y):
         y = np.asarray(y)
-        return self._xp.asarray(np.matmul(self.x, y))
+        return self._xp.asarray(np.matmul(self.x, y), device=self._device)
 
     def g(self, y, z):
         return self.f(y) + self.f(z)

--- a/scipy/_lib/tests/test_xp_capabilities.py
+++ b/scipy/_lib/tests/test_xp_capabilities.py
@@ -3,7 +3,7 @@ import pytest
 from scipy._lib._array_api import np_compat as np
 from scipy._lib._array_api import (
     array_namespace, make_xp_pytest_param, xp_assert_close, xp_capabilities,
-    xp_device, _has_own_device
+    xp_result_device
 )
 
 local_capabilities_table = {}  # type:ignore[var-annotated]
@@ -26,7 +26,7 @@ class A:
         xp = array_namespace(x)
         self._xp = xp
         # the NumPy round-trip must return results on the input's device
-        self._device = xp_device(x) if _has_own_device(x) else None
+        self._device = xp_result_device(x)
         self.x = np.asarray(x)
 
     def f(self, y):

--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -43,7 +43,8 @@ import numpy as np
 from . import _hierarchy, _optimal_leaf_ordering  # type:ignore[attr-defined]
 import scipy.spatial.distance as distance
 from scipy._lib._array_api import (_asarray, array_namespace, is_dask,
-                                   is_lazy_array, xp_capabilities, xp_copy)
+                                   is_lazy_array, xp_capabilities, xp_copy,
+                                   xp_device, xp_result_device)
 from scipy._lib._disjoint_set import DisjointSet
 import scipy._external.array_api_extra as xpx
 
@@ -1265,23 +1266,24 @@ def cut_tree(Z, n_clusters=None, height=None):
         raise ValueError("At least one of either height or n_clusters "
                          "must be None")
     elif height is None and n_clusters is None:  # return the full cut tree
-        cols_idx = xp.arange(nobs)
+        cols_idx = xp.arange(nobs, device=xp_device(Z))
     elif height is not None:
         height = xp.asarray(height)
         heights = xp.asarray([x.dist for x in nodes])
         cols_idx = xp.searchsorted(heights, height)
     else:
         n_clusters = xp.asarray(n_clusters)
-        cols_idx = nobs - xp.searchsorted(xp.arange(nobs), n_clusters)
+        cols_idx = nobs - xp.searchsorted(
+            xp.arange(nobs, device=xp_device(Z)), n_clusters)
 
     try:
         n_cols = len(cols_idx)
     except TypeError:  # scalar
         n_cols = 1
-        cols_idx = xp.asarray([cols_idx])
+        cols_idx = xp.asarray([cols_idx], device=xp_device(Z))
 
-    groups = xp.zeros((n_cols, nobs), dtype=xp.int64)
-    last_group = xp.arange(nobs)
+    groups = xp.zeros((n_cols, nobs), dtype=xp.int64, device=xp_device(Z))
+    last_group = xp.arange(nobs, device=xp_device(Z))
     if 0 in cols_idx:
         groups[0] = last_group
 
@@ -1790,7 +1792,7 @@ def from_mlab_linkage(Z):
     if not lazy and xp.min(Z[:, :2]) != 1.0 and xp.max(Z[:, :2]) != 2 * n:
         raise ValueError('The format of the indices is not 1..N')
 
-    res = xp.empty((Z.shape[0], Z.shape[1] + 1), dtype=Z.dtype)
+    res = xp.empty((Z.shape[0], Z.shape[1] + 1), dtype=Z.dtype, device=xp_device(Z))
     res = xpx.at(res)[:, :2].set(Z[:, :2] - 1.0)
     res = xpx.at(res)[:, 2:-1].set(Z[:, 2:])
 
@@ -2259,7 +2261,8 @@ def _is_valid_linkage(Z, warning=False, throw=False, name=None,
          f'Linkage {name_str}contains negative counts.'),
         (xp.any(Z[:, 3] > n + 1),
          f'Linkage {name_str}contains excessive observations in a cluster'),
-        (xp.any(xp.max(Z[:, :2], axis=1) >= xp.arange(n + 1, 2 * n + 1, dtype=Z.dtype)),
+        (xp.any(xp.max(Z[:, :2], axis=1)
+                >= xp.arange(n + 1, 2 * n + 1, dtype=Z.dtype, device=xp_device(Z))),
          f'Linkage {name_str}uses non-singleton cluster before it is formed.'),
         (xpx.nunique(Z[:, :2]) < n * 2,
          f'Linkage {name_str}uses the same cluster more than once.'),
@@ -2568,6 +2571,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
 
     """
     xp = array_namespace(Z)
+    device = xp_result_device(Z)
     Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', materialize=True, xp=xp)
 
@@ -2599,7 +2603,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         _hierarchy.cluster_maxclust_monocrit(Z, monocrit, T, int(n), int(t))
     else:
         raise ValueError(f'Invalid cluster formation criterion: {str(criterion)}')
-    return xp.asarray(T)
+    return xp.asarray(T, device=device)
 
 
 @xp_capabilities(cpu_only=True, reason="Cython code",
@@ -3770,8 +3774,9 @@ def is_isomorphic(T1, T2):
 
     """
     xp = array_namespace(T1, T2)
-    T1 = _asarray(T1, xp=xp)
-    T2 = _asarray(T2, xp=xp)
+    device = xp_result_device(T1, T2)
+    T1 = _asarray(T1, xp=xp, device=device)
+    T2 = _asarray(T2, xp=xp, device=device)
 
     if T1.ndim != 1:
         raise ValueError('T1 must be one-dimensional.')

--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -2,7 +2,9 @@ import warnings
 import numpy as np
 from collections import deque
 from scipy._lib._array_api import (_asarray, array_namespace, is_lazy_array,
-                                   xp_capabilities, xp_copy, xp_size)
+                                   xp_capabilities,
+                                   xp_device, xp_size,
+                                   xp_result_device)
 from scipy._lib._util import (check_random_state, rng_integers,
                               _transition_to_rng)
 from scipy._lib.deprecation import _deprecated
@@ -153,7 +155,9 @@ def vq(obs, code_book, check_finite=True):
         c_obs = np.asarray(c_obs)
         c_code_book = np.asarray(c_code_book)
         result = _vq.vq(c_obs, c_code_book)
-        return xp.asarray(result[0]), xp.asarray(result[1])
+        device = xp_result_device(obs)
+        return (xp.asarray(result[0], device=device),
+                xp.asarray(result[1], device=device))
     return _py_vq(obs, code_book, check_finite=False)
 
 
@@ -206,7 +210,8 @@ def _py_vq(obs, code_book, check_finite=True):
         code_book = code_book[:, xp.newaxis]
 
     # Once `cdist` has array API support, this `xp.asarray` call can be removed
-    dist = xp.asarray(cdist(obs, code_book))
+    device = xp_result_device(obs)
+    dist = xp.asarray(cdist(obs, code_book), device=device)
     code = xp.argmin(dist, axis=1)
     min_dist = xp.min(dist, axis=1)
     return code, min_dist
@@ -266,7 +271,8 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
         code_book, has_members = _vq.update_cluster_means(np_obs, obs_code,
                                                           code_book.shape[0])
         code_book = code_book[has_members]
-        code_book = xp.asarray(code_book)
+        code_book = xp.asarray(code_book,
+                               device=xp_result_device(obs))
         diff = xp.abs(prev_avg_dists[0] - prev_avg_dists[1])
 
     _, final_distortions = vq(obs, code_book, check_finite=False)
@@ -411,7 +417,8 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
     else:
         xp = array_namespace(obs, k_or_guess)
     obs = _asarray(obs, xp=xp, check_finite=check_finite)
-    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite)
+    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite,
+                     device=xp_result_device(obs))
     if iter < 1:
         raise ValueError(f"iter must be at least 1, got {iter}")
 
@@ -464,7 +471,8 @@ def _kpoints(data, k, rng, xp):
     """
     idx = rng.choice(data.shape[0], size=int(k), replace=False)
     # convert to array with default integer dtype (avoids numpy#25607)
-    idx = xp.asarray(idx, dtype=xp.asarray([1]).dtype)
+    int_dtype = xpx.default_dtype(xp, "integral")
+    idx = xp.asarray(idx, dtype=int_dtype, device=xp_device(data))
     return xp.take(data, idx, axis=0)
 
 
@@ -497,14 +505,15 @@ def _krandinit(data, k, rng, xp):
     if data.ndim == 1:
         _cov = xpx.cov(data, xp=xp)
         x = rng.standard_normal(size=k)
-        x = xp.asarray(x)
+        x = xp.asarray(x, device=xp_device(data))
         x *= xp.sqrt(_cov)
     elif data.shape[1] > data.shape[0]:
         # initialize when the covariance matrix is rank deficient
         _, s, vh = xp.linalg.svd(data - mu, full_matrices=False)
         x = rng.standard_normal(size=(k, xp_size(s)))
-        x = xp.asarray(x)
-        sVh = s[:, None] * vh / xp.sqrt(data.shape[0] - xp.asarray(1.))
+        x = xp.asarray(x, device=xp_device(data))
+        sVh = s[:, None] * vh / xp.sqrt(
+            data.shape[0] - xp.asarray(1., device=xp_device(data)))
         x = x @ sVh
     else:
         _cov = xpx.atleast_nd(xpx.cov(data.T, xp=xp), ndim=2, xp=xp)
@@ -512,7 +521,7 @@ def _krandinit(data, k, rng, xp):
         # k rows, d cols (one row = one obs)
         # Generate k sample of a random variable ~ Gaussian(mu, cov)
         x = rng.standard_normal(size=(k, xp_size(mu)))
-        x = xp.asarray(x)
+        x = xp.asarray(x, device=xp_device(data))
         x = x @ xp.linalg.cholesky(_cov).T
 
     x += mu
@@ -551,7 +560,7 @@ def _kpp(data, k, rng, xp):
 
     dims = data.shape[1]
 
-    init = xp.empty((int(k), dims))
+    init = xp.empty((int(k), dims), device=xp_device(data))
 
     for i in range(k):
         if i == 0:
@@ -725,7 +734,8 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
     else:
         xp = array_namespace(data, k)
     data = _asarray(data, xp=xp, check_finite=check_finite)
-    code_book = xp_copy(k, xp=xp)
+    device = xp_result_device(data)
+    code_book = _asarray(k, copy=True, xp=xp, device=device)
     if data.ndim == 1:
         d = 1
     elif data.ndim == 2:
@@ -774,4 +784,4 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
             new_code_book[~has_members] = code_book[~has_members]
         code_book = new_code_book
 
-    return xp.asarray(code_book), xp.asarray(label)
+    return xp.asarray(code_book, device=device), xp.asarray(label, device=device)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -604,7 +604,19 @@ def devices(xp):
         devices = xp.__array_namespace_info__().devices()
         # open an issue about this - cannot branch based on `any`/`all`?
         return (device for device in devices if device.type != 'meta')
-    return tuple(xp.__array_namespace_info__().devices()) + (None,)
+    info = xp.__array_namespace_info__()
+    # Exclude devices that do not support the default dtype, such as the
+    # synthetic 'no_float64' device of array-api-strict >= 2.6: this fixture
+    # tests device *propagation*, and scipy functions routinely create
+    # default-dtype intermediates. Reduced-capability devices would need
+    # per-test dtype-support handling instead (see e.g. the `dtype_devices`
+    # fixture in `scipy/stats/tests/test_device_dtype.py`).
+    default_dtype = info.default_dtypes()["real floating"]
+    devices = tuple(
+        d for d in info.devices()
+        if default_dtype in info.dtypes(device=d).values()
+    )
+    return devices + (None,)
 
 
 if hypothesis_available:


### PR DESCRIPTION
Central infrastructure so that functions operating on arrays residing on a non-default device return results on that device, instead of silently creating intermediates and results on the backend's default device:

- `_asarray` gains a `device` keyword.
- `xp_promote` infers the common device from its first array argument and creates scalars and array-like iterables on it; array arguments always keep their own device.
- `xp_result_device` now skips host data (via the `_has_own_device` helper) and is the single anchoring helper for input->output device propagation: `device = xp_result_device(*args)`, then create with `device=device`.
- `concat_1d` anchors python scalars and host data on the device of its array arguments.
- `_elementwise_iterative_method._loop` derives the device of its result and bookkeeping arrays from `work.status`, which every caller creates from its input arrays -- callers cannot forget to propagate the device.
- The `devices` fixture excludes devices that do not support the default dtype (the synthetic 'no_float64' device of array-api-strict >= 2.6): it tests device *propagation*; reduced-capability devices need per-test dtype-support handling instead.
- A new helper function: `xp_compat_namespace` consolidate sthe throwaway probe-array patterns (namespace coercion) into a single, documented location.

`scipy.cluster` is converted as the first consumer, showing the patterns in action: `device=xp_device(<input>)` for internal creation, `xp_result_device` anchoring for NumPy round-trips (`vq`/`cdist` results return on the input's device), `xp_default_int_dtype`, and an input->output device-propagation test.

See issue gh-22680 for context on the problem.

This is the first part of a series of PRs to address the structural problem; the next follow-up PRs will do for other modules what is done for `cluster` here.


#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch `'meta'` device (see gh-25578) with heavy use of Claude Fable 5. I iterated on the core machinery a fair amount, and had to clean up coding style/comments, but most of the diff was generated with Claude (it's nicely AI-shaped and would have taken a ton of time to edit the code patterns across the whole code base by hand). I spent a lot of time minimizing the diff by hand and on the commit message - it should be in close-to-optimal shape for review.