### PR TITLE
ENH: fft: raise ValueError for DCT-I with fewer than two points

### DIFF
--- a/scipy/fft/_duccfft/realtransforms.py
+++ b/scipy/fft/_duccfft/realtransforms.py
@@ -5,6 +5,26 @@ from .helper import (_asfarray, _init_nd_shape_and_axes, _datacopied,
 import functools
 
 
+def _assert_dct1_length(transform, type, shape, axes):
+    """Validate that DCT-I inputs are long enough.
+
+    The DCT-I of a length ``N`` signal is evaluated with a real FFT of length
+    ``2 * (N - 1)``, so ``N`` must be at least 2. Without this check a length
+    of 1 reaches the backend as a zero-length FFT and surfaces as a bare
+    ``RuntimeError``. DST-I is unaffected: it uses a length ``2 * (N + 1)``
+    FFT and is well defined for ``N == 1``.
+    """
+    if type != 1 or transform is not pfft.dct:
+        return
+    for axis in axes:
+        if shape[axis] < 2:
+            raise ValueError(
+                f"invalid number of data points ({shape[axis]}) specified "
+                f"along axis {axis} for DCT type 1, which requires at least "
+                "2 data points"
+            )
+
+
 def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
          overwrite_x=False, workers=None, orthogonalize=None):
     """Forward or backward 1-D DCT/DST
@@ -32,6 +52,8 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
         overwrite_x = overwrite_x or copied
     elif tmp.shape[axis] < 1:
         raise ValueError(f"invalid number of data points ({tmp.shape[axis]}) specified")
+
+    _assert_dct1_length(transform, type, tmp.shape, (axis,))
 
     out = (tmp if overwrite_x else None)
 
@@ -86,6 +108,9 @@ def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
 
     norm = _normalization(norm, forward)
     workers = _workers(workers)
+
+    _assert_dct1_length(transform, type, tmp.shape, axes)
+
     out = (tmp if overwrite_x else None)
 
     # For complex input, transform real and imaginary components separably

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -241,3 +241,35 @@ def test_array_like(func):
          [[1.0, 1.0], [1.0, 1.0]],
          [[1.0, 1.0], [1.0, 1.0]]]
     xp_assert_close(func(x), func(np.asarray(x)))
+
+
+@pytest.mark.parametrize("func", [dct, idct])
+def test_dct1_requires_at_least_two_points(func):
+    # DCT-I uses a length 2*(N-1) FFT, so N == 1 reached the backend as a
+    # zero-length FFT and raised a bare RuntimeError. It should be reported
+    # as a ValueError, whether the short length comes from the input itself
+    # or from `n`.
+    x = np.arange(8.0)
+    with pytest.raises(ValueError, match="DCT type 1"):
+        func(x, type=1, n=1)
+    with pytest.raises(ValueError, match="DCT type 1"):
+        func(np.array([5.0]), type=1)
+    # Other types accept a single point, and DCT-I accepts two.
+    for type in (2, 3, 4):
+        assert func(x, type=type, n=1).shape == (1,)
+    assert func(x, type=1, n=2).shape == (2,)
+
+
+@pytest.mark.parametrize("func", [dctn, idctn])
+def test_dctn1_requires_at_least_two_points(func):
+    x = np.arange(8.0)
+    with pytest.raises(ValueError, match="DCT type 1"):
+        func(x, type=1, s=[1])
+
+
+@pytest.mark.parametrize("func", [dst, idst, dstn, idstn])
+def test_dst1_allows_single_point(func):
+    # DST-I uses a length 2*(N+1) FFT and stays well defined for N == 1.
+    x = np.arange(8.0)
+    kwargs = {"s": [1]} if func in (dstn, idstn) else {"n": 1}
+    assert func(x, type=1, **kwargs).shape == (1,)


### PR DESCRIPTION
### Reference issue

None — reporting and fixing together, since the fix is small and self-contained.

### What does this implement/fix?

The DCT-I of a length `N` signal is evaluated with a real FFT of length `2 * (N - 1)`. For `N == 1` that becomes a zero-length FFT, which the backend reports as a bare `RuntimeError`:

```python
>>> import numpy as np
>>> from scipy import fft
>>> x = np.arange(8.0)
>>> fft.dct(x, type=1, n=1)
RuntimeError: zero-length FFT requested
>>> fft.dct(np.array([5.0]), type=1)
RuntimeError: zero-length FFT requested
>>> fft.dctn(x, type=1, s=[1])
RuntimeError: zero-length FFT requested
```

`_r2r` already validates the number of data points (`tmp.shape[axis] < 1`), but nothing enforces the stricter minimum that type 1 requires, so an invalid argument surfaces as an internal error rather than a `ValueError` naming the problem. The same holds for the n-D path in `_r2rn`.

This adds a small `_assert_dct1_length` helper, called from both `_r2r` and `_r2rn`, so the effective transform length is checked after `n`/`s` has been applied:

```python
>>> fft.dct(x, type=1, n=1)
ValueError: invalid number of data points (1) specified along axis -1 for DCT type 1, which requires at least 2 data points
```

The check is deliberately narrow:

* **DST-I is untouched.** It uses a length `2 * (N + 1)` FFT and is well defined for `N == 1`, so `dst`/`idst`/`dstn`/`idstn` still accept a single point.
* **Types 2, 3 and 4 are untouched** — they accept `n=1` as before.
* Valid DCT-I calls (`N >= 2`) are unaffected.

### Additional information

Behaviour only changes for inputs that already raised; a `RuntimeError` becomes a `ValueError`.

Existing coverage is unaffected: `test_identity_1d` and friends parametrize `n` over `[2, 3, 4, 5, 10, 16]`, so no current test exercises type 1 with a single point, and no test asserts the old `RuntimeError`.

New tests in `scipy/fft/tests/test_real_transforms.py` cover:

* `dct`/`idct` type 1 rejecting a single point via both `n=1` and a length-1 input, while types 2–4 and `n=2` keep working
* `dctn`/`idctn` type 1 rejecting `s=[1]`
* `dst`/`idst`/`dstn`/`idstn` type 1 still accepting a single point
