### PR TITLE
BUG: ensure contiguous arrays in BivariateSpline._validate_input (#25678)

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1674,12 +1674,17 @@ class BivariateSpline(_BivariateSplineBase):
 
     @staticmethod
     def _validate_input(x, y, z, w, kx, ky, eps):
-        x, y, z = np.asarray(x), np.asarray(y), np.asarray(z)
+        # Use ascontiguousarray to handle non-contiguous views (e.g., column
+        # slices of a 2D array).  The underlying C/Fortran routines require
+        # C-contiguous data.  Fixes GH-25678.
+        x = np.ascontiguousarray(x)
+        y = np.ascontiguousarray(y)
+        z = np.ascontiguousarray(z)
         if not x.size == y.size == z.size:
             raise ValueError('x, y, and z should have a same length')
 
         if w is not None:
-            w = np.asarray(w)
+            w = np.ascontiguousarray(w)
             if x.size != w.size:
                 raise ValueError('x, y, z, and w should have a same length')
             elif not np.all(w >= 0.0):


### PR DESCRIPTION
## Problem

`SmoothBivariateSpline` (and other `BivariateSpline` subclasses) fail in
SciPy 1.18.0 when the input arrays are non-contiguous views — e.g., column
slices of a 2D NumPy array:

```python
import numpy as np
from scipy.interpolate import SmoothBivariateSpline

lut = np.load("data.npy")          # shape (N, 3), C-contiguous
x2, y2, z2 = lut[:, 0], lut[:, 1], lut[:, 2]   # non-contiguous!
itp = SmoothBivariateSpline(x2, y2, z2)         # fails in 1.18.0
```

The error message is `ValueError: c must have length (nx-kx-1)*(ny-ky-1)`.
Using `np.copy()` on the inputs works around the issue.

## Root cause

`BivariateSpline._validate_input` uses `np.asarray()`, which preserves
non-contiguous memory layouts (e.g., column slices with non-unit strides).
The underlying C/Fortran routines (`dfitpack.surfit_smth` and related
functions) require C-contiguous arrays.

## Fix

Replace `np.asarray()` with `np.ascontiguousarray()` in
`BivariateSpline._validate_input` to guarantee contiguous input before
passing to the Fortran routines. This is a zero-copy operation when the
input is already contiguous.

Closes #25678.
