### PR TITLE
ENH: spatial: Rotation: avoid allocation in `_compose_quat_single` (cython backend)

### DIFF
--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -320,13 +320,9 @@ cdef double[:, :] _compute_davenport_from_quat(
 cdef inline void _compose_quat_single( # calculate p * q into r
     const double[:] p, const double[:] q, double[:] r
 ) noexcept nogil:
-    cdef double cx = p[1]*q[2] - p[2]*q[1]
-    cdef double cy = p[2]*q[0] - p[0]*q[2]
-    cdef double cz = p[0]*q[1] - p[1]*q[0]
-
-    r[0] = p[3]*q[0] + q[3]*p[0] + cx
-    r[1] = p[3]*q[1] + q[3]*p[1] + cy
-    r[2] = p[3]*q[2] + q[3]*p[2] + cz
+    r[0] = p[3]*q[0] + q[3]*p[0] + p[1]*q[2] - p[2]*q[1]
+    r[1] = p[3]*q[1] + q[3]*p[1] + p[2]*q[0] - p[0]*q[2]
+    r[2] = p[3]*q[2] + q[3]*p[2] + p[0]*q[1] - p[1]*q[0]
     r[3] = p[3]*q[3] - p[0]*q[0] - p[1]*q[1] - p[2]*q[2]
 
 @cython.boundscheck(False)

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -319,12 +319,14 @@ cdef double[:, :] _compute_davenport_from_quat(
 @cython.wraparound(False)
 cdef inline void _compose_quat_single( # calculate p * q into r
     const double[:] p, const double[:] q, double[:] r
-) noexcept:
-    cdef double[:] cross = _cross3(p[:3], q[:3])
+) noexcept nogil:
+    cdef double cx = p[1]*q[2] - p[2]*q[1]
+    cdef double cy = p[2]*q[0] - p[0]*q[2]
+    cdef double cz = p[0]*q[1] - p[1]*q[0]
 
-    r[0] = p[3]*q[0] + q[3]*p[0] + cross[0]
-    r[1] = p[3]*q[1] + q[3]*p[1] + cross[1]
-    r[2] = p[3]*q[2] + q[3]*p[2] + cross[2]
+    r[0] = p[3]*q[0] + q[3]*p[0] + cx
+    r[1] = p[3]*q[1] + q[3]*p[1] + cy
+    r[2] = p[3]*q[2] + q[3]*p[2] + cz
     r[3] = p[3]*q[3] - p[0]*q[0] - p[1]*q[1] - p[2]*q[2]
 
 @cython.boundscheck(False)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
I was looking at old issues and found https://github.com/scipy/scipy/issues/14452. Since I was always curious why the numpy backend scaled so much worse compared to the xp backend, I went back and took a stab at optimizing `_compose_quat_single` in the cython backend. Turns out we are allocating for each quaternion, resulting in significant slowdowns at larger batch sizes.

#### What does this implement/fix?
Removes the vector allocation in favor of single floats, improving performance by up to 15x.

#### Additional information
Benchmarks as in the array API PRs from #23391.
<img width="800" height="600" alt="cython_compose_mul" src="https://github.com/user-attachments/assets/fdb76bfe-6af4-46e5-a9aa-4aa49a0fe1c1" />

#### AI Generation Disclosure
I worked with Claude Code to review the Cython backend.

@lucascolley @scottshambaugh 