### PR TITLE
BUG: portable `__call__` for `test_spiral_cleanup`

### DIFF
--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -110,7 +110,12 @@ class _BarycentricRational:
         with np.errstate(invalid="ignore", divide="ignore"):
             CC = 1 / np.subtract.outer(zv, self._support_points)
             # Vector of values
-            r = CC @ (weights * support_values) / (CC @ weights)
+            # NOTE: optimized matrix multiplications are avoided here
+            # to prevent the platform-specific deviations noted in
+            # gh-23707
+            num = np.einsum('ik,kj->ij', CC, weights * support_values)
+            denom = np.einsum('ik,kj->ij', CC, weights)
+            r = num / denom
 
         # Deal with input inf: `r(inf) = lim r(z) = sum(w*f) / sum(w)`
         if np.any(np.isinf(zv)):


### PR DESCRIPTION
* Fixes gh-23707.

* The `__call__` method in `_BarycentricRational` had some (optimized) matrix multiplications that were
behaving differently on ARM Mac vs. x86_64 Linux, independent of OpenBLAS vs. Accelerate or clang vs. gcc (based on Warren's comments in the matching issue).

* I noticed that, for the code patched here, when I take the denominator operation (`CC @ weights`), save `CC` and `weights` arrays to disk, and run that operation on MacOS ARM vs. x86_64 Linux, the number of `nan` in the result is not the same. A few low level differences can cause this kind of thing--I admit that I did not determine exactly which one it is, but proceeding on the assumption that the test is written correctly, I've reduced the level of optimization in the operation directly by switching from a matmal to `einsum`, which allows `test_spiral_cleanup()` to finally pass locally on ARM Mac.

* I'd probably have a bit more sympathy for preservation of performance if the test had not been failing on ARM Mac for almost a year now--if we can agree that the test is enforcing the correct behavior, I'd tend to argue that correctness should supersede performance.


#### AI Generation Disclosure
After identifying the high level source of the platform-specific behavior (the matrix multiplications in the operations patched here), I prompted Claude Opus `4.8` to suggest some less optimized versions of the operations that would still work with batched operations.