### PR TITLE
ENH: spatial: Rotation: improve from_matrix performance (xp backend)

### DIFF
--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -87,7 +87,6 @@ def from_matrix(matrix: Array, assume_valid: bool = False) -> Array:
 def _from_matrix_orthogonal(matrix: Array) -> Array:
     """Convert known orthogonal rotation matrix to quaternion"""
     xp = array_namespace(matrix)
-    device = xp_device(matrix)
 
     matrix_trace = matrix[..., 0, 0] + matrix[..., 1, 1] + matrix[..., 2, 2]
     decision = xp.stack(
@@ -95,7 +94,6 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         axis=-1,
     )
     choice = xp.argmax(decision, axis=-1, keepdims=True)
-    quat = xp.empty((*matrix.shape[:-2], 4), dtype=matrix.dtype, device=device)
 
     # The Array API does not support mixing integer indexing with ellipsis, so we cannot
     # follow the same pattern as the cython backend. Instead, we compute each case
@@ -113,8 +111,6 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         ],
         axis=-1,
     )
-    quat = xp.where(choice == 0, quat_0, quat)
-
     # Case 1
     quat_1 = xp.stack(
         [
@@ -125,8 +121,6 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         ],
         axis=-1,
     )
-    quat = xp.where(choice == 1, quat_1, quat)
-
     # Case 2
     quat_2 = xp.stack(
         [
@@ -137,8 +131,6 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         ],
         axis=-1,
     )
-    quat = xp.where(choice == 2, quat_2, quat)
-
     # Case 3
     quat_3 = xp.stack(
         [
@@ -149,7 +141,13 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         ],
         axis=-1,
     )
-    quat = xp.where(choice == 3, quat_3, quat)
+    # Nested selection: three where calls instead of four, and no dead xp.empty
+    # buffer that the first branch would immediately overwrite.
+    quat = xp.where(
+        choice == 0,
+        quat_0,
+        xp.where(choice == 1, quat_1, xp.where(choice == 2, quat_2, quat_3)),
+    )
 
     return _normalize_quaternion(quat)
 

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -141,15 +141,11 @@ def _from_matrix_orthogonal(matrix: Array) -> Array:
         ],
         axis=-1,
     )
-    # Nested selection: three where calls instead of four, and no dead xp.empty
-    # buffer that the first branch would immediately overwrite.
-    quat = xp.where(
-        choice == 0,
-        quat_0,
-        xp.where(choice == 1, quat_1, xp.where(choice == 2, quat_2, quat_3)),
-    )
-
-    return _normalize_quaternion(quat)
+    # Override locations where quat_0 is not our choice
+    quat_0 = xp.where(choice == 1, quat_1, quat_0)
+    quat_0 = xp.where(choice == 2, quat_2, quat_0)
+    quat_0 = xp.where(choice == 3, quat_3, quat_0)
+    return _normalize_quaternion(quat_0)
 
 
 def from_rotvec(rotvec: Array, degrees: bool = False) -> Array:
@@ -239,7 +235,7 @@ def from_davenport(
         raise ValueError("Axes must be vectors of length 3.")
 
     axes = xpx.atleast_nd(axes, ndim=2, xp=xp)
-    angles = xpx.atleast_nd(angles, ndim=1, xp=xp) 
+    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)
     num_axes = axes.shape[-2]
     if num_axes is None:
         raise ValueError(f"axes must have a known shape, got shape {axes.shape}")
@@ -641,9 +637,7 @@ def apply(quat: Array, points: Array, inverse: bool = False) -> Array:
     return (mat @ points)[..., 0]
 
 
-def setitem(
-    quat: Array, value: Array, indexer: int | slice | EllipsisType
-) -> Array:
+def setitem(quat: Array, value: Array, indexer: int | slice | EllipsisType) -> Array:
     return xpx.at(quat)[indexer, ...].set(value)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
Follow-up from https://github.com/scipy/scipy/pull/25691. Optimizes the performance of `Rotation.from_matrix`.

### What does this implement/fix?
Optimizes `from_matrix` by dropping one redundant `xp.where` call and an empty allocation. As before, this optimization is minor and only visible in eager frameworks. Jax likely optimizes it away.

### Benchmarks
<img width="1500" height="1200" alt="image" src="https://github.com/user-attachments/assets/e4171963-5ff4-4547-82ee-e60b3787b3de" />

On the default call path, the determinant, orthonormality check etc dominate and make the optimization invisible. However, when using `assume_valid=True`, we observe a minor efficiency gain. Dashed lines are the baseline performances based off of commit 52e0539. Numpy remains unaffected (xp backend only).

### AI Generation Disclosure
Claude to review the xp backend.