### PR TITLE
TST: Run Pyodide test suite with increased verbosity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,7 @@ PKG_CONFIG_PATH = "{project}"
 dependency-versions = "packages: pyodide-build==0.36.0"
 before-build = "bash {project}/tools/ci/emscripten/cibw_before_build_pyodide.sh {project}"
 repair-wheel-command = "pyodide auditwheel repair --libdir {project}/.blis/lib --output-dir {dest_dir} {wheel}"
-test-command = "python -m pytest --pyargs scipy -m 'not slow'"
+test-command = "python -m pytest -vra --pyargs scipy -m 'not slow'"
 
 [tool.cibuildwheel.pyodide.config-settings]
 setup-args = ["-Dblas=blis", "-Dlapack=semicolon-lapack"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

As a follow-up PR to the work done in gh-25618.

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR runs `pytest` with `-vra` flags when running in cibuildwheel Pyodide builds. I usually tend to avoid this, as increasing the verbosity really makes GitHub Actions so sluggish to load and scroll through (ugh), but it's the only way to see individual tests as they run and find out the test names. I added `-ra` as well besides `-v` because the additional diagnostic information might be valuable, in terms of seeing whether that test at around 31% usually takes a long time, or there is some other form of deadlock that we haven't detected.

The next plan in the course of action after this PR would be to skip the test the next time it hangs on another PR in CI, and then understand more deeply why it fails and mitigate the problem without skipping the test.

cc: @rgommers

#### Additional information
<!--Any additional information you think is important.-->

See https://github.com/scipy/scipy/pull/25618#issuecomment-4953433702 and https://github.com/scipy/scipy/pull/25618#issuecomment-5037022459 for more. This 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used
