### PR TITLE
ENH: spatial: Rotation: improve mul performance (xp backend)

### DIFF
--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -1112,17 +1112,17 @@ def _get_angles(
 
 def compose_quat(p: Array, q: Array) -> Array:
     xp = array_namespace(p)
-    cross = xp.linalg.cross(p[..., :3], q[..., :3])
-    qx = p[..., 3] * q[..., 0] + q[..., 3] * p[..., 0] + cross[..., 0]
-    qy = p[..., 3] * q[..., 1] + q[..., 3] * p[..., 1] + cross[..., 1]
-    qz = p[..., 3] * q[..., 2] + q[..., 3] * p[..., 2] + cross[..., 2]
-    qw = (
-        p[..., 3] * q[..., 3]
-        - p[..., 0] * q[..., 0]
-        - p[..., 1] * q[..., 1]
-        - p[..., 2] * q[..., 2]
+    px, py, pz, pw = p[..., 0], p[..., 1], p[..., 2], p[..., 3]
+    qx, qy, qz, qw = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+    quat = xp.stack(
+        [
+            pw * qx + px * qw + py * qz - pz * qy,
+            pw * qy - px * qz + py * qw + pz * qx,
+            pw * qz + px * qy - py * qx + pz * qw,
+            pw * qw - px * qx - py * qy - pz * qz,
+        ],
+        axis=-1,
     )
-    quat = xp.stack([qx, qy, qz, qw], axis=-1)
     return quat
 
 


### PR DESCRIPTION
Follow-up from #25691. Optimizes the performance of `Rotation.__mul__`

### What does this implement/fix?
Mirrors the changes in #25687 and removes the cross product for the quaternion multiplication. The gains are mostly visible in torch and on jax using the CPU. However, it also restories parity to the changes in the Cython backend, so I think overall this improves the maintenance and is easier to read.

### Benchmarks
<img width="1500" height="1200" alt="image" src="https://github.com/user-attachments/assets/59489539-a1fd-4ca6-8e74-769714bc3d78" />

Dashed lines are the baseline performances based off of commit 52e0539. Numpy is unchanged because the Cython backend was done in #25687.