### PR TITLE
ENH: spatial: Rotation: improve from_rotvec performance (xp backend)

### DIFF
--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -164,8 +164,8 @@ def from_rotvec(rotvec: Array, degrees: bool = False) -> Array:
 
     angle = xp_vector_norm(rotvec, axis=-1, keepdims=True, xp=xp)
     small_angle = angle <= 1e-3
-    angle2 = angle * angle
-    small_scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
+    angle2 = angle**2
+    small_scale = 0.5 - angle2 / 48 + angle2**2 / 3840
     # We need to handle the case where angle is 0 to avoid division by zero. We use the
     # value of the Taylor series approximation, but non-branching operations require
     # that we still divide by the angle. Since we do not use the result where the angle
@@ -242,7 +242,7 @@ def from_davenport(
         raise ValueError("Axes must be vectors of length 3.")
 
     axes = xpx.atleast_nd(axes, ndim=2, xp=xp)
-    angles = xpx.atleast_nd(angles, ndim=1, xp=xp) 
+    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)
     num_axes = axes.shape[-2]
     if num_axes is None:
         raise ValueError(f"axes must have a known shape, got shape {axes.shape}")
@@ -644,9 +644,7 @@ def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
     return (mat @ points)[..., 0]
 
 
-def setitem(
-    quat: Array, value: Array, indexer: int | slice | EllipsisType
-) -> Array:
+def setitem(quat: Array, value: Array, indexer: int | slice | EllipsisType) -> Array:
     return xpx.at(quat)[indexer, ...].set(value)
 
 

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -164,16 +164,17 @@ def from_rotvec(rotvec: Array, degrees: bool = False) -> Array:
 
     angle = xp_vector_norm(rotvec, axis=-1, keepdims=True, xp=xp)
     small_angle = angle <= 1e-3
-    angle2 = angle**2
-    small_scale = 0.5 - angle2 / 48 + angle2**2 / 3840
+    angle2 = angle * angle
+    small_scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
     # We need to handle the case where angle is 0 to avoid division by zero. We use the
     # value of the Taylor series approximation, but non-branching operations require
     # that we still divide by the angle. Since we do not use the result where the angle
     # is close to 0, this is safe.
-    div_angle = angle + xp.asarray(small_angle, dtype=angle.dtype)
-    large_scale = xp.sin(angle / 2) / div_angle
+    half_angle = angle / 2
+    div_angle = angle + xp.astype(small_angle, angle.dtype)
+    large_scale = xp.sin(half_angle) / div_angle
     scale = xp.where(small_angle, small_scale, large_scale)
-    quat = xp.concat([rotvec * scale, xp.cos(angle / 2)], axis=-1)
+    quat = xp.concat([rotvec * scale, xp.cos(half_angle)], axis=-1)
     return quat
 
 


### PR DESCRIPTION
Follow-up from https://github.com/scipy/scipy/pull/25691. Optimizes the performance of `Rotation.from_rotvec`

### What does this implement/fix?
Save the half angle instead of computing it twice, and turn an `asarray()` into an `astype()` cast. This performance optimization only impacts eager backends, i.e. torch and cupy. It is only minor in terms of savings, but since the required changes are minimal and logical, I think it still makes sense.

### Benchmarks
<img width="1500" height="1200" alt="image" src="https://github.com/user-attachments/assets/be28c6f6-a2d3-4802-a574-99c507b92c4b" />

Dashed lines are the baseline performances based off of commit 52e0539.

### AI Generation Disclosure
Claude to review the xp backend.