### PR TITLE
MAINT: integrate: propagate the input device in array creation

### DIFF
--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from scipy._lib._array_api import (
     array_namespace,
+    xp_device,
     xp_size,
     xp_copy,
     xp_promote,
@@ -661,7 +662,8 @@ class _InfiniteLimitsTransform(_VariableTransform):
         # class, then without this condition the initial region of integration will
         # be split around the origin unnecessarily.
         if self._num_inf != 0:
-            return [self._xp.zeros(self._orig_a.shape)]
+            return [self._xp.zeros(self._orig_a.shape,
+                                   device=xp_device(self._orig_a))]
         else:
             return []
 

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -342,14 +342,14 @@ def cubature(f, a, b, *, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
         ndim = xp_size(a)
 
         if rule == "genz-malik":
-            rule = GenzMalikCubature(ndim, xp=xp)
+            rule = GenzMalikCubature(ndim)
         else:
             quadratues = {
-                "gauss-kronrod": GaussKronrodQuadrature(21, xp=xp),
+                "gauss-kronrod": GaussKronrodQuadrature(21),
 
                 # Also allow names quad_vec uses:
-                "gk21": GaussKronrodQuadrature(21, xp=xp),
-                "gk15": GaussKronrodQuadrature(15, xp=xp),
+                "gk21": GaussKronrodQuadrature(21),
+                "gk15": GaussKronrodQuadrature(15),
             }
 
             base_rule = quadratues.get(rule)

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -8,7 +8,7 @@ from scipy.special import gammaln, logsumexp
 from scipy._lib._util import _rng_spawn
 from scipy._lib._array_api import (_asarray, array_namespace, xp_result_type, xp_copy,
                                    xp_capabilities, xp_promote, xp_swapaxes, is_numpy,
-                                   xp_size,
+                                   xp_size, xp_device,
                                    is_lazy_array)
 import scipy._external.array_api_extra as xpx
 
@@ -241,7 +241,9 @@ def fixed_quad(func, a, b, args=(), n=5):
     xp = array_namespace(a, b)
     a, b = xp_promote(a, b, force_floating=True, xp=xp)
     x, w = _cached_roots_legendre(n)
-    x, w = xp.asarray(x, dtype=a.dtype), xp.asarray(w, dtype=a.dtype)
+    device = xp_device(a)
+    x = xp.asarray(x, dtype=a.dtype, device=device)
+    w = xp.asarray(w, dtype=a.dtype, device=device)
     x = xp.real(x)
     if not is_lazy_array(a) and (xp.isinf(a) or xp.isinf(b)):
         raise ValueError("Gaussian quadrature is only available for "
@@ -347,7 +349,8 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
         shape = list(res.shape)
         shape[axis] = 1
-        res = xp.concat((xp.full(tuple(shape), initial, dtype=res.dtype), res),
+        res = xp.concat((xp.full(tuple(shape), initial, dtype=res.dtype,
+                                 device=xp_device(res)), res),
                         axis=axis)
 
     return res
@@ -540,7 +543,7 @@ def _cumulatively_sum_simpson_integrals(y, dx, integration_func, xp):
 
     shape = list(sub_integrals_h1.shape)
     shape[-1] += 1
-    sub_integrals = xp.empty(shape, dtype=xp.result_type(y, dx))
+    sub_integrals = xp.empty(shape, dtype=xp.result_type(y, dx), device=xp_device(y))
     sub_integrals = xpx.at(sub_integrals)[..., :-1:2].set(sub_integrals_h1[..., ::2])
     sub_integrals = xpx.at(sub_integrals)[..., 1::2].set(sub_integrals_h2[..., ::2])
     # Integral over last subinterval can only be calculated from
@@ -744,7 +747,10 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         )
 
     else:
-        dx = xp_promote(xp.asarray(dx), force_floating=True, xp=xp)
+        # `dx` is a scalar on the default device; place it on the input's device
+        # so it does not clash with `y` downstream (see gh-22680).
+        dx = xp.asarray(dx, device=xp_device(y))
+        dx = xp_promote(dx, force_floating=True, xp=xp)
         final_dx_shape = tupleset(original_shape, axis, original_shape[axis] - 1)
         alt_input_dx_shape = tupleset(original_shape, axis, 1)
         message = ("If provided, `dx` must either be a scalar or have the same "
@@ -758,6 +764,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         )
 
     if initial is not None:
+        initial = xp.asarray(initial, device=xp_device(y))
         initial = xp_promote(initial, force_floating=True, xp=xp)
         alt_initial_input_shape = tupleset(original_shape, axis, 1)
         message = ("If provided, `initial` must either be a scalar or have the "
@@ -853,7 +860,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
     slice_all = (slice(None),) * nd
     slice0 = tupleset(slice_all, axis, 0)
     slicem1 = tupleset(slice_all, axis, -1)
-    h = Ninterv * xp.asarray(dx, dtype=xp.float64)
+    h = Ninterv * xp.asarray(dx, dtype=xp.float64, device=xp_device(y))
     R[(0, 0)] = (y[slice0] + y[slicem1])/2.0*h
     slice_R = slice_all
     start = stop = step = Ninterv
@@ -1306,8 +1313,8 @@ def qmc_quad(func, a, b, *, n_estimates=8, n_points=1024, qrng=None,
         message = ("A lower limit was equal to an upper limit, so the value "
                    "of the integral is zero by definition.")
         warnings.warn(message, stacklevel=2)
-        zero = xp.asarray(-xp.inf if log else 0, dtype=a.dtype)
-        return QMCQuadResult(zero, xp.asarray(0., dtype=a.dtype))
+        zero = xp.asarray(-xp.inf if log else 0, dtype=a.dtype, device=xp_device(a))
+        return QMCQuadResult(zero, xp.asarray(0., dtype=a.dtype, device=xp_device(a)))
 
     i_swap = b < a
     sign = (-1)**(xp.count_nonzero(i_swap, axis=-1))  # odd # of swaps -> negative
@@ -1321,11 +1328,12 @@ def qmc_quad(func, a, b, *, n_estimates=8, n_points=1024, qrng=None,
     A = xp.prod(b - a)
     dA = A / n_points
 
-    estimates = xp.zeros(n_estimates, dtype=a.dtype)
+    device = xp_device(a)
+    estimates = xp.zeros(n_estimates, dtype=a.dtype, device=device)
     rngs = _rng_spawn(qrng.rng, n_estimates)
     for i in range(n_estimates):
         # Generate integral estimate
-        sample = xp.asarray(qrng.random(n_points), dtype=a.dtype)
+        sample = xp.asarray(qrng.random(n_points), dtype=a.dtype, device=device)
         # The rationale for transposing is that this allows users to easily
         # unpack `x` into separate variables, if desired. This is consistent
         # with the `xx` array passed into the `scipy.integrate.nquad` `func`.

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -1,4 +1,4 @@
-from scipy._lib._array_api import array_namespace, xp_size
+from scipy._lib._array_api import array_namespace, xp_size, xp_device
 
 from functools import cached_property
 
@@ -236,10 +236,14 @@ class FixedRule(Rule):
         """
         nodes, weights = self.nodes_and_weights
 
+        # nodes/weights are NumPy host data; see `_cached_cast` for details
+        xp = array_namespace(a)
         if self.xp is None:
-            self.xp = array_namespace(nodes)
+            self.xp = xp
 
-        return _apply_fixed_rule(f, a, b, nodes, weights, args, self.xp)
+        nodes, weights = _cached_cast(self, "_nw_cache", nodes, weights,
+                                      a.dtype, xp_device(a), xp)
+        return _apply_fixed_rule(f, a, b, nodes, weights, args, xp)
 
 
 class NestedFixedRule(FixedRule):
@@ -338,14 +342,21 @@ class NestedFixedRule(FixedRule):
         nodes, weights = self.nodes_and_weights
         lower_nodes, lower_weights = self.lower_nodes_and_weights
 
+        xp = array_namespace(a)
         if self.xp is None:
-            self.xp = array_namespace(nodes)
+            self.xp = xp
 
-        error_nodes = self.xp.concat([nodes, lower_nodes], axis=0)
-        error_weights = self.xp.concat([weights, -lower_weights], axis=0)
+        # combine the constants in their own (host) namespace before the
+        # conversion onto `a`'s namespace; see `_cached_cast` for details
+        nodes_xp = array_namespace(nodes)
+        error_nodes = nodes_xp.concat([nodes, lower_nodes], axis=0)
+        error_weights = nodes_xp.concat([weights, -lower_weights], axis=0)
+        error_nodes, error_weights = _cached_cast(
+            self, "_error_nw_cache", error_nodes, error_weights,
+            a.dtype, xp_device(a), xp)
 
-        return self.xp.abs(
-            _apply_fixed_rule(f, a, b, error_nodes, error_weights, args, self.xp)
+        return xp.abs(
+            _apply_fixed_rule(f, a, b, error_nodes, error_weights, args, xp)
         )
 
 
@@ -473,11 +484,40 @@ def _split_subregion(a, b, xp, split_at=None):
         yield a_sub[i, ...], b_sub[i, ...]
 
 
+def _cached_cast(rule, attr, nodes, weights, dtype, device, xp):
+    """Convert a rule's nodes/weights onto ``(xp, dtype, device)``, memoized.
+
+    The built-in fixed rules keep their nodes and weights as NumPy *host*
+    arrays: a rule object is constructed once, independently of any integrand,
+    so at construction time there is no array whose namespace or device could
+    be matched -- ``xp`` arrays built there would land on the backend's
+    default device and get baked into the rule, forcing estimates with
+    integrand arrays on another device to either raise or silently transfer
+    (see gh-22680). Host data keeps construction backend- and device-neutral.
+
+    The target namespace, dtype and device only become known at apply time,
+    from the actual integration limits; this helper performs the conversion
+    there and memoizes the result on the rule (keyed on the full target
+    triple), so the adaptive cubature loop does not re-cast -- or re-transfer,
+    for non-default devices -- the constants for every subregion.
+    """
+    cache = getattr(rule, attr, None)
+    if cache is None or cache[:3] != (xp, dtype, device):
+        nodes = xp.asarray(nodes, dtype=dtype, device=device)
+        weights = xp.asarray(weights, dtype=dtype, device=device)
+        cache = (xp, dtype, device, nodes, weights)
+        setattr(rule, attr, cache)
+    return cache[3], cache[4]
+
+
 def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args, xp):
-    # Downcast nodes and weights to common dtype of a and b
+    # Convert nodes/weights onto `a`'s dtype and device (see `_cached_cast`
+    # for details); a no-op when already converted, as when called via
+    # `FixedRule.estimate`/`NestedFixedRule.estimate_error`.
     result_dtype = a.dtype
-    orig_nodes = xp.astype(orig_nodes, result_dtype)
-    orig_weights = xp.astype(orig_weights, result_dtype)
+    device = xp_device(a)
+    orig_nodes = xp.asarray(orig_nodes, dtype=result_dtype, device=device)
+    orig_weights = xp.asarray(orig_weights, dtype=result_dtype, device=device)
 
     # Ensure orig_nodes are at least 2D, since 1D cubature methods can return arrays of
     # shape (npoints,) rather than (npoints, 1)

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -148,7 +148,9 @@ class Rule:
         for a_k, b_k in _split_subregion(a, b):
             refined_est += self.estimate(f, a_k, b_k, args)
 
-        return self.xp.abs(est - refined_est)
+        # rules carry no namespace state; resolve locally from the estimate
+        xp = array_namespace(est)
+        return xp.abs(est - refined_est)
 
 
 class FixedRule(Rule):
@@ -190,9 +192,6 @@ class FixedRule(Rule):
     ... )
      [0.3333333]
     """
-
-    def __init__(self):
-        self.xp = None
 
     @property
     def nodes_and_weights(self):
@@ -238,9 +237,6 @@ class FixedRule(Rule):
 
         # nodes/weights are NumPy host data; see `_cached_cast` for details
         xp = array_namespace(a)
-        if self.xp is None:
-            self.xp = xp
-
         nodes, weights = _cached_cast(self, "_nw_cache", nodes, weights,
                                       a.dtype, xp_device(a), xp)
         return _apply_fixed_rule(f, a, b, nodes, weights, args, xp)
@@ -289,7 +285,6 @@ class NestedFixedRule(FixedRule):
     def __init__(self, higher, lower):
         self.higher = higher
         self.lower = lower
-        self.xp = None
 
     @property
     def nodes_and_weights(self):
@@ -343,8 +338,6 @@ class NestedFixedRule(FixedRule):
         lower_nodes, lower_weights = self.lower_nodes_and_weights
 
         xp = array_namespace(a)
-        if self.xp is None:
-            self.xp = xp
 
         # combine the constants in their own (host) namespace before the
         # conversion onto `a`'s namespace; see `_cached_cast` for details
@@ -411,7 +404,6 @@ class ProductNestedFixed(NestedFixedRule):
                                  "NestedFixedRule")
 
         self.base_rules = base_rules
-        self.xp = None
 
     @cached_property
     def nodes_and_weights(self):
@@ -419,10 +411,8 @@ class ProductNestedFixed(NestedFixedRule):
             [rule.nodes_and_weights[0] for rule in self.base_rules]
         )
 
-        if self.xp is None:
-            self.xp = array_namespace(nodes)
-
-        weights = self.xp.prod(
+        xp = array_namespace(nodes)
+        weights = xp.prod(
             _cartesian_product(
                 [rule.nodes_and_weights[1] for rule in self.base_rules]
             ),
@@ -437,10 +427,8 @@ class ProductNestedFixed(NestedFixedRule):
             [cubature.lower_nodes_and_weights[0] for cubature in self.base_rules]
         )
 
-        if self.xp is None:
-            self.xp = array_namespace(nodes)
-
-        weights = self.xp.prod(
+        xp = array_namespace(nodes)
+        weights = xp.prod(
             _cartesian_product(
                 [cubature.lower_nodes_and_weights[1] for cubature in self.base_rules]
             ),

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,4 +1,6 @@
-from scipy._lib._array_api import np_compat, array_namespace
+import numpy as np
+
+from scipy._lib._array_api import xp_compat_namespace
 
 from functools import cached_property
 
@@ -88,18 +90,16 @@ class GaussKronrodQuadrature(NestedFixedRule):
 
         self.npoints = npoints
 
-        if xp is None:
-            xp = np_compat
-
-        self.xp = array_namespace(xp.empty(0))
+        self.xp = xp_compat_namespace(xp)
 
         self.gauss = GaussLegendreQuadrature(npoints//2, xp=self.xp)
 
     @cached_property
     def nodes_and_weights(self):
-        # These values are from QUADPACK's `dqk21.f` and `dqk15.f` (1983).
+        # These values are from QUADPACK's `dqk21.f` and `dqk15.f` (1983),
+        # as NumPy host data; see `_cached_cast` for details.
         if self.npoints == 21:
-            nodes = self.xp.asarray(
+            nodes = np.asarray(
                 [
                     0.995657163025808080735527280689003,
                     0.973906528517171720077964012084452,
@@ -123,10 +123,10 @@ class GaussKronrodQuadrature(NestedFixedRule):
                     -0.973906528517171720077964012084452,
                     -0.995657163025808080735527280689003,
                 ],
-                dtype=self.xp.float64,
+                dtype=np.float64,
             )
 
-            weights = self.xp.asarray(
+            weights = np.asarray(
                 [
                     0.011694638867371874278064396062192,
                     0.032558162307964727478818972459390,
@@ -150,10 +150,10 @@ class GaussKronrodQuadrature(NestedFixedRule):
                     0.032558162307964727478818972459390,
                     0.011694638867371874278064396062192,
                 ],
-                dtype=self.xp.float64,
+                dtype=np.float64,
             )
         elif self.npoints == 15:
-            nodes = self.xp.asarray(
+            nodes = np.asarray(
                 [
                     0.991455371120812639206854697526329,
                     0.949107912342758524526189684047851,
@@ -171,10 +171,10 @@ class GaussKronrodQuadrature(NestedFixedRule):
                     -0.949107912342758524526189684047851,
                     -0.991455371120812639206854697526329,
                 ],
-                dtype=self.xp.float64,
+                dtype=np.float64,
             )
 
-            weights = self.xp.asarray(
+            weights = np.asarray(
                 [
                     0.022935322010529224963732008058970,
                     0.063092092629978553290700663189204,
@@ -192,7 +192,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
                     0.063092092629978553290700663189204,
                     0.022935322010529224963732008058970,
                 ],
-                dtype=self.xp.float64,
+                dtype=np.float64,
             )
 
         return nodes, weights

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from scipy._lib._array_api import xp_compat_namespace
 
 from functools import cached_property
 
@@ -28,10 +27,6 @@ class GaussKronrodQuadrature(NestedFixedRule):
     ----------
     npoints : int
         Number of nodes for the higher-order rule.
-
-    xp : array_namespace, optional
-        The namespace for the node and weight arrays. Default is None, where NumPy is
-        used.
 
     Attributes
     ----------
@@ -81,7 +76,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
      np.float64(2.220446049250313e-16)
     """
 
-    def __init__(self, npoints, xp=None):
+    def __init__(self, npoints):
         # TODO: nodes and weights are currently hard-coded for values 15 and 21, but in
         # the future it would be best to compute the Kronrod extension of the lower rule
         if npoints != 15 and npoints != 21:
@@ -90,9 +85,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
 
         self.npoints = npoints
 
-        self.xp = xp_compat_namespace(xp)
-
-        self.gauss = GaussLegendreQuadrature(npoints//2, xp=self.xp)
+        self.gauss = GaussLegendreQuadrature(npoints//2)
 
     @cached_property
     def nodes_and_weights(self):

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,4 +1,6 @@
-from scipy._lib._array_api import array_namespace, np_compat
+import numpy as np
+
+from scipy._lib._array_api import xp_compat_namespace
 
 from functools import cached_property
 
@@ -46,17 +48,14 @@ class GaussLegendreQuadrature(FixedRule):
 
         self.npoints = npoints
 
-        if xp is None:
-            xp = np_compat
-
-        self.xp = array_namespace(xp.empty(0))
+        self.xp = xp_compat_namespace(xp)
 
     @cached_property
     def nodes_and_weights(self):
-        # TODO: current converting to/from numpy
+        # constants as NumPy host data; see `_cached_cast` for details
         nodes, weights = roots_legendre(self.npoints)
 
         return (
-            self.xp.asarray(nodes, dtype=self.xp.float64),
-            self.xp.asarray(weights, dtype=self.xp.float64)
+            np.asarray(nodes, dtype=np.float64),
+            np.asarray(weights, dtype=np.float64),
         )

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from scipy._lib._array_api import xp_compat_namespace
 
 from functools import cached_property
 
@@ -17,10 +16,6 @@ class GaussLegendreQuadrature(FixedRule):
     ----------
     npoints : int
         Number of nodes for the higher-order rule.
-
-    xp : array_namespace, optional
-        The namespace for the node and weight arrays. Default is None, where NumPy is
-        used.
 
     Examples
     --------
@@ -40,15 +35,13 @@ class GaussLegendreQuadrature(FixedRule):
      array([1.11022302e-16])
     """
 
-    def __init__(self, npoints, xp=None):
+    def __init__(self, npoints):
         if npoints < 2:
             raise ValueError(
                 "At least 2 nodes required for Gauss-Legendre cubature"
             )
 
         self.npoints = npoints
-
-        self.xp = xp_compat_namespace(xp)
 
     @cached_property
     def nodes_and_weights(self):

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from functools import cached_property
 
-from scipy._lib._array_api import xp_compat_namespace
 
 from scipy.integrate._rules import NestedFixedRule
 
@@ -20,10 +19,6 @@ class GenzMalikCubature(NestedFixedRule):
     ----------
     ndim : int
         The spatial dimension of the integrand.
-
-    xp : array_namespace, optional
-        The namespace for the node and weight arrays. Default is None, where NumPy is
-        used.
 
     Attributes
     ----------
@@ -58,7 +53,7 @@ class GenzMalikCubature(NestedFixedRule):
      np.float64(1.378269656626685e-06)
     """
 
-    def __init__(self, ndim, degree=7, lower_degree=5, xp=None):
+    def __init__(self, ndim, degree=7, lower_degree=5):
         if ndim < 2:
             raise ValueError("Genz-Malik cubature is only defined for ndim >= 2")
 
@@ -69,8 +64,6 @@ class GenzMalikCubature(NestedFixedRule):
         self.ndim = ndim
         self.degree = degree
         self.lower_degree = lower_degree
-
-        self.xp = xp_compat_namespace(xp)
 
     @cached_property
     def nodes_and_weights(self):

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -1,9 +1,11 @@
 import math
 import itertools
 
+import numpy as np
+
 from functools import cached_property
 
-from scipy._lib._array_api import array_namespace, np_compat
+from scipy._lib._array_api import xp_compat_namespace
 
 from scipy.integrate._rules import NestedFixedRule
 
@@ -68,10 +70,7 @@ class GenzMalikCubature(NestedFixedRule):
         self.degree = degree
         self.lower_degree = lower_degree
 
-        if xp is None:
-            xp = np_compat
-
-        self.xp = array_namespace(xp.empty(0))
+        self.xp = xp_compat_namespace(xp)
 
     @cached_property
     def nodes_and_weights(self):
@@ -96,12 +95,12 @@ class GenzMalikCubature(NestedFixedRule):
 
         nodes_size = 1 + (2 * (self.ndim + 1) * self.ndim) + 2**self.ndim
 
-        nodes = self.xp.asarray(
+        nodes = np.asarray(
             list(zip(*its)),
-            dtype=self.xp.float64,
+            dtype=np.float64,
         )
 
-        nodes = self.xp.reshape(nodes, (self.ndim, nodes_size))
+        nodes = np.reshape(nodes, (self.ndim, nodes_size))
 
         # It's convenient to generate the nodes as a sequence of evaluation points
         # as an array of shape (npoints, ndim), but nodes needs to have shape
@@ -116,15 +115,15 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = self.xp.concat([
-            self.xp.asarray([w_1] * 1, dtype=self.xp.float64),
-            self.xp.asarray([w_2] * (2 * self.ndim), dtype=self.xp.float64),
-            self.xp.asarray([w_3] * (2 * self.ndim), dtype=self.xp.float64),
-            self.xp.asarray(
+        weights = np.concatenate([
+            np.asarray([w_1] * 1, dtype=np.float64),
+            np.asarray([w_2] * (2 * self.ndim), dtype=np.float64),
+            np.asarray([w_3] * (2 * self.ndim), dtype=np.float64),
+            np.asarray(
                 [w_4] * (2 * (self.ndim - 1) * self.ndim),
-                dtype=self.xp.float64,
+                dtype=np.float64,
             ),
-            self.xp.asarray([w_5] * (2**self.ndim), dtype=self.xp.float64),
+            np.asarray([w_5] * (2**self.ndim), dtype=np.float64),
         ])
 
         return nodes, weights
@@ -153,8 +152,8 @@ class GenzMalikCubature(NestedFixedRule):
 
         nodes_size = 1 + (2 * (self.ndim + 1) * self.ndim)
 
-        nodes = self.xp.asarray(list(zip(*its)), dtype=self.xp.float64)
-        nodes = self.xp.reshape(nodes, (self.ndim, nodes_size))
+        nodes = np.asarray(list(zip(*its)), dtype=np.float64)
+        nodes = np.reshape(nodes, (self.ndim, nodes_size))
         nodes = nodes.T
 
         # Weights are different from those in the full rule.
@@ -163,13 +162,13 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = self.xp.concat([
-            self.xp.asarray([w_1] * 1, dtype=self.xp.float64),
-            self.xp.asarray([w_2] * (2 * self.ndim), dtype=self.xp.float64),
-            self.xp.asarray([w_3] * (2 * self.ndim), dtype=self.xp.float64),
-            self.xp.asarray(
+        weights = np.concatenate([
+            np.asarray([w_1] * 1, dtype=np.float64),
+            np.asarray([w_2] * (2 * self.ndim), dtype=np.float64),
+            np.asarray([w_3] * (2 * self.ndim), dtype=np.float64),
+            np.asarray(
                 [w_4] * (2 * (self.ndim - 1) * self.ndim),
-                dtype=self.xp.float64,
+                dtype=np.float64,
             ),
         ])
 

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -4,7 +4,7 @@ from scipy import special
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
 from scipy._lib._array_api import (array_namespace, xp_copy, xp_ravel,
-                                   xp_promote, xp_capabilities)
+                                   xp_promote, xp_capabilities, xp_device)
 
 
 __all__ = ['nsum']
@@ -353,30 +353,34 @@ def tanhsinh(f, a, b, *, args=(), kwargs=None, log=False, maxlevel=None, minleve
     # Define variables we'll need
     nit, nfev = 0, 1  # one function evaluation performed above
     zero = -xp.inf if log else 0
-    pi = xp.asarray(xp.pi, dtype=dtype)[()]
+    device = xp_device(a)
+    pi = xp.asarray(xp.pi, dtype=dtype, device=device)[()]
     maxiter = maxlevel - minlevel + 1
     eps = xp.finfo(dtype).eps
     if rtol is None:
         rtol = 0.75*math.log(eps) if log else eps**0.75
 
-    Sn = xp_ravel(xp.full(shape, zero, dtype=dtype))  # latest integral estimate
+    # latest integral estimate
+    Sn = xp_ravel(xp.full(shape, zero, dtype=dtype, device=device))
     Sn[xp.isnan(a) | xp.isnan(b) | xp.isnan(fs[0])] = xp.nan
     Sk = xp.reshape(xp.empty_like(Sn), (-1, 1))[:, 0:0]  # all integral estimates
-    aerr = xp_ravel(xp.full(shape, xp.nan, dtype=dtype))  # absolute error
-    status = xp_ravel(xp.full(shape, eim._EINPROGRESS, dtype=xp.int32))
-    h0 = _get_base_step(dtype, xp)
+    aerr = xp_ravel(xp.full(shape, xp.nan, dtype=dtype,  # absolute error
+                            device=device))
+    status = xp_ravel(xp.full(shape, eim._EINPROGRESS, dtype=xp.int32,
+                              device=device))
+    h0 = _get_base_step(dtype, xp, device=device)
     h0 = xp.real(h0) # base step
 
     # For term `d4` of error estimate ([1] Section 5), we need to keep the
     # most extreme abscissae and corresponding `fj`s, `wj`s in Euler-Maclaurin
     # sum. Here, we initialize these variables.
-    xr0 = xp_ravel(xp.full(shape, -xp.inf, dtype=dtype))
-    fr0 = xp_ravel(xp.full(shape, xp.nan, dtype=dtype))
-    wr0 = xp_ravel(xp.zeros(shape, dtype=dtype))
-    xl0 = xp_ravel(xp.full(shape, xp.inf, dtype=dtype))
-    fl0 = xp_ravel(xp.full(shape, xp.nan, dtype=dtype))
-    wl0 = xp_ravel(xp.zeros(shape, dtype=dtype))
-    d4 = xp_ravel(xp.zeros(shape, dtype=dtype))
+    xr0 = xp_ravel(xp.full(shape, -xp.inf, dtype=dtype, device=device))
+    fr0 = xp_ravel(xp.full(shape, xp.nan, dtype=dtype, device=device))
+    wr0 = xp_ravel(xp.zeros(shape, dtype=dtype, device=device))
+    xl0 = xp_ravel(xp.full(shape, xp.inf, dtype=dtype, device=device))
+    fl0 = xp_ravel(xp.full(shape, xp.nan, dtype=dtype, device=device))
+    wl0 = xp_ravel(xp.zeros(shape, dtype=dtype, device=device))
+    d4 = xp_ravel(xp.zeros(shape, dtype=dtype, device=device))
 
     work = _RichResult(
         Sn=Sn, Sk=Sk, aerr=aerr, h=h0, log=log, dtype=dtype, pi=pi, eps=eps,
@@ -432,13 +436,13 @@ def tanhsinh(f, a, b, *, args=(), kwargs=None, log=False, maxlevel=None, minleve
 
     def check_termination(work):
         """Terminate due to convergence or encountering non-finite values"""
-        stop = xp.zeros(work.Sn.shape, dtype=bool)
+        stop = xp.zeros(work.Sn.shape, dtype=bool, device=xp_device(work.Sn))
 
         # Terminate before first iteration if integration limits are equal
         if work.nit == 0:
             i = xp_ravel(work.a == work.b)  # ravel singleton dimension
-            zero = xp.asarray(-xp.inf if log else 0.)
-            zero = xp.full(work.Sn.shape, zero, dtype=Sn.dtype)
+            zero = xp.full(work.Sn.shape, -xp.inf if log else 0., dtype=Sn.dtype,
+                           device=xp_device(work.Sn))
             zero[xp.isnan(Sn)] = xp.nan
             work.Sn[i] = zero[i]
             work.aerr[i] = zero[i]
@@ -493,7 +497,7 @@ def tanhsinh(f, a, b, *, args=(), kwargs=None, log=False, maxlevel=None, minleve
     return res
 
 
-def _get_base_step(dtype, xp):
+def _get_base_step(dtype, xp, device=None):
     # Compute the base step length for the provided dtype. Theoretically, the
     # Euler-Maclaurin sum is infinite, but it gets cut off when either the
     # weights underflow or the abscissae cannot be distinguished from the
@@ -512,7 +516,7 @@ def _get_base_step(dtype, xp):
     # results in a base step size close to `1`, which is what [1] uses (and I
     # used here until I found [2] and these ideas settled).
     h0 = tmax / _N_BASE_STEPS
-    return xp.asarray(h0, dtype=dtype)[()]
+    return xp.asarray(h0, dtype=dtype, device=device)[()]
 
 
 _N_BASE_STEPS = 8
@@ -534,7 +538,12 @@ def _compute_pair(k, h0, xp):
 
     # For iterations after the first, "....the integrand function needs to be
     # evaluated only at the odd-indexed abscissas at each level."
-    j = xp.arange(max+1) if k == 0 else xp.arange(1, max+1, 2)
+    # Float `j` so that `j * h` is a legal promotion under the array API standard;
+    # `j` isn't used elsewhere and promotion would otherwise be implicit.
+    if k == 0:
+        j = xp.arange(max+1, dtype=h.dtype, device=xp_device(h0))
+    else:
+        j = xp.arange(1, max+1, 2, dtype=h.dtype, device=xp_device(h0))
     jh = j * h
 
     # "In this case... the weights wj = u1/cosh(u2)^2, where..."
@@ -560,8 +569,8 @@ def _pair_cache(k, h0, xp, work):
     # `index` records the indices that correspond with each level:
     # `xjc[index[k]:index[k+1]` extracts the level `k` abscissae.
     if not isinstance(h0, type(work.pair_cache.h0)) or h0 != work.pair_cache.h0:
-        work.pair_cache.xjc = xp.empty(0)
-        work.pair_cache.wj = xp.empty(0)
+        work.pair_cache.xjc = xp.empty(0, device=xp_device(h0))
+        work.pair_cache.wj = xp.empty(0, device=xp_device(h0))
         work.pair_cache.indices = [0]
 
     xjcs = [work.pair_cache.xjc]
@@ -758,7 +767,7 @@ def _estimate_error(work, xp):
     Snm2 = work.Sk[..., -2]
     Snm1 = work.Sk[..., -1]
 
-    e1 = xp.asarray(work.eps)[()]
+    e1 = xp.asarray(work.eps, device=xp_device(work.Sn))[()]
 
     if work.log:
         log_e1 = xp.log(e1)
@@ -1180,8 +1189,8 @@ def nsum(f, a, b, *, step=1, args=(), kwargs=None,
     # Prepare result arrays
     S = xp.empty_like(a)
     E = xp.empty_like(a)
-    status = xp.zeros(len(a), dtype=xp.int32)
-    nfev = xp.ones(len(a), dtype=xp.int32)  # one function evaluation above
+    status = xp.zeros(len(a), dtype=xp.int32, device=xp_device(a))
+    nfev = xp.ones(len(a), dtype=xp.int32, device=xp_device(a))  # one func eval above
 
     # Branch for direct sum evaluation / integral approximation / invalid input
     i0 = ~valid_abstep                     # invalid
@@ -1288,7 +1297,7 @@ def _direct(f, a, b, step, args, constants, xp, inclusive=True):
     # elementwise algorithms.
     a2, b2, step2 = a[:, xp.newaxis], b[:, xp.newaxis], step[:, xp.newaxis]
     args2 = [arg[:, xp.newaxis] for arg in args]
-    ks = a2 + xp.arange(max_steps, dtype=dtype) * step2
+    ks = a2 + xp.arange(max_steps, dtype=dtype, device=xp_device(a)) * step2
     i_nan = ks >= (b2 + inclusive_adjustment*step2/2)
     ks[i_nan] = xp.nan
     fs = f(ks, *args2)
@@ -1307,11 +1316,12 @@ def _direct(f, a, b, step, args, constants, xp, inclusive=True):
 def _integral_bound(f, a, b, step, args, constants, xp):
     # Estimate the sum with integral approximation
     dtype, log, _, _, rtol, atol, maxterms = constants
-    log2 = xp.asarray(math.log(2), dtype=dtype)
+    device = xp_device(a)
+    log2 = xp.asarray(math.log(2), dtype=dtype, device=device)
 
     # Get a lower bound on the sum and compute effective absolute tolerance
     lb = tanhsinh(f, a, b, args=args, atol=atol, rtol=rtol, log=log)
-    tol = xp.broadcast_to(xp.asarray(atol), lb.integral.shape)
+    tol = xp.broadcast_to(xp.asarray(atol, device=device), lb.integral.shape)
     if log:
         tol = special.logsumexp(xp.stack((tol, rtol + lb.integral)), axis=0)
     else:
@@ -1329,7 +1339,8 @@ def _integral_bound(f, a, b, step, args, constants, xp):
 
     # Find the location of a term that is less than the tolerance (if possible)
     log2maxterms = math.floor(math.log2(maxterms)) if maxterms else 0
-    n_steps = xp.concat((2**xp.arange(0, log2maxterms), xp.asarray([maxterms])))
+    n_steps = xp.concat((2**xp.arange(0, log2maxterms, device=xp_device(a)),
+                         xp.asarray([maxterms], device=xp_device(a))))
     n_steps = xp.astype(n_steps, dtype)
     nfev = len(n_steps) * 2
     ks = a2 + n_steps * step2
@@ -1365,7 +1376,7 @@ def _integral_bound(f, a, b, step, args, constants, xp):
     right = tanhsinh(f, k, b, args=args, atol=atol, rtol=rtol, log=log)
 
     # Calculate the full estimate and error from the pieces
-    fk = fks[xp.arange(len(fks)), nt]
+    fk = fks[xp.arange(len(fks), device=xp_device(a)), nt]
 
     # fb = f(b, *args), but some functions return NaN at infinity.
     # instead of 0 like they must (for the sum to be convergent).

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -7,6 +7,7 @@ import pytest
 from scipy._lib._array_api import (
     array_namespace,
     xp_assert_close,
+    xp_device,
     xp_size,
     np_compat,
     is_array_api_strict,
@@ -1375,4 +1376,4 @@ class BadErrorRule(Rule):
 
     def estimate_error(self, f, a, b, args=()):
         xp = array_namespace(a, b)
-        return xp.asarray(1e6, dtype=xp.float64)
+        return xp.asarray(1e6, dtype=xp.float64, device=xp_device(a))

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1215,7 +1215,7 @@ class TestRules:
     ])
     def test_incompatible_dimension_raises_error(self, problem, xp):
         a, b, quadrature, quadrature_args = problem
-        rule = quadrature(*quadrature_args, xp=xp)
+        rule = quadrature(*quadrature_args)
 
         a = xp.asarray(a, dtype=xp.float64)
         b = xp.asarray(b, dtype=xp.float64)
@@ -1246,7 +1246,7 @@ class TestRulesQuadrature:
         (GaussKronrodQuadrature, (21,)),
     ])
     def test_base_1d_quadratures_simple(self, rule, rule_args, xp):
-        quadrature = rule(*rule_args, xp=xp)
+        quadrature = rule(*rule_args)
 
         n = xp.arange(5, dtype=xp.float64)
 
@@ -1278,8 +1278,8 @@ class TestRulesQuadrature:
         a = xp.asarray([0], dtype=xp.float64)
         b = xp.asarray([2], dtype=xp.float64)
 
-        higher = rule_pair[0](rule_pair_args[0], xp=xp)
-        lower = rule_pair[1](rule_pair_args[1], xp=xp)
+        higher = rule_pair[0](rule_pair_args[0])
+        lower = rule_pair[1](rule_pair_args[1])
 
         rule = NestedFixedRule(higher, lower)
         res = cubature(
@@ -1302,7 +1302,7 @@ class TestRulesQuadrature:
     ])
     def test_one_point_fixed_quad_impossible(self, quadrature, xp):
         with pytest.raises(Exception):
-            quadrature(1, xp=xp)
+            quadrature(1)
 
 
 @pytest.mark.uses_xp_capabilities(False, reason="private")
@@ -1318,13 +1318,13 @@ class TestRulesCubature:
         matches the number in Genz and Malik 1980.
         """
 
-        nodes, _ = GenzMalikCubature(ndim, xp=xp).nodes_and_weights
+        nodes, _ = GenzMalikCubature(ndim).nodes_and_weights
 
         assert nodes.shape[0] == (2**ndim) + 2*ndim**2 + 2*ndim + 1
 
     def test_genz_malik_1d_raises_error(self, xp):
         with pytest.raises(Exception, match="only defined for ndim >= 2"):
-            GenzMalikCubature(1, xp=xp)
+            GenzMalikCubature(1)
 
 
 @pytest.mark.skip_xp_backends('dask.array', reason=boolean_index_skip_reason)
@@ -1370,7 +1370,7 @@ class BadErrorRule(Rule):
 
     def estimate(self, f, a, b, args=()):
         xp = array_namespace(a, b)
-        underlying = GaussLegendreQuadrature(10, xp=xp)
+        underlying = GaussLegendreQuadrature(10)
 
         return underlying.estimate(f, a, b, args)
 

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1369,9 +1369,7 @@ class BadErrorRule(Rule):
     """
 
     def estimate(self, f, a, b, args=()):
-        xp = array_namespace(a, b)
         underlying = GaussLegendreQuadrature(10)
-
         return underlying.estimate(f, a, b, args)
 
     def estimate_error(self, f, a, b, args=()):


### PR DESCRIPTION
Device-propagation fixes for issue gh-22680: internal array creation that omits `device=` lands on the backend's *default* device and raises when combined with input arrays residing elsewhere.

The non-trivial changes are for `cubature`: the fixed-rule constants (Gauss-Legendre, Gauss-Kronrod and Genz-Malik nodes/weights) change from `xp` arrays to NumPy host arrays, converted only at apply time. 
*Rationale*: a rule object is constructed once, independently of any integrand, so at construction time there is no array whose device could be matched - `xp` arrays built there necessarily land on the backend's default device and get baked into the rule. When `cubature` is then called with arrays living on another device, every estimate must either raise on the first combination with the integrand or perform a hidden device-to-device transfer of the constants. NumPy host arrays keep rule construction backend- and device-neutral; the apply path resolves the namespace from the integrand arrays and converts the constants onto the actual `(xp, dtype, device)` there, memoized in `_cached_cast` so the conversion happens once per combination rather than once per estimate.

Note that I also investigated the alternative for `cubature`: pass along `device` in addition to `xp`. I like the current change better, not only because it seems a bit cleaner to not store `self.xp`, but because it seems like the idea is to make user-fined `rule`'s available, which would require the _user_ to pass along `(xp, device)` which would clearly be bad:

https://github.com/scipy/scipy/blob/f29f562b19e4076c847d1489a271a9e13cc7bc68/scipy/integrate/_cubature.py#L320-L321

This is the fourth PR of the series, following gh-25714

#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see gh-25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.
