### PR TITLE
DOC: fix typo in "Sparse Matrix Legacy Interface"

### DIFF
--- a/doc/source/reference/sparse.spmatrix_api.rst
+++ b/doc/source/reference/sparse.spmatrix_api.rst
@@ -68,7 +68,7 @@ Building sparse matrices
 Identifying sparse matrices
 ---------------------------
 .. The functions `issparse` and `isspmatrix` are already referenced in a toctree in the
-   file `scipy/sparse/__init__.py` via `doc/source/reference/sparse.rst`. To supress a
+   file `scipy/sparse/__init__.py` via `doc/source/reference/sparse.rst`. To suppress a
    consistency check warning during build, those functions are placed in a table
    instead of an `autosummary` block.
 


### PR DESCRIPTION
#### Reference issue

No issue. Trivial change.

#### What does this implement/fix?

Fix typo `supress` should be `suppress`

#### Additional information

Detected with typos-cli: https://github.com/crate-ci/typos

#### AI Generation Disclosure

No AI tools used.