### PR TITLE
DOC: Add Examples to docstrings in scipy.special for berp, beip, kerp, and keip

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2568,6 +2568,16 @@ const char *berp_doc = R"(
     --------
     ber : Kelvin function ber
 
+    Examples
+    --------
+    It can be expressed as the derivative of the Kelvin function `ber`.
+
+    >>> import numpy as np
+    >>> import scipy.special as sc
+    >>> x = np.array([1.0, 2.0, 3.0, 4.0])
+    >>> sc.berp(x)
+    array([-0.06244575, -0.49306712, -1.56984663, -3.13465396])
+
     References
     ----------
     .. [dlmf] NIST, Digital Library of Mathematical Functions,


### PR DESCRIPTION
[docs only]

Fixes #7168 (partially).

This PR adds an `Examples` section to the docstrings of four `scipy.special` functions that were missing them:
* `berp`
* `beip`
* `kerp`
* `keip`

These examples compute the derivatives of the respective Kelvin functions using arrays.