### PR TITLE
MAINT: propagate the input device in array creation (batch 1)

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -2,7 +2,9 @@ import warnings
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import array_namespace, xp_copy, xp_promote, xp_capabilities
+from scipy._lib._array_api import (xp_result_device, array_namespace,
+                                   xp_copy, xp_promote,
+                                   xp_capabilities, xp_device)
 import scipy._external.array_api_extra as xpx
 
 _EERRORINCREASE = -1  # used in derivative
@@ -40,8 +42,13 @@ def _derivative_iv(f, x, args, kwargs, tolerances, maxiter, order, initial_step,
     if order_int != order or order <= 0:
         raise ValueError('`order` must be a positive integer.')
 
-    step_direction = xp.asarray(step_direction)
-    initial_step = xp.asarray(initial_step)
+    # scalars and host data land on the device of `x`; arrays keep their own
+    # device, so that a device mismatch raises in `broadcast_arrays` below
+    step_direction = xp.asarray(step_direction,
+                                device=xp_result_device(step_direction, x))
+    initial_step = xp.asarray(initial_step,
+                              device=xp_result_device(initial_step, x))
+
     temp = xp.broadcast_arrays(x, step_direction, initial_step)
     x, step_direction, initial_step = temp
 
@@ -473,18 +480,19 @@ def derivative(f, x, *, args=(), kwargs=None, tolerances=None, maxiter=10,
         # Note - no need to be careful about dtypes until we allocate `x_eval`
 
         if work.nit == 0:
-            hc = h / c**xp.arange(n, dtype=work.dtype)
+            hc = h / c**xp.arange(n, dtype=work.dtype, device=xp_device(work.x))
             hc = xp.concat((-xp.flip(hc, axis=-1), hc), axis=-1)
         else:
             hc = xp.concat((-h, h), axis=-1) / c**(n-1)
 
         if work.nit == 0:
-            hr = h / d**xp.arange(2*n, dtype=work.dtype)
+            hr = h / d**xp.arange(2*n, dtype=work.dtype, device=xp_device(work.x))
         else:
             hr = xp.concat((h, h/d), axis=-1) / c**(n-1)
 
         n_new = 2*n if work.nit == 0 else 2  # number of new abscissae
-        x_eval = xp.zeros((work.hdir.shape[0], n_new), dtype=work.dtype)
+        x_eval = xp.zeros((work.hdir.shape[0], n_new), dtype=work.dtype,
+                          device=xp_device(work.x))
         il, ic, ir = work.il, work.ic, work.ir
         x_eval = xpx.at(x_eval)[ir].set(work.x[ir][:, xp.newaxis] + hr[ir])
         x_eval = xpx.at(x_eval)[ic].set(work.x[ic][:, xp.newaxis] + hc[ic])
@@ -537,7 +545,8 @@ def derivative(f, x, *, args=(), kwargs=None, tolerances=None, maxiter=10,
         else:
             fo = xp.concat((work_fo[:, 0:1], work_fo[:, -2*n:]), axis=-1)
 
-        work.fs = xp.zeros((ic.shape[0], work.fs.shape[-1] + 2*n_new), dtype=work.dtype)
+        work.fs = xp.zeros((ic.shape[0], work.fs.shape[-1] + 2*n_new),
+                           dtype=work.dtype, device=xp_device(work.x))
         work.fs = xpx.at(work.fs)[ic].set(work_fc)
         work.fs = xpx.at(work.fs)[io].set(work_fo)
 
@@ -713,8 +722,9 @@ def _derivative_weights(work, n, xp):
 
         diff_state.right = weights
 
-    return (xp.asarray(diff_state.central, dtype=work.dtype),
-            xp.asarray(diff_state.right, dtype=work.dtype))
+    device = xp_device(work.x)
+    return (xp.asarray(diff_state.central, dtype=work.dtype, device=device),
+            xp.asarray(diff_state.right, dtype=work.dtype, device=device))
 
 
 @xp_capabilities(skip_backends=[('array_api_strict', _array_api_strict_skip_reason),
@@ -925,7 +935,7 @@ def jacobian(f, x, *, tolerances=None, maxiter=10, order=8, initial_step=0.5,
         raise ValueError(message)
 
     m = x0.shape[0]
-    i = xp.arange(m)
+    i = xp.arange(m, device=xp_device(x0))
 
     def wrapped(x):
         p = () if x.ndim == x0.ndim else (x.shape[-1],)  # number of abscissae

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -3,7 +3,9 @@ import math
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 from scipy._lib._util import _apply_over_batch
-from scipy._lib._array_api import array_namespace, xp_capabilities, xp_size, xp_promote
+from scipy._lib._array_api import (
+    array_namespace, xp_capabilities, xp_size, xp_promote, xp_device
+)
 import scipy._external.array_api_extra as xpx
 
 
@@ -344,7 +346,7 @@ def leslie(f, s):
         raise ValueError("The length of s must be at least 1.")
 
     n = f.shape[-1]
-    a = xp.zeros((n, n), dtype=f.dtype)
+    a = xp.zeros((n, n), dtype=f.dtype, device=xp_device(f))
     a = xpx.at(a)[0, :].set(f)
     a += xpx.create_diagonal(s, offset=-1, xp=xp)
     return a
@@ -433,7 +435,7 @@ def block_diag(*arrs):
     block_shapes = [a.shape[-2:] for a in arrs]
     out = xp.zeros(batch_shape +
                    tuple(map(int, xp.sum(xp.asarray(block_shapes), axis=0))),
-                   dtype=out_dtype)
+                   dtype=out_dtype, device=xp_device(arrs[0]))
 
     r, c = 0, 0
     for i, (rr, cc) in enumerate(block_shapes):
@@ -1017,9 +1019,9 @@ def fiedler(a):
     a = xpx.atleast_nd(xp.asarray(a), ndim=1)
 
     if xp_size(a) == 0:
-        return xp.empty((0, 0), dtype=xp.float64)
+        return xp.empty((0, 0), dtype=xp.float64, device=xp_device(a))
     elif xp_size(a) == 1:
-        return xp.asarray([[0.]])
+        return xp.asarray([[0.]], device=xp_device(a))
     else:
         return xp.abs(a[..., :, xp.newaxis] - a[..., xp.newaxis, :])
 

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import array_namespace, xp_ravel, xp_promote
+from scipy._lib._array_api import array_namespace, xp_device, xp_ravel, xp_promote
 
 _ELIMITS = -1  # used in _bracket_root
 _ESTOPONESIDE = 2  # used in _bracket_root
@@ -57,7 +57,7 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, kwargs, maxiter):
         xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.ones_like(xmax))
         xr0 = xp.astype(xr0, xl0.dtype, copy=False)
 
-    maxiter = xp.asarray(maxiter)
+    maxiter = xp.asarray(maxiter, device=xp_device(xl0))
     message = '`maxiter` must be a non-negative integer.'
     if (not xp.isdtype(maxiter.dtype, "numeric") or maxiter.shape != tuple()
             or xp.isdtype(maxiter.dtype, "complex floating")):
@@ -210,7 +210,7 @@ def _bracket_root(func, xl0, xr0=None, *, xmin=None, xmax=None, factor=None,
     factor = xp.astype(factor, dtype, copy=False)
     factor = xp.concat((factor, factor))
 
-    active = xp.arange(2*n)
+    active = xp.arange(2*n, device=xp_device(x))
     args = [xp.concat((arg, arg)) for arg in args]
 
     # This is needed due to inner workings of `eim._loop`.
@@ -482,7 +482,7 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, kwargs, m
         xr0 = xm0 + xp.minimum((xmax - xm0)/16, 0.5)
         xr0 = xp.astype(xr0, xm0.dtype, copy=False)
 
-    maxiter = xp.asarray(maxiter)
+    maxiter = xp.asarray(maxiter, device=xp_device(xm0))
     message = '`maxiter` must be a non-negative integer.'
     if (not xp.isdtype(maxiter.dtype, "numeric") or maxiter.shape != tuple()
             or xp.isdtype(maxiter.dtype, "complex floating")):

--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import xp_copy
+from scipy._lib._array_api import xp_copy, xp_device
 
 
 def _chandrupatla(func, a, b, *, args=(), kwargs=None, xatol=None, xrtol=None,
@@ -186,7 +186,8 @@ def _chandrupatla(func, a, b, *, args=(), kwargs=None, xatol=None, xrtol=None,
         # If the bracket is no longer valid, report failure (unless a function
         # tolerance is met, as detected above).
         i = (xp.sign(work.f1) == xp.sign(work.f2)) & ~stop
-        NaN = xp.asarray(xp.nan, dtype=work.xmin.dtype)
+        NaN = xp.asarray(xp.nan, dtype=work.xmin.dtype,
+                         device=xp_device(work.xmin))
         work.xmin[i], work.fmin[i], work.status[i] = NaN, NaN, eim._ESIGNERR
         stop[i] = True
 
@@ -400,7 +401,8 @@ def _chandrupatla_minimize(func, x1, x2, x3, *, args=(), kwargs=None, xatol=None
     func, xs, fs, args, shape, dtype, xp = temp  # line split for PEP8
     x1, x2, x3 = xs
     f1, f2, f3 = fs
-    phi = xp.asarray(0.5 + 0.5*5**0.5, dtype=dtype)[()]  # golden ratio
+    phi = xp.asarray(0.5 + 0.5*5**0.5, dtype=dtype,
+                     device=xp_device(x1))[()]  # golden ratio
     status = xp.full_like(x1, eim._EINPROGRESS, dtype=xp.int32)  # in progress
     nit, nfev = 0, 3  # three function evaluations performed above
     fatol = xp.finfo(dtype).smallest_normal if fatol is None else fatol

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -41,7 +41,9 @@ from scipy._lib._util import (MapWrapper, check_random_state, _RichResult,
                               _call_callback_maybe_halt, _transition_to_rng,
                               wrapped_inspect_signature)
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy._lib._array_api import array_namespace, xp_capabilities, xp_promote
+from scipy._lib._array_api import (
+    array_namespace, xp_capabilities, xp_device, xp_promote
+)
 from scipy._external import array_api_extra as xpx
 
 
@@ -465,7 +467,7 @@ def rosen_hess(x):
 
     H = (xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp)
          - xpx.create_diagonal(400 * x[:-1], offset=-1, xp=xp))
-    diagonal = xp.zeros(x.shape[0], dtype=x.dtype)
+    diagonal = xp.zeros(x.shape[0], dtype=x.dtype, device=xp_device(x))
     diagonal = xpx.at(diagonal)[0].set(1200 * x[0]**2 - 400 * x[1] + 2)
     diagonal = xpx.at(diagonal)[-1].set(200)
     diagonal = xpx.at(diagonal)[1:-1].set(202 + 1200 * x[1:-1]**2 - 400 * x[2:])
@@ -508,7 +510,7 @@ def rosen_hess_prod(x, p):
     x = xp_promote(x, force_floating=True, xp=xp)
     x = xpx.atleast_nd(x, ndim=1, xp=xp)
     p = xp.asarray(p, dtype=x.dtype)
-    Hp = xp.zeros(x.shape[0], dtype=x.dtype)
+    Hp = xp.zeros(x.shape[0], dtype=x.dtype, device=xp_device(x))
     Hp = xpx.at(Hp)[0].set((1200 * x[0]**2 - 400 * x[1] + 2) * p[0] - 400 * x[0] * p[1])
     Hp = xpx.at(Hp)[1:-1].set(-400 * x[:-2] * p[:-2] +
                               (202 + 1200 * x[1:-1]**2 - 400 * x[2:]) * p[1:-1] -

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -232,7 +232,8 @@ class LinearOperator:
         """
         xp = np_compat if xp is None else xp
         if dtype is not None:
-            dtype = xp.empty(0, dtype=dtype).dtype
+            # throwaway 0-size array to canonicalize `dtype`; no array in scope
+            dtype = xp.empty(0, dtype=dtype).dtype  # skip device check
 
         shape = tuple(shape)
         if len(shape) < 2:
@@ -267,7 +268,8 @@ class LinearOperator:
         """
         if self.dtype is None:
             xp = self._xp
-            v = xp.zeros(self.shape[-1], dtype=xp.int8)
+            # dtype probe; user callables define the operator, no device to match
+            v = xp.zeros(self.shape[-1], dtype=xp.int8)  # skip device check
             try:
                 matvec_v = xp.asarray(self.matvec(v))
             except (OverflowError, TypeError, RuntimeError):
@@ -558,7 +560,9 @@ class LinearOperator:
     def _check_matching_namespace(self, x):
         xp_x = getattr(x, "_xp", None)
         if xp_x is None:
-            xp_x = array_namespace(x, self._xp.empty(0), sparse_ok=True)
+            # `empty(0)` is a throwaway used only to resolve the namespace
+            xp_x = array_namespace(x, self._xp.empty(0),  # skip device check
+                                   sparse_ok=True)
         if xp_x != self._xp:
             msg = (
                 f"Mismatched array namespaces."

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -613,7 +613,9 @@ def reduce(
     right_best = max_ind % rv.shape[0]
     # Array API limitation: Integer index arrays are only allowed with integer indices
     # TODO: Can we somehow avoid this?
-    all_idx = xp.reshape(xp.arange(left.shape[-1]), (1, -1))
+    all_idx = xp.reshape(
+        xp.arange(left.shape[-1], device=xp_device(left)), (1, -1)
+    )
     left_idx = xp.reshape(left_best, (-1, 1))
     left = left[left_idx, all_idx]
     right_idx = xp.reshape(right_best, (-1, 1))
@@ -703,7 +705,9 @@ def align_vectors(
 
     # For the special case of a single vector pair, we use the infinite
     # weight code path
-    weight_is_inf = xp.asarray([True]) if N == 1 else weights == xp.inf
+    weight_is_inf = (
+        xp.asarray([True], device=xp_device(a)) if N == 1 else weights == xp.inf
+    )
     n_inf = xp.sum(xp.astype(weight_is_inf, a.dtype))
     # We can only error out on multiple infinite weights or sensitivity return with
     # infinite weights in eager execution models. Lazy backends will return NaNs.


### PR DESCRIPTION
Mechanical device-propagation fixes (see issue 22680) for `differentiate`, `linalg`, `optimize`, `sparse.linalg`, and `spatial.transform`.

Internal array creation that omits `device=` lands on the backend's default device and raises (or silently misplaces results) when the input arrays reside on a non-default device.
Fix that by passing on the device, typically with `device=xp_device(<input>)`

This is the second PR of the series, following gh-25677.

#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see gh-25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.