### PR TITLE
MAINT: linalg: unify includes in `_batched_linalg.cc`

### DIFF
--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <complex>
 #include <vector>
+#include <tuple>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include <cstring>
 #include "_linalg_inv.hh"
 #include "_linalg_solve.hh"

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1,14 +1,23 @@
 #include "Python.h"
+
 #include <cstring>
+#include <complex>
+#include <vector>
+#include "numpy/arrayobject.h"
+#include "numpy/npy_math.h"
+
+#include "scipy_blas_defines.h"
+#include "_npymath.hh"
+#include "_common_array_utils.hh"
+
+#include "_linalg_cholesky.hh"
+#include "_linalg_eig.hh"
 #include "_linalg_inv.hh"
+#include "_linalg_lstsq.hh"
+#include "_linalg_lu_det.hh"
+#include "_linalg_qr.hh"
 #include "_linalg_solve.hh"
 #include "_linalg_svd.hh"
-#include "_linalg_lstsq.hh"
-#include "_linalg_eig.hh"
-#include "_linalg_cholesky.hh"
-#include "_linalg_qr.hh"
-#include "_common_array_utils.hh"
-#include "_linalg_lu_det.hh"
 
 using namespace sp_linalg;
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1,12 +1,7 @@
 /*
  * LAPACK declarations.
  */
-#ifndef _SCIPY_COMMON_ARRAY_UTILS_H
-#define _SCIPY_COMMON_ARRAY_UTILS_H
-#include "Python.h"
-#include <tuple>
-#include "numpy/npy_math.h"
-#include "scipy_blas_defines.h"
+#pragma once
 
 /*
  * declare LAPACK prototypes
@@ -1580,4 +1575,3 @@ nan_matrix(T * data, npy_intp n) {
 }
 
 } // namespace sp_linalg
-#endif

--- a/scipy/linalg/src/_linalg_cholesky.hh
+++ b/scipy/linalg/src/_linalg_cholesky.hh
@@ -1,3 +1,7 @@
+/*
+ * Templated loops for `linalg.cholesky`
+ */
+#pragma once
 
 namespace sp_linalg {
 

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -1,8 +1,7 @@
-#pragma once
 /*
- * Templated loops for linalg.eig
+ * Templated loops for `linalg.eig`
  */
-
+#pragma once
 
 namespace sp_linalg {
 
@@ -367,7 +366,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
         // copy-and-transpose W, VR and VL slices from temp buffers to the output;
         if constexpr (detail::type_traits<T>::is_complex) {
-            // alphar and beta are complex and compatible with the W array 
+            // alphar and beta are complex and compatible with the W array
             memcpy(ptr_W, alphar, n*sizeof(T));
             ptr_W += n;
 
@@ -422,7 +421,7 @@ _eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm,
 ) {
     int info;
     if (ap_Bm == NULL) {
-        // sanity check: B and beta are either both NULL or both not NULL (for a generalized eig problem) 
+        // sanity check: B and beta are either both NULL or both not NULL (for a generalized eig problem)
         if (ap_beta != NULL) { return -222; }
 
         info = _reg_eig<T>(ap_Am, ap_w, ap_vl, ap_vr, overwrite_a, vec_status);

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -1,7 +1,6 @@
 /*
  * Templated loops for `linalg.inv`
  */
-#include "Python.h"
 #include <iostream>
 #include <vector>
 #include "numpy/arrayobject.h"

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -1,14 +1,7 @@
 /*
  * Templated loops for `linalg.inv`
  */
-#include <iostream>
-#include <vector>
-#include "numpy/arrayobject.h"
-#include "numpy/npy_math.h"
-#include "scipy_blas_defines.h"
-#include "_npymath.hh"
-#include "_common_array_utils.hh"
-
+#pragma once
 
 namespace sp_linalg {
 
@@ -89,7 +82,7 @@ void invert_slice_cholesky(
 template<typename T>
 void invert_slice_sym_herm(
     char uplo, CBLAS_INT N, T *data, CBLAS_INT *ipiv, T *work, void *irwork, CBLAS_INT lwork,
-    bool is_symm_not_herm, 
+    bool is_symm_not_herm,
     SliceStatus& status
 ) {
     using real_type = typename detail::type_traits<T>::real_type;
@@ -291,7 +284,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
     T *data=NULL, *scratch=NULL, *work=NULL;
     if (overwrite_a) {
-        // work in-place 
+        // work in-place
         data = ret_data;
         work = &buffer[0];
     }
@@ -509,4 +502,3 @@ free_exit:
 }
 
 } // namespace sp_linalg
-

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -1,6 +1,7 @@
 /*
- * Templated loops for linalg.lstsq
+ * Templated loops for `linalg.lstsq`
  */
+#pragma once
 
 namespace sp_linalg {
 

--- a/scipy/linalg/src/_linalg_lu_det.hh
+++ b/scipy/linalg/src/_linalg_lu_det.hh
@@ -1,8 +1,7 @@
+/*
+ * Templated loops for `linalg.lu` and `linalg.det`
+ */
 #pragma once
-#include <cstring>
-#include <cstdint>
-#include <type_traits>
-#include "scipy_blas_defines.h"
 
 namespace sp_linalg {
 

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -1,6 +1,7 @@
 /*
  * Templated loops for `linalg.qr`
  */
+#pragma once
 
 namespace sp_linalg {
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -1,7 +1,6 @@
 /*
  * Templated loops for `linalg.solve`
  */
-#include "Python.h"
 #include <iostream>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -1,13 +1,7 @@
 /*
  * Templated loops for `linalg.solve`
  */
-#include <iostream>
-#include "numpy/arrayobject.h"
-#include "numpy/npy_math.h"
-#include "scipy_blas_defines.h"
-#include "_npymath.hh"
-#include "_common_array_utils.hh"
-
+#pragma once
 
 namespace sp_linalg {
 
@@ -489,7 +483,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     CBLAS_INT buf_size_a = overwrite_a ? 0 : n*n;
     CBLAS_INT buf_size_b = overwrite_b ? 0 : n*nrhs;
     CBLAS_INT buf_size_trcon = 2*n; // // 2*n for tridiag trcon
-    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork; 
+    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork;
 
     T* buffer = (T *)malloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -1,21 +1,20 @@
+/*
+ * Templated loops for `linalg.svd`
+ */
 #pragma once
-#include "scipy_blas_defines.h"
-#include "_npymath.hh"
-#include "_common_array_utils.hh"
-
 
 namespace sp_linalg {
 
 /*
  * SVD size helper: if A.shape == (m, n),
  * U is either (m, m) or (m, k) and Vh is either (n, n) or (k, n)
- */ 
+ */
 int
 u_vh_shapes(npy_intp m, npy_intp n, char jobz,
             npy_intp *u_shape0, npy_intp *u_shape1,
             npy_intp *vh_shape0, npy_intp *vh_shape1
 ){
-    npy_intp k = m < n ? m : n; 
+    npy_intp k = m < n ? m : n;
 
     switch(jobz) {
         case('N') :
@@ -99,9 +98,9 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     /*
      * Allocate memory and chop the buffer into parts
      *
-     *    lwork     data_size         
+     *    lwork     data_size
      * |----------|-----------|----------|------|
-     * ^          ^           ^          ^      
+     * ^          ^           ^          ^
      * work       data        buf_U     buf_Vh
      *
      * Here
@@ -262,9 +261,9 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     /*
      * Allocate memory and chop the buffer into parts
      *
-     *    lwork     data_size         
+     *    lwork     data_size
      * |----------|-----------|----------|------|
-     * ^          ^           ^          ^      
+     * ^          ^           ^          ^
      * work       data        buf_U     buf_Vh
      *
      * Here

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -2,7 +2,6 @@
  * Helpers for dealing with npy_complex128/npy_complex64 types.
  */
 #pragma once
-#include "Python.h"
 #include <iostream>
 #include <complex>
 #include "numpy/npy_math.h"

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -2,10 +2,6 @@
  * Helpers for dealing with npy_complex128/npy_complex64 types.
  */
 #pragma once
-#include <iostream>
-#include <complex>
-#include "numpy/npy_math.h"
-
 
 namespace sp_linalg {
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

triggered by https://github.com/scipy/scipy/issues/25648#issuecomment-5083241993

#### What does this implement/fix?
<!--Please explain your changes.-->

Pure maintenance: Include `Python.h` once, before any other includes, and remove the includes from individual header files.

The net effect is to make `_linalg_inv.hh` look similar to `_linalg_qr.hh` : either both include Python.h or neither does.
Since all these `_linalg_*.hh` headers are only included in `_batched_linalg.cc`, it's cleaner to add the include to the latter and remove from the former.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.
