### PR TITLE
ENH: spherical_yn: move reflection to `xsf`

### DIFF
--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -126,7 +126,6 @@ def spherical_jn(n, z, derivative=False):
         return _spherical_jn(n, z)
 
 
-@use_reflection(-1)  # See DLMF 10.47(v) https://dlmf.nist.gov/10.47
 def spherical_yn(n, z, derivative=False):
     r"""Spherical Bessel function of the second kind or its derivative.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
follow-up to #25668 and to scipy/xsf/issues/222

#### What does this implement/fix?
The handling of real negative arguments was already implemented in `xsf/sph_bessel.h` and is now tested in `xsf` as well (cf. scipy/xsf/pull/225). Therefore, there is no need to apply the reflection property on the level of SciPy. This PR removes the corresponding decorator from `spherical_yn`.

#### AI Generation Disclosure
No AI tools used