### PR TITLE
MAINT: interpolate: correct NdBSpline nu error message ("non-negative", not "positive")

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -169,7 +169,7 @@ class NdBSpline:
                     f"invalid number of derivative orders {nu = } for "
                     f"ndim = {len(self.t)}.")
             if any(nu < 0):
-                raise ValueError(f"derivatives must be positive, got {nu = }")
+                raise ValueError(f"derivatives must be non-negative, got {nu = }")
 
         # prepare xi : shape (..., m1, ..., md) -> (1, m1, ..., md)
         xi = np.asarray(xi, dtype=float)
@@ -318,7 +318,7 @@ class NdBSpline:
                 f"ndim = {len(self.t)}.")
 
         if any(nu_arr < 0):
-            raise ValueError(f"derivative orders must be positive, got {nu = }")
+            raise ValueError(f"derivative orders must be non-negative, got {nu = }")
 
         # extract t and c as numpy arrays
         t_new = [self._t[d, :self._len_t[d]] for d in range(self._t.shape[0])]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2959,7 +2959,8 @@ class TestNdBSpline:
         b = make_interp_spline(x, np.sin(x), k=3)
         nb = NdBSpline((b.t,), b.c, b.k)
         pt = np.array([[0.5]])
-        nb(pt, nu=(0,))  # nu == 0 is accepted (function value)
+        # ``nu == 0`` is accepted and must return the function value itself.
+        xp_assert_close(nb(pt, nu=(0,)), nb(pt))
         nb.derivative((0,))
         with assert_raises(ValueError, match="non-negative"):
             nb(pt, nu=(-1,))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2951,6 +2951,21 @@ class TestNdBSpline:
 
         _run_concurrent_barrier(10, worker_fn, spl)
 
+    def test_nu_negative_error_message_is_non_negative(self):
+        # ``nu == 0`` is a valid derivative order (it evaluates the function
+        # value), so the error raised for ``nu < 0`` must say "non-negative",
+        # not "positive" -- matching the ``__call__`` docstring for ``nu``.
+        x = np.linspace(0, 1, 7)
+        b = make_interp_spline(x, np.sin(x), k=3)
+        nb = NdBSpline((b.t,), b.c, b.k)
+        pt = np.array([[0.5]])
+        nb(pt, nu=(0,))  # nu == 0 is accepted (function value)
+        nb.derivative((0,))
+        with assert_raises(ValueError, match="non-negative"):
+            nb(pt, nu=(-1,))
+        with assert_raises(ValueError, match="non-negative"):
+            nb.derivative((-1,))
+
 
 class TestMakeND:
     def test_2D_separable_simple(self):


### PR DESCRIPTION
#### Reference issue

None — self-reported here (a small error-message inconsistency found while reading `NdBSpline`).

#### What does this implement/fix?

`NdBSpline.__call__` and `NdBSpline.derivative` reject a derivative order only when `nu < 0`, so `nu = 0` (i.e. the function value) is a valid, accepted input. But the `ValueError` raised for an invalid order says the value `must be positive`, which reads as excluding `0`. The `__call__` docstring already states the intended contract — *"nu : ... Each must be non-negative."* — so the docstring and the accepted behavior agree, and only the error message was inconsistent.

Both messages are reworded from `must be positive` to `must be non-negative`. This is a wording-only change; the accepted/rejected inputs are unchanged.

Reproducer on 1.18.0:

```python
import numpy as np
from scipy.interpolate import NdBSpline, make_interp_spline
b = make_interp_spline(np.linspace(0, 1, 7), np.sin(np.linspace(0, 1, 7)), k=3)
nb = NdBSpline((b.t,), b.c, b.k)
pt = np.array([[0.5]])
nb(pt, nu=(0,))       # accepted (function value)
nb(pt, nu=(-1,))      # ValueError: derivatives must be positive, got nu = array([-1])
```

#### Additional information

Added a regression test (`TestNdBSpline.test_nu_negative_error_message_is_non_negative`) that checks `nu = 0` is accepted and that `nu < 0` raises a `ValueError` matching `"non-negative"`. I verified it fails before the change (message is "positive") and passes after. No release note seems warranted since there is no behavior/API change, but happy to add one if you'd prefer.

#### AI Generation Disclosure

Yes, AI tooling was used. Tool: Claude Code (Opus 4.8). How it was used: to help locate the two inconsistent error-message sites in `_ndbspline.py`, cross-check them against the `nu` docstring, and draft the regression test. What is AI-generated: the two message wording changes and the regression test were drafted with AI assistance; I reviewed, ran, and verified them, and I understand and take responsibility for the change. This description is my own.
