### PR TITLE
BUG: special.eval_gegenbauer: fix UBSAN crash for NaN

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -191,7 +191,7 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
 cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcept nogil:
     # If n is an integer, use more stable `eval_gegenbauer_l`
     if number_t is double and n >= 0 and n < 1e10 and n == <long long> n:
-        return <number_t> eval_gegenbauer_l(<Py_ssize_t> <long long> n, alpha, <double> x)
+        return <number_t> eval_gegenbauer_l(<Py_ssize_t> n, alpha, <double> x)
 
     cdef double a, b, c, d
     cdef number_t g

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -189,12 +189,9 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
 
 @cython.cdivision(True)
 cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcept nogil:
-    cdef long long ni
-
     # If n is an integer, use more stable `eval_gegenbauer_l`
-    ni = <long long> n
-    if number_t is double and n == ni and n < 1e10:
-        return <number_t> eval_gegenbauer_l(<Py_ssize_t> ni, alpha, <double> x)
+    if number_t is double and n >= 0 and n < 1e10 and n == <long long> n:
+        return <number_t> eval_gegenbauer_l(<Py_ssize_t> <long long> n, alpha, <double> x)
 
     cdef double a, b, c, d
     cdef number_t g

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -265,7 +265,7 @@ def test_genlaguerre_nan(n, alpha, x):
     assert nan_laguerre == nan_arg
 
 
-@pytest.mark.parametrize('n', [0, 1, 2, 3.2])
+@pytest.mark.parametrize('n', [0, 1, 2, 3.2, np.nan])
 @pytest.mark.parametrize('alpha', [0.0, 1, np.nan])
 @pytest.mark.parametrize('x', [1e-6, 2, np.nan])
 def test_gegenbauer_nan(n, alpha, x):


### PR DESCRIPTION
Running the clang Undefined Behavior Sanitizer revealed a new issue in `orthogonal_eval.pxd` in scipy 1.18.0; namely the illegal conversion of `n` to an integer when it may contain an invalid value like `nan`. This change should sidestep the undefined behavior, while leaving the function's API unchanged.