### PR TITLE
ENH: spatial: Rotation: improve `apply` performance (xp backend)

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -81,7 +81,6 @@ rotation_extra_note = """The methods ``as_davenport``, ``apply``, and ``align_ve
         "apply": dict(
             skip_backends=[
                 ("dask.array", "missing linalg.cross/det functions and .mT attribute"),
-                ("cupy", "missing .mT attribute in cupy<14.*"),
             ],
         ),
         "__getitem__": dict(

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -241,7 +241,7 @@ def from_davenport(
         raise ValueError("Axes must be vectors of length 3.")
 
     axes = xpx.atleast_nd(axes, ndim=2, xp=xp)
-    angles = xpx.atleast_nd(angles, ndim=1, xp=xp) 
+    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)
     num_axes = axes.shape[-2]
     if num_axes is None:
         raise ValueError(f"axes must have a known shape, got shape {axes.shape}")
@@ -635,8 +635,7 @@ def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
             f"Cannot broadcast {quat.shape[:-1]} rotations to {points.shape[:-1]} "
             "vectors."
         )
-    # Rotate by the quaternion directly rather than materializing a (..., 3, 3) matrix
-    # to produce a (..., 3) result: v' = v + 2w(qv x v) + 2(qv x (qv x v)).
+    # Quaternion rotation: p' = p + 2w(qv x p) + 2(qv x (qv x p))
     qv = quat[..., :3]
     w = quat[..., 3:4]
     if inverse:
@@ -645,9 +644,7 @@ def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
     return points + w * t + xp.linalg.cross(qv, t)
 
 
-def setitem(
-    quat: Array, value: Array, indexer: int | slice | EllipsisType
-) -> Array:
+def setitem(quat: Array, value: Array, indexer: int | slice | EllipsisType) -> Array:
     return xpx.at(quat)[indexer, ...].set(value)
 
 

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -630,7 +630,7 @@ def reduce(
 
 def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
     xp = array_namespace(quat)
-    if not broadcastable(quat.shape[:-1] + (3, 1), points[..., None].shape):
+    if not broadcastable(quat.shape[:-1] + (3,), points.shape):
         raise ValueError(
             f"Cannot broadcast {quat.shape[:-1]} rotations to {points.shape[:-1]} "
             "vectors."

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -629,18 +629,20 @@ def reduce(
 
 
 def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
-    mat = as_matrix(quat)
-    # We do not have access to einsum. To avoid broadcasting issues, we add a singleton
-    # dimension to the points array and remove it after the operation.
-    points = points[..., None]
-    if not broadcastable(mat.shape, points.shape):
+    xp = array_namespace(quat)
+    if not broadcastable(quat.shape[:-1] + (3, 1), points[..., None].shape):
         raise ValueError(
             f"Cannot broadcast {quat.shape[:-1]} rotations to {points.shape[:-1]} "
             "vectors."
         )
+    # Rotate by the quaternion directly rather than materializing a (..., 3, 3) matrix
+    # to produce a (..., 3) result: v' = v + 2w(qv x v) + 2(qv x (qv x v)).
+    qv = quat[..., :3]
+    w = quat[..., 3:4]
     if inverse:
-        return (mat.mT @ points)[..., 0]
-    return (mat @ points)[..., 0]
+        qv = -qv
+    t = 2.0 * xp.linalg.cross(qv, points)
+    return points + w * t + xp.linalg.cross(qv, t)
 
 
 def setitem(

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -771,7 +771,7 @@ def test_inverse_apply(xp):
 
 @make_xp_test_case((RigidTransform, "apply"))
 def test_rotation_alone(xp):
-    atol = 1e-12
+    atol = 1e-12 if xpx.default_dtype(xp) == xp.float64 else 1e-7
 
     r = Rotation.from_euler('z', xp.asarray(90), degrees=True)
     tf = RigidTransform.from_rotation(r)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2088,7 +2088,7 @@ def test_align_vectors_near_inf(xp):
 
 @make_xp_test_case((Rotation, "align_vectors"), (Rotation, "as_matrix"))
 def test_align_vectors_parallel(xp):
-    atol = 1e-12
+    atol = 1e-12 if xpx.default_dtype(xp) == xp.float64 else 1e-7
     a = xp.asarray([[1.0, 0, 0], [0, 1, 0]])
     b = xp.asarray([[0.0, 1, 0], [0, 1, 0]])
     m_expected = xp.asarray([[0.0, 1, 0],


### PR DESCRIPTION
#25687 made me curious how much performance was still on the table in the xp backend. The result is a series of optimizations that improve the performance of the generic `Rotation` backend.

Because each function needs benchmarks to prove they are an actual improvement, and each needs to be reviewed, I think the best strategy is to merge them one-by-one. If you want one larger performance PR, I can also collect them all in one PR, which might be a bit more to review.

### What does this implement/fix?
We previously converted q to a matrix before doing the rotation. Now we skip the conversion and directly rotate with the Quaternion.

Edit: This also unlocks supporting Cupy before version 14.0 by dropping `.mT` previously required for the inverse applied rotation.

### Benchmarks
<img width="1500" height="1200" alt="apply" src="https://github.com/user-attachments/assets/2cf45b7a-9e04-42ff-882d-5716225d3ccd" />
Dashed lines are the baseline performances based off of commit 52e0539.

### Additional information
Might be a candidate also for the Cython backend.

### AI Generation Disclosure
I work with Claude Code to prototype ideas.

@lucascolley @scottshambaugh @j-bowhay 