### PR TITLE
MAINT: stats: propagate the input device in array creation

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -12,7 +12,8 @@ from scipy._lib._array_api import xp_ravel
 from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._util import _contains_nan, AxisError, _get_nan
 from scipy._lib._array_api import (array_namespace, is_numpy, xp_size, xp_copy,
-                                   xp_promote, is_dask, is_jax, xp_capabilities)
+                                   xp_promote, is_dask, is_jax, xp_capabilities,
+                                   xp_device)
 import scipy._external.array_api_extra as xpx
 
 import inspect
@@ -272,7 +273,7 @@ def _check_empty_inputs(samples, axis, xp=None):
     # arrays with NaNs. Produce the appropriate array and return it.
     output_shape = _broadcast_array_shapes_remove_axis(samples, axis)
     NaN = _get_nan(*samples)
-    output = xp.full(output_shape, xp.nan, dtype=NaN.dtype)
+    output = xp.full(output_shape, xp.nan, dtype=NaN.dtype, device=xp_device(NaN))
     return output
 
 
@@ -578,7 +579,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 # Addresses nan_policy == "propagate"
                 if any_contains_nan and (nan_policy == 'propagate'
                                          and override['nan_propagation']):
-                    res = xp.full(n_out, xp.nan, dtype=NaN.dtype)
+                    res = xp.full(n_out, xp.nan, dtype=NaN.dtype,
+                                  device=xp_device(NaN))
                     res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                     return tuple_to_result(*res)
 
@@ -594,7 +596,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
 
                 if is_too_small(samples, kwds):
                     warnings.warn(too_small_msg, SmallSampleWarning, stacklevel=2)
-                    res = xp.full(n_out, xp.nan, dtype=NaN.dtype)
+                    res = xp.full(n_out, xp.nan, dtype=NaN.dtype,
+                                  device=xp_device(NaN))
                     res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                     return tuple_to_result(*res)
 

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy._external.array_api_extra as xpx
-from scipy._lib._array_api import xp_capabilities, array_namespace, xp_promote, is_jax
+from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_promote,
+                                   is_jax, xp_device)
 from scipy.optimize.elementwise import find_root
 from scipy.special import ndtri
 from scipy.special import _ufuncs as scu
@@ -321,7 +322,8 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
 
         pval = xpx.apply_where(k < p*n, (d, k, p, n), k_lt_pn,  k_gte_pn)
         # xp.minimum(1.0, pval) but for data-apis/array-api-compat#271
-        pval = xp.minimum(xp.asarray(1.0, dtype=pval.dtype), pval)
+        pval = xp.minimum(xp.asarray(1.0, dtype=pval.dtype, device=xp_device(pval)),
+                          pval)
 
     statistic = xp.where(valid, k/n, xp.nan)
     pval = xp.where(valid, pval, xp.nan)

--- a/scipy/stats/_bws_test.py
+++ b/scipy/stats/_bws_test.py
@@ -5,7 +5,7 @@ from scipy import stats
 from scipy.stats._axis_nan_policy import _broadcast_arrays
 from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_ravel,
-                                   xp_result_type)
+                                   xp_result_type, xp_device)
 
 
 def _bws_input_validation(x, y, alternative, axis, method):
@@ -59,7 +59,8 @@ def _bws_statistic(x, y, alternative, axis, xp):
 
     Ri, Hj = xp.sort(x, axis=axis), xp.sort(y, axis=axis)
     n, m = Ri.shape[axis], Hj.shape[axis]
-    i, j = xp.arange(1, n+1, dtype=Ri.dtype), xp.arange(1, m+1, dtype=Hj.dtype)
+    i = xp.arange(1, n+1, dtype=Ri.dtype, device=xp_device(Ri))
+    j = xp.arange(1, m+1, dtype=Hj.dtype, device=xp_device(Hj))
 
     Bx_num = Ri - (m + n)/n * i
     By_num = Hj - (m + n)/m * j

--- a/scipy/stats/_continued_fraction.py
+++ b/scipy/stats/_continued_fraction.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import (
-    array_namespace, xp_ravel, xp_copy, xp_promote
+    array_namespace, xp_ravel, xp_copy, xp_device, xp_promote
 )
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
@@ -309,7 +309,7 @@ def _continued_fraction(a, b, *, args=(), tolerances=None, maxiter=100, log=Fals
     if tiny is None:
         tiny = xp.finfo(dtype).eps**2 if not log else 2*np.log(xp.finfo(dtype).eps)
 
-    tiny = xp.asarray(tiny, dtype=dtype)
+    tiny = xp.asarray(tiny, dtype=dtype, device=xp_device(b0))
 
     # "Set f0 and C0 to the value b0 or to tiny if b0=0. Set D0 = 0.
     zero = -xp.inf if log else 0

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -3,7 +3,8 @@ import math
 from scipy import stats, special
 from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_promote,
-                                   is_numpy, _share_masks, _count_nonmasked, is_marray)
+                                   is_numpy, _share_masks, _count_nonmasked, is_marray,
+                                   xp_device)
 from scipy.stats._stats_py import (_SimpleNormal, SignificanceResult, _get_pvalue,
                                    _rankdata)
 from scipy.stats._axis_nan_policy import _axis_nan_policy_factory
@@ -51,12 +52,13 @@ def _xi_std(r, l, y_continuous, xp):
     # "Suppose that X and Y are independent and Y is continuous. Then
     # √n·ξn(X, Y) → N(0, 2/5) in distribution as n → ∞"
     if y_continuous:  # [1] Theorem 2.1
-        return xp.asarray(math.sqrt(2 / 5) / math.sqrt(n), dtype=r.dtype)
+        return xp.asarray(math.sqrt(2 / 5) / math.sqrt(n), dtype=r.dtype,
+                          device=xp_device(r))
 
     # "Suppose that X and Y are independent. Then √n·ξn(X, Y)
     # converges to N(0, τ²) in distribution as n → ∞
     # [1] Eq. 2.2 and surrounding math
-    i = xp.arange(1, n + 1, dtype=r.dtype)
+    i = xp.arange(1, n + 1, dtype=r.dtype, device=xp_device(r))
     u = xp.sort(r, axis=-1)
     v = xp.cumulative_sum(u, axis=-1)
     an = 1 / n**4 * xp.sum((2*n - 2*i + 1) * u**2, axis=-1)
@@ -628,7 +630,8 @@ def _robust_slopes(y, *, x, alpha=None, method, pfun):
 
     xp = array_namespace(y, x)
     y, x = xp_promote(y, x, force_floating=True, xp=xp)
-    x = xp.arange(y.shape[-1], dtype=y.dtype) if x is None else x
+    x = (xp.arange(y.shape[-1], dtype=y.dtype, device=xp_device(y))
+         if x is None else x)
     y, x = xp.broadcast_arrays(y, x)
     x, y = _share_masks(x, y, xp=xp)
 
@@ -640,7 +643,10 @@ def _robust_slopes(y, *, x, alpha=None, method, pfun):
     deltay = y[..., :, xp.newaxis] - y[..., xp.newaxis, :]
 
     if pfun == 'theilslopes':
-        i = xp.astype(xp.triu(xp.ones(deltax.shape[-2:]), k=1), xp.bool)
+        i = xp.astype(
+            xp.triu(xp.ones(deltax.shape[-2:], device=xp_device(deltax)), k=1),
+            xp.bool,
+        )
         if is_numpy(xp):
             deltax, deltay = deltax[..., i], deltay[..., i]
         else:
@@ -714,7 +720,7 @@ def _robust_slopes(y, *, x, alpha=None, method, pfun):
     Ru = xp.minimum(xp.astype(xp.round((nt - z*sigma)/2.), xp.int64),
                     xp.astype(nt, xp.int64)-1)
     Rl = xp.maximum(xp.astype(xp.round((nt + z*sigma)/2.), xp.int64) - 1,
-                    xp.asarray(0, dtype=xp.int64))
+                    xp.asarray(0, dtype=xp.int64, device=xp_device(nt)))
     R = xp.concat((xpx.atleast_nd(Rl, ndim=1), xpx.atleast_nd(Ru, ndim=1)), axis=-1)
     slopes = xp.sort(slopes, axis=-1)
     delta = xp.take_along_axis(slopes, R, axis=-1)

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,7 +12,7 @@ from ._continuous_distns import norm
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_size,
                                    xp_promote, xp_result_type, xp_copy, is_numpy,
                                    is_lazy_array, _count_nonmasked, is_marray,
-                                   _masked_apply)
+                                   _masked_apply, xp_device)
 import scipy._external.array_api_extra as xpx
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
@@ -432,7 +432,7 @@ def _psi1_mod(x, *, xp=None):
     def _ed2(y):
         z = y**2 / 4
         z_ = np.asarray(z)
-        b = xp.asarray(kv(1/4, z_) + kv(3/4, z_))
+        b = xp.asarray(kv(1/4, z_) + kv(3/4, z_), device=xp_device(z))
         return xp.exp(-z) * (y/2)**(3/2) * b / math.sqrt(np.pi)
 
     def _ed3(y):
@@ -440,7 +440,8 @@ def _psi1_mod(x, *, xp=None):
         z_ = np.asarray(z)
         c = xp.exp(-z) / math.sqrt(np.pi)
         kv_terms = xp.asarray(2*kv(1/4, z_)
-                              + 3*kv(3/4, z_) - kv(5/4, z_))
+                              + 3*kv(3/4, z_) - kv(5/4, z_),
+                              device=xp_device(z))
         return c * (y/2)**(5/2) * kv_terms
 
     def _Ak(k, x):
@@ -498,7 +499,8 @@ def _cdf_cvm_inf(x, *, xp=None):
         u = math.exp(gammaln(k + 0.5) - gammaln(k+1)) / (xp.pi**1.5 * xp.sqrt(x))
         y = 4*k + 1
         q = y**2 / (16*x)
-        b = xp.asarray(kv(0.25, np.asarray(q)), dtype=u.dtype)  # not automatic?
+        b = xp.asarray(kv(0.25, np.asarray(q)), dtype=u.dtype,  # not automatic?
+                       device=xp_device(q))
         return u * math.sqrt(y) * xp.exp(-q) * b
 
     tot = xp.zeros_like(x, dtype=x.dtype)
@@ -683,9 +685,11 @@ def cramervonmises(rvs, cdf, args=(), *, axis=0):
     rvs = xp_promote(rvs, force_floating=True, xp=xp)
     vals = xp.sort(rvs, axis=-1)
     cdfvals = _masked_apply(cdf, args=(vals, *args), xp=xp)
-    n_count = xp.asarray(_count_nonmasked(rvs, axis=-1, xp=xp), dtype=rvs.dtype)
+    n_count = xp.asarray(_count_nonmasked(rvs, axis=-1, xp=xp), dtype=rvs.dtype,
+                         device=xp_device(rvs))
 
-    u = (2*xp.arange(1, n_length+1, dtype=rvs.dtype) - 1)/(2*n_count[..., xp.newaxis])
+    u = ((2*xp.arange(1, n_length+1, dtype=rvs.dtype, device=xp_device(rvs)) - 1)
+         / (2*n_count[..., xp.newaxis]))
     w = 1/(12*n_count) + xp.sum((u - cdfvals)**2, axis=-1)
 
     # avoid small negative values that can occur due to the approximation
@@ -1644,7 +1648,9 @@ def _pval_cvm_2samp_exact(s, m, n):
 
 def _pval_cvm_2samp_asymptotic(t, N, nx, ny, k, *, xp):
     # compute expected value and variance of T (eq. 11 and 14 in [2])
-    nx, ny = xp.asarray(nx, dtype=t.dtype), xp.asarray(ny, dtype=t.dtype)
+    device = xp_device(t)
+    nx, ny = (xp.asarray(nx, dtype=t.dtype, device=device),
+              xp.asarray(ny, dtype=t.dtype, device=device))
     et = (1 + 1 / N) / 6
     vt = (N + 1) * (4 * k * N - 3 * (nx ** 2 + ny ** 2) - 2 * k)
     vt = vt / (45 * N ** 2 * 4 * k)
@@ -1820,8 +1826,12 @@ def cramervonmises_2samp(x, y, method='auto', *, axis=0):
     ry = r[..., length_x:]
 
     # compute U (eq. 10 in [2])
-    u = (count_x * xp.sum((rx - xp.arange(1, length_x+1, dtype=dtype))**2, axis=-1)
-         + count_y * xp.sum((ry - xp.arange(1, length_y+1, dtype=dtype))**2, axis=-1))
+    u = (count_x * xp.sum(
+             (rx - xp.arange(1, length_x+1, dtype=dtype, device=xp_device(rx)))**2,
+             axis=-1)
+         + count_y * xp.sum(
+             (ry - xp.arange(1, length_y+1, dtype=dtype, device=xp_device(ry)))**2,
+             axis=-1))
 
     # compute T (eq. 9 in [2])
     k, N = count_x*count_y, count_x + count_y
@@ -1831,7 +1841,7 @@ def cramervonmises_2samp(x, y, method='auto', *, axis=0):
         if is_marray(xp):
             u, count_x, count_y = u.data, count_x.data, count_y.data
         p = _pval_cvm_2samp_exact(np.asarray(u), count_x, count_y)
-        p = xp.asarray(p, dtype=dtype)
+        p = xp.asarray(p, dtype=dtype, device=xp_device(t))
     else:
         p = _pval_cvm_2samp_asymptotic(t, N, count_x, count_y, k, xp=xp)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2205,7 +2205,7 @@ def _swilk(y, *, xp):
     if n == 3:
         # [2] Table 5 gives the first four digits
         c = math.sqrt(2) / 2
-        a = xp.asarray([-c, 0, c])
+        a = xp.asarray([-c, 0, c], device=xp_device(y))
         # [2] Corollary 4; discussed in https://github.com/scipy/scipy/issues/18322
         W = xp.clip(_swilk_w(y, a, xp=xp), 0.75, 1.)
         pvalue = xp.clip(1. - 6/np.pi * xp.acos(xp.sqrt(W)), 0., 1.)
@@ -2213,7 +2213,7 @@ def _swilk(y, *, xp):
 
     # Follows [4] section 2.2
     # could calculate half the coefficients and get the rest by antisymmetry
-    i = xp.arange(1, n + 1, dtype=y.dtype)
+    i = xp.arange(1, n + 1, dtype=y.dtype, device=xp_device(y))
     m = special.ndtri((i - 3 / 8) / (n + 1 / 4))
     u = n**(-0.5)
     mTm = xp.vecdot(m, m)
@@ -3251,7 +3251,7 @@ def ansari(x, y, alternative='two-sided', *, axis=0, method='auto'):
             varAB = n * m * (N + 1.0) * (3 + N ** 2) / (48.0 * N ** 2)
         else:
             varAB = m * n * (N + 2) * (N - 2.0) / 48 / (N - 1.0)
-        varAB = xp.asarray(varAB, dtype=dtype)
+        varAB = xp.asarray(varAB, dtype=dtype, device=xp_device(AB))
 
     # Small values of AB indicate larger dispersion for the x sample.
     # Large values of AB indicate larger dispersion for the y sample.
@@ -3524,7 +3524,9 @@ def levene(*samples, center='median', proportiontocut=0.05, axis=0):
     W = numer / denom
     W = xp.squeeze(W, axis=-1)
     dfd = xp.squeeze(dfd, axis=-1) if is_marray(xp) else dfd
-    dfn, dfd = xp.asarray(dfn, dtype=W.dtype), xp.asarray(dfd, dtype=W.dtype)
+    device = xp_device(W)
+    dfn, dfd = (xp.asarray(dfn, dtype=W.dtype, device=device),
+                xp.asarray(dfd, dtype=W.dtype, device=device))
     pval = _get_pvalue(W, _SimpleF(dfn, dfd), 'greater', xp=xp)
     W = W[()] if W.ndim == 0 else W
     pval = pval[()] if pval.ndim == 0 else pval
@@ -3684,7 +3686,7 @@ def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     V2 = xp.var(a_Ni, axis=-1, correction=1)
     statistic = sum(ni_ * (Aibar_ - abar)**2 for ni_, Aibar_ in zip(ni, Aibar)) / V2
 
-    chi2 = _SimpleChi2(xp.asarray(k-1, dtype=dtype))
+    chi2 = _SimpleChi2(xp.asarray(k-1, dtype=dtype, device=xp_device(statistic)))
     pval = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=xp)
     return FlignerResult(statistic, pval)
 
@@ -3738,7 +3740,7 @@ def _mood_statistic_with_ties(x, y, t, m, n, N, xp):
     i = xp.argsort(xy, stable=True, axis=-1)
     _, _, a = _stats_py._rankdata(x, method='average', return_ties=True)
 
-    zeros = xp.zeros(a.shape[:-1] + (n,), dtype=a.dtype)
+    zeros = xp.zeros(a.shape[:-1] + (n,), dtype=a.dtype, device=xp_device(a))
     a = xp.concat((a, zeros), axis=-1)
     a = xp.take_along_axis(a, i, axis=-1)
 

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -513,7 +513,7 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
     # output is that of `y`, broadcasting the batch dimensions with those of `x` if
     # necessary.
     xp = array_namespace(x, y) if xp is None else xp
-    xp_default_int = xp.asarray(1).dtype
+    default_int = xpx.default_dtype(xp, "integral")
     y_0d = xp.asarray(y).ndim == 0
     x, y = _broadcast_arrays((x, y), axis=-1, xp=xp)
     x_1d = x.ndim <= 1
@@ -521,7 +521,7 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
     if x_1d or is_torch(xp):
         y = xp.reshape(y, ()) if (y_0d and x_1d) else y
         out = xp.searchsorted(x, y, side=side)
-        out = xp.astype(out, xp_default_int, copy=False)
+        out = xp.astype(out, default_int, copy=False)
         return out
 
     a = xp.full(y.shape, 0, device=xp_device(x))
@@ -545,7 +545,7 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
 
     out = xp.where(compare(y, xp.min(x, axis=-1, keepdims=True)), 0, b)
     out = xp.where(xp.isnan(y), x.shape[-1], out) if side == 'right' else out
-    out = xp.astype(out, xp_default_int, copy=False)
+    out = xp.astype(out, default_int, copy=False)
     return out
 
 
@@ -790,7 +790,7 @@ _estimated_cdf_methods = (set(_estimated_cdf_continuous_methods).union(
 def _estimated_cdf_hf(x, y, n, method, xp):
     n_int = xp.astype(n, xp.int64)
     j_max = n_int - 1
-    j_min = xp.minimum(j_max, xp.asarray(1, dtype=j_max.dtype))
+    j_min = xp.minimum(j_max, xp.asarray(1, dtype=j_max.dtype, device=xp_device(j_max)))
     jp1 = _xp_searchsorted(x, y, side='right')
 
     if method in _estimated_cdf_discontinuous_methods:

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -227,7 +227,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
             data = [_get_from_last_axis(sample, i, xp=xp) for sample in data]
             return unpaired_statistic(*data, axis=axis)
 
-        data_iv = [xp.arange(n)]
+        data_iv = [xp.arange(n, device=xp_device(data_iv[0]))]
 
     confidence_level_float = float(confidence_level)
 
@@ -1487,7 +1487,7 @@ def _calculate_null_both(data, statistic, n_permutations, batch,
     for indices in _batch_generator(perm_generator, batch=batch):
         # Creating a tensor from a list of numpy.ndarrays is extremely slow...
         indices = np.asarray(indices)
-        indices = xp.asarray(indices)
+        indices = xp.asarray(indices, device=xp_device(data))
 
         # `indices` is 2D: each row is a permutation of the indices.
         # We use it to index `data` along its last axis, which corresponds
@@ -1542,7 +1542,7 @@ def _calculate_null_pairings(data, statistic, n_permutations, batch,
     null_distribution = []
 
     for indices in batched_perm_generator:
-        indices = xp.asarray(indices)
+        indices = xp.asarray(indices, device=xp_device(data[0]))
 
         # `indices` is 3D: the zeroth axis is for permutations, the next is
         # for samples, and the last is for observations. Swap the first two

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -85,6 +85,7 @@ from scipy._lib._array_api import (
     _masked_apply,
     xp_swapaxes,
     xp_device,
+    xp_result_device,
 )
 import scipy._external.array_api_extra as xpx
 from scipy.stats._quantile import _xp_searchsorted
@@ -479,7 +480,8 @@ def _mode_result(mode, count):
     xp = array_namespace(mode, count)
     i = xp.isnan(count)
     if i.shape == ():
-        count = xp.asarray(0, dtype=count.dtype)[()] if i else count
+        count = (xp.asarray(0, dtype=count.dtype, device=xp_device(count))[()]
+                 if i else count)
     else:
         count = xpx.at(count)[i].set(0)
     if is_numpy(xp) and mode.ndim > 0:
@@ -488,7 +490,7 @@ def _mode_result(mode, count):
         # `np.apply_along_axis` to compute mode/count along each axis-slice separately.
         # The result is a single array with the result dtype of `mode` and `count`.
         # We need to change `count` back to an integer.
-        count = xp.astype(count, xp.asarray(0).dtype)
+        count = xp.astype(count, xpx.default_dtype(xp, "integral"))
     return ModeResult(mode, count)
 
 
@@ -575,7 +577,7 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
 
     if xp_size(a) == 0:
         NaN = _get_nan(a, xp=xp)
-        return ModeResult(*xp.asarray([NaN, 0], dtype=NaN.dtype))
+        return ModeResult(*xp.asarray([NaN, 0], dtype=NaN.dtype, device=xp_device(a)))
 
     if a.ndim == 1 and not is_marray(xp):
         vals, cnts = xp.unique_counts(a)
@@ -585,7 +587,7 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
         mask = xp.isnan(vals)
         cnts = xpx.at(cnts)[mask].set(xp.count_nonzero(mask))
         modes, counts = vals[xp.argmax(cnts)], xp.max(cnts)
-        default_int = xp.asarray(1).dtype  # fail slow CI job failed - incorrect dtype
+        default_int = xpx.default_dtype(xp, "integral")
         counts = xp.astype(counts, default_int, copy=False)
         modes = modes[()] if modes.ndim == 0 else modes
         counts = counts[()] if counts.ndim == 0 else counts
@@ -602,15 +604,16 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
         # - NaNs in the original data *will* be treated as distinct.
         y_data = xp_promote(y.data, force_floating=True, xp=y._xp)
         y_data = y._xp.where(y.mask, y._xp.nan, y_data)
-        i = xp.concat([xp.ones(y.shape[:-1] + (1,), dtype=xp.bool),
+        i = xp.concat([xp.ones(y.shape[:-1] + (1,), dtype=xp.bool, device=xp_device(y)),
                       (y_data[..., :-1] != y_data[..., 1:])], axis=-1)
     else:
-        i = xp.concat([xp.ones(y.shape[:-1] + (1,), dtype=xp.bool),
+        i = xp.concat([xp.ones(y.shape[:-1] + (1,), dtype=xp.bool, device=xp_device(y)),
                       (y[..., :-1] != y[..., 1:]) & ~xp.isnan(y[..., :-1])], axis=-1)
     # Get linear integer indices of these elements in a raveled array
     indices = xp.arange(xp_size(y), device=xp_device(y))[xp_ravel(i)]
     # The difference between integer indices is the number of repeats
-    append = xp.full(indices.shape[:-1] + (1,), xp_size(y), dtype=indices.dtype)
+    append = xp.full(indices.shape[:-1] + (1,), xp_size(y), dtype=indices.dtype,
+                     device=xp_device(indices))
     counts = xp.diff(indices, append=append)
     # Now we form an array of `counts` corresponding with each element of `y`...
     counts = xp.reshape(xp.repeat(counts, counts), y.shape)
@@ -2285,7 +2288,8 @@ def _histogram(a, numbins=10, defaultlimits=None, weights=None, *,
     if defaultlimits is None:
         if xp_size(a) == 0:
             # handle empty arrays. Undetermined range, so use 0-1.
-            defaultlimits = xp.asarray(0., dtype=a.dtype), xp.asarray(1., dtype=a.dtype)
+            defaultlimits = (xp.asarray(0., dtype=a.dtype, device=xp_device(a)),
+                             xp.asarray(1., dtype=a.dtype, device=xp_device(a)))
         else:
             # no range given, so use values in `a`
             data_min = xp.min(a)
@@ -2307,7 +2311,8 @@ def _histogram(a, numbins=10, defaultlimits=None, weights=None, *,
             message = 'All `weights` must be non-negative.'
             raise ValueError(message)
 
-    bin_edges = xp.linspace(*defaultlimits, numbins+1, dtype=a.dtype)
+    bin_edges = xp.linspace(*defaultlimits, numbins+1, dtype=a.dtype,
+                            device=xp_device(a))
     if weights is None:
         indices = xp.searchsorted(xp.sort(a), bin_edges, side='left')
         hist = xp.diff(indices)
@@ -3733,7 +3738,8 @@ def trim_mean(a, proportiontocut, axis=0):
             else xp.sort(a, axis=axis))
 
     if is_marray(xp):
-        indices = xp.arange(a.shape[-1])  # axis_nan_policy decorator -> axis=-1
+        # axis_nan_policy decorator -> axis=-1
+        indices = xp.arange(a.shape[-1], device=xp_device(a))
         mask = (indices < lowercut) | (indices >= (nobs - lowercut)) | atmp.mask
         trimmed = xp.asarray(atmp.data, mask=mask.data)
     else:
@@ -4003,7 +4009,8 @@ def f_oneway(*samples, axis=0, equal_var=True):
                             for sample in samples])
             n_t = xp.asarray(n_t, dtype=n_t.dtype)
         else:
-            n_t = xp.asarray([sample.shape[-1] for sample in samples], dtype=y_t.dtype)
+            n_t = xp.asarray([sample.shape[-1] for sample in samples],
+                             dtype=y_t.dtype, device=xp_device(y_t))
             n_t = xp.reshape(n_t, (-1,) + (1,) * (y_t.ndim - 1))
         # "... from $k$ different normal populations..."
         k = len(samples)
@@ -4177,7 +4184,8 @@ def alexandergovern(*samples, nan_policy='propagate', axis=0):
     # Special case: statistic is NaN when variance is zero
     eps = xp.finfo(standard_errors.dtype).eps
     zero = standard_errors <= xp.abs(eps * means)
-    NaN = xp.asarray(xp.nan, dtype=standard_errors.dtype)
+    NaN = xp.asarray(xp.nan, dtype=standard_errors.dtype,
+                     device=xp_device(standard_errors))
     standard_errors = xp.where(zero, NaN, standard_errors)
 
     # (2) define a weight for each sample
@@ -4195,7 +4203,8 @@ def alexandergovern(*samples, nan_policy='propagate', axis=0):
     if is_marray(xp):
         v = xp.stack(lengths) - 1
     else:
-        v = xp.asarray(lengths, dtype=t_stats.dtype) - 1
+        v = xp.asarray(lengths, dtype=t_stats.dtype,
+                       device=xp_device(t_stats)) - 1
         # align along 0th axis, which corresponds with separate samples
         v = xp.reshape(v, (-1,) + (1,)*(t_stats.ndim-1))
     a = v - .5
@@ -4213,7 +4222,7 @@ def alexandergovern(*samples, nan_policy='propagate', axis=0):
 
     # "[the p value is determined from] central chi-square random deviates
     # with k - 1 degrees of freedom". Alexander, Govern (94)
-    df = xp.asarray(len(samples) - 1, dtype=A.dtype)
+    df = xp.asarray(len(samples) - 1, dtype=A.dtype, device=xp_device(A))
     chi2 = _SimpleChi2(df)
     p = _get_pvalue(A, chi2, alternative='greater', symmetric=False, xp=xp)
     return AlexanderGovernResult(A, p)
@@ -4698,7 +4707,8 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         raise ValueError('`x` and `y` must have length at least 2.')
 
     x, y = _share_masks(x, y, xp=xp)
-    n = xp.asarray(_count_nonmasked(x, axis=axis), dtype=x.dtype)
+    n = xp.asarray(_count_nonmasked(x, axis=axis), dtype=x.dtype,
+                   device=xp_device(x))
 
     x = xp.moveaxis(x, axis, -1)
     y = xp.moveaxis(y, axis, -1)
@@ -5704,6 +5714,7 @@ def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
     xp = array_namespace(x, y)
     x, y = xp_promote(x, y, force_floating=True, xp=xp)
     dtype = x.dtype
+    device = xp_result_device(x)
     if is_marray(xp):
         mask_x, mask_y = np.asarray(x.mask), np.asarray(y.mask)
         x, y = np.asarray(x.data).copy(), np.asarray(y.data).copy()
@@ -5721,8 +5732,8 @@ def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
     res = _kendalltau(x, y, nan_policy=nan_policy, method=method, variant=variant,
                       alternative=alternative, axis=axis, keepdims=keepdims)
     vals = res.statistic, res.pvalue, res.statistic
-    vals = (xp.asarray(val, dtype=dtype)[()] if val.ndim == 0
-            else xp.asarray(val, dtype=dtype) for val in vals)
+    vals = (xp.asarray(val, dtype=dtype, device=device)[()] if val.ndim == 0
+            else xp.asarray(val, dtype=dtype, device=device) for val in vals)
     return _pack_CorrelationResult(*vals)
 
 
@@ -6100,7 +6111,8 @@ def pack_TtestResult(statistic, pvalue, df, alternative, standard_error,
     # Due to behavior of `_axis_nan_policy` decorator, `alternative` can be any number
     # of dimensions, but there is at most one unique non-NaN value.
     # `_xp_mean` with `nan_policy='omit'` is a JIT-compatible way to extract it.
-    alternative = xp.asarray(alternative)
+    device = xp_result_device(statistic, pvalue)
+    alternative = xp.asarray(alternative, device=device)
     alternative = (_xp_mean(alternative, axis=None, nan_policy='omit', warn=False)
                    if xp_size(alternative) != 0 else xp.nan)
     return TtestResult(statistic, pvalue, df=df, alternative=alternative,
@@ -6326,7 +6338,7 @@ def _t_confidence_interval(df, t, confidence_level, alternative, dtype=None, xp=
         raise ValueError(message)
 
     confidence_level = xp.asarray(confidence_level, dtype=dtype, device=xp_device(t))
-    inf = xp.asarray(xp.inf, dtype=dtype)
+    inf = xp.asarray(xp.inf, dtype=dtype, device=xp_device(t))
 
     if alternative < 0:  # 'less'
         p = confidence_level
@@ -6391,13 +6403,14 @@ def _equal_var_ttest_denom(v1, n1, v2, n2, xp=None):
     # The pooled variance is still defined, though, because the (n-1) in the
     # numerator should cancel with the (n-1) in the denominator, leaving only
     # the sum of squared differences from the mean: zero.
-    v1 = xp.where(xp.asarray(n1 == 1), 0., v1)
-    v2 = xp.where(xp.asarray(n2 == 1), 0., v2)
+    device = xp_result_device(v1)
+    v1 = xp.where(xp.asarray(n1 == 1, device=device), 0., v1)
+    v2 = xp.where(xp.asarray(n2 == 1, device=device), 0., v2)
 
     df = n1 + n2 - 2.0
     svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
     denom = xp.sqrt(svar * (1.0 / n1 + 1.0 / n2))
-    df = xp.asarray(df, dtype=denom.dtype)
+    df = xp.asarray(df, dtype=denom.dtype, device=xp_device(denom))
     return df, denom
 
 
@@ -6849,8 +6862,10 @@ def ttest_ind(a, b, *, axis=0, equal_var=True, nan_policy='propagate',
 
 
 def _ttest_resampling(x, y, axis, alternative, ttest_kwargs, method, *, xp):
+    device = xp_result_device(x, y)
+
     def statistic(x, y, axis):
-        x, y = xp.asarray(x), xp.asarray(y)
+        x, y = xp.asarray(x, device=device), xp.asarray(y, device=device)
         return ttest_ind(x, y, axis=axis, **ttest_kwargs).statistic
 
     test = (permutation_test if isinstance(method, PermutationMethod)
@@ -7484,8 +7499,10 @@ def _compute_d(cdfvals, x, sign, xp=None):
     xp = array_namespace(cdfvals, x) if xp is None else xp
     length = cdfvals.shape[-1]
     n = _count_nonmasked(cdfvals, axis=-1, keepdims=True)
-    D = (xp.arange(1.0, length + 1, dtype=x.dtype) / n - cdfvals if sign == +1
-         else (cdfvals - xp.arange(0.0, length, dtype=x.dtype) / n))
+    dev = xp_device(x)
+    D = (xp.arange(1.0, length + 1, dtype=x.dtype, device=dev) / n - cdfvals
+         if sign == +1
+         else (cdfvals - xp.arange(0.0, length, dtype=x.dtype, device=dev) / n))
     amax = xp.argmax(D, axis=-1, keepdims=True)
     loc_max = xp.squeeze(xp.take_along_axis(x, amax, axis=-1), axis=-1)
     D = xp.squeeze(xp.take_along_axis(D, amax, axis=-1), axis=-1)
@@ -7662,13 +7679,13 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     N = _count_nonmasked(x, axis=-1, xp=xp)
     cdfvals = _masked_apply(cdf, args=(x, *args), xp=xp)
 
-    ones = xp.ones(x.shape[:-1], dtype=xp.int8)
+    ones = xp.ones(x.shape[:-1], dtype=xp.int8, device=xp_device(x))
     ones = ones[()] if ones.ndim == 0 else ones
 
     if alternative == 'greater':
         Dplus, d_location = _compute_d(cdfvals, x, +1)
         pvalue = _masked_apply(distributions.ksone.sf, args=(Dplus, N), xp=xp)
-        pvalue = xp.asarray(pvalue, dtype=x.dtype)
+        pvalue = xp.asarray(pvalue, dtype=x.dtype, device=xp_device(x))
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dplus = xp.asarray(Dplus) if is_marray(xp) else Dplus
         return KstestResult(Dplus, pvalue,
@@ -7678,7 +7695,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if alternative == 'less':
         Dminus, d_location = _compute_d(cdfvals, x, -1)
         pvalue = _masked_apply(distributions.ksone.sf, args=(Dminus, N), xp=xp)
-        pvalue = xp.asarray(pvalue, dtype=x.dtype)
+        pvalue = xp.asarray(pvalue, dtype=x.dtype, device=xp_device(x))
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dminus = xp.asarray(Dminus) if is_marray(xp) else Dminus
         return KstestResult(Dminus, pvalue,
@@ -7704,7 +7721,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     else:
         # mode == 'approx'
         prob = 2 * _masked_apply(distributions.ksone.sf, args=(D, N), xp=xp)
-    prob = xp.clip(xp.asarray(prob, dtype=x.dtype), 0., 1.)
+    prob = xp.clip(xp.asarray(prob, dtype=x.dtype, device=xp_device(x)), 0., 1.)
     return KstestResult(D, prob,
                         statistic_location=d_location,
                         statistic_sign=d_sign)
@@ -8080,16 +8097,18 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
 
         # We want the ECDF of each sample evaluated at *all* the points in the pooled
         # sample. The values each ECDF can assume are given by:
-        cdf1_vals = xp.broadcast_to(xp.linspace(0, 1, n1 + 1, dtype=dtype),
-                                    batch_shape + (n1 + 1,))
-        cdf2_vals = xp.broadcast_to(xp.linspace(0, 1, n2 + 1, dtype=dtype),
-                                    batch_shape + (n2 + 1,))
+        cdf1_vals = xp.broadcast_to(
+            xp.linspace(0, 1, n1 + 1, dtype=dtype, device=xp_device(data_all)),
+            batch_shape + (n1 + 1,))
+        cdf2_vals = xp.broadcast_to(
+            xp.linspace(0, 1, n2 + 1, dtype=dtype, device=xp_device(data_all)),
+            batch_shape + (n2 + 1,))
         # Now we "just" need to know how many times each of these values *will* be
         # assumed when we evaluate the ECDFs at all points in the pooled sample.
         # These counts are given by the differences between consecutive ("min" or "max")
         # ranks corresponding with the observations in the (sorted) samples.
         ranks, data_all, _ = _rankdata(data_all, method='min', return_sorted=True)
-        ranks = xp.astype(ranks, xp.asarray(1).dtype)  # default int type
+        ranks = xp.astype(ranks, xpx.default_dtype(xp, "integral"))
         one = xp.ones((*ranks.shape[:-1], 1), dtype=ranks.dtype,
                       device=xp_device(ranks))
         cdf1_counts = xp.diff(ranks[..., :n1], prepend=one, append=n + one, axis=-1)
@@ -8113,15 +8132,15 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     minS = xp.clip(minS, 0., 1.)
 
     if alternative == 'less':
-        selector = xp.ones(minS.shape, dtype=xp.bool)
+        selector = xp.ones(minS.shape, dtype=xp.bool, device=xp_device(minS))
     elif alternative == 'two-sided':
         selector = minS > maxS
     else:
-        selector = xp.zeros(minS.shape, dtype=xp.bool)
+        selector = xp.zeros(minS.shape, dtype=xp.bool, device=xp_device(minS))
 
     d = xp.where(selector, minS, maxS)
     d_location = xp.where(selector, loc_minS, loc_maxS)
-    one = xp.asarray(1, dtype=xp.int8)
+    one = xp.asarray(1, dtype=xp.int8, device=xp_device(minS))
     d_sign = xp.where(selector, -one, one)
 
     if is_marray(xp):
@@ -8129,8 +8148,9 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
         n1, n2 = np.asarray(n1.data, dtype=int), np.asarray(n2.data, dtype=int)
     prob = _ks_2samp_prob(np.asarray(d), n1, n2, mode, MAX_AUTO_N, alternative)
     dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
-    prob = xp.asarray(prob, dtype=dtype)
-    d = xp.asarray(d, dtype=dtype)
+    device = xp_device(d_location)
+    prob = xp.asarray(prob, dtype=dtype, device=device)
+    d = xp.asarray(d, dtype=dtype, device=device)
     if d.ndim == 0:
         d, prob, d_location, d_sign = d[()], prob[()], d_location[()], d_sign[()]
     return KstestResult(d, prob, statistic_location=d_location, statistic_sign=d_sign)
@@ -8669,7 +8689,8 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
 
     alldata = xp.concat(samples, axis=-1)
     ranked, _, t = _rankdata(alldata, method='average', return_ties=True)
-    counts = [xp.asarray(_count_nonmasked(sample, -1), dtype=t.dtype)
+    counts = [xp.asarray(_count_nonmasked(sample, -1), dtype=t.dtype,
+                         device=xp_device(t))
               for sample in samples]
     totaln = sum(counts)
     ties = 1 - xp.sum(t**3 - t, axis=-1) / (totaln**3 - totaln)  # tiecorrect(ranked)
@@ -8680,7 +8701,7 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
                for i in range(num_groups))
 
     h = 12.0 / (totaln * (totaln + 1)) * ssbn - 3 * (totaln + 1)
-    df = xp.asarray(num_groups - 1, dtype=h.dtype)
+    df = xp.asarray(num_groups - 1, dtype=h.dtype, device=xp_device(h))
     h /= ties
 
     chi2 = _SimpleChi2(df)
@@ -8779,13 +8800,14 @@ def friedmanchisquare(*samples, axis=0):
 
     # Handle ties
     ties = xp.sum(t * (t*t - 1), axis=(0, -1))
-    count = xp.asarray(_count_nonmasked(samples[0], axis=-1), dtype=ties.dtype)
+    count = xp.asarray(_count_nonmasked(samples[0], axis=-1), dtype=ties.dtype,
+                       device=xp_device(ties))
     c = 1 - ties / (k*(k*k - 1)*count)
 
     ssbn = xp.sum(xp.sum(data, axis=0)**2, axis=-1)
     statistic = (12.0 / (k*count*(k+1)) * ssbn - 3*count*(k+1)) / c
 
-    chi2 = _SimpleChi2(xp.asarray(k - 1, dtype=dtype))
+    chi2 = _SimpleChi2(xp.asarray(k - 1, dtype=dtype, device=xp_device(ties)))
     pvalue = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=xp)
     return FriedmanchisquareResult(statistic, pvalue)
 
@@ -9208,11 +9230,11 @@ class QuantileTestResult:
             raise ValueError(message)
 
         if n == 0:
-            zeros = xp.zeros(p.shape, dtype=x.dtype)
+            zeros = xp.zeros(p.shape, dtype=x.dtype, device=xp_device(x))
             low, high = zeros, zeros
         elif alternative == 'less':
             p = 1 - confidence_level
-            low = xp.full(shape, -xp.inf)
+            low = xp.full(shape, -xp.inf, device=xp_device(x))
             high_index = xp.astype(bd.isf(p), xp.int64)
             valid_index = high_index < n
             high_index = xpx.at(high_index)[~valid_index].set(0)
@@ -9225,7 +9247,7 @@ class QuantileTestResult:
             low_index = xpx.at(low_index)[~valid_index].set(0)
             x_low = xp.take_along_axis(x, low_index, axis=-1)
             low = xp.where(valid_index, x_low, xp.nan)
-            high = xp.full(shape, xp.inf)
+            high = xp.full(shape, xp.inf, device=xp_device(x))
         elif alternative == 'two-sided':
             p = (1 - confidence_level) / 2
             low_index = xp.astype(bd.ppf(p), xp.int64) - 1
@@ -9249,18 +9271,19 @@ class QuantileTestResult:
 def quantile_test_iv(x, q, p, alternative, axis, keepdims):
     xp = array_namespace(x, q, p)
     dtype = xp_result_type(x, q, p, force_floating=True, xp=xp)
+    device = xp_result_device(x, q, p)
 
     x = xpx.atleast_nd(x, ndim=1, xp=xp)
     message = '`x` must be an array of numbers.'
     if not xp.isdtype(x.dtype, 'numeric'):
         raise ValueError(message)
 
-    q = xp.asarray(q)
+    q = xp.asarray(q, device=device)
     message = "`q` must be a scalar or array of numbers."
     if not xp.isdtype(q.dtype, 'numeric'):
         raise ValueError(message)
 
-    p = xp.asarray(p)
+    p = xp.asarray(p, device=device)
     message = "`p` must be a scalar or array of floats."
     if not xp.isdtype(p.dtype, 'real floating'):
         raise ValueError(message)
@@ -9646,7 +9669,7 @@ def quantile_test(x, *, q=0.0, p=0.5, alternative='two-sided', axis=0, keepdims=
         T1, T2 = xp.astype(T1, dtype), xp.astype(T2, dtype)
     else:
         nan_out = xp.ones_like(nan_out)
-        T = xp.zeros(x_star.shape, dtype=dtype)
+        T = xp.zeros(x_star.shape, dtype=dtype, device=xp_device(x_star))
         T1, T2 = T, T
 
     # "The null distribution of the test statistics T1 and T2 is "
@@ -10369,7 +10392,7 @@ def _order_ranks(ranks, j, *, xp):
     # Reorder ascending order `ranks` according to `j`
     xp = array_namespace(ranks) if xp is None else xp
     if is_numpy(xp) or is_cupy(xp):
-        ordered_ranks = xp.empty(j.shape, dtype=ranks.dtype)
+        ordered_ranks = xp.empty(j.shape, dtype=ranks.dtype, device=xp_device(ranks))
         xp.put_along_axis(ordered_ranks, j, ranks, axis=-1)
     else:
         # `put_along_axis` not in array API (data-apis/array-api#177)
@@ -10414,7 +10437,8 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
 
     # Get sort order
     j = xp.argsort(x, axis=-1, stable=True)
-    ordinal_ranks = xp.broadcast_to(xp.arange(1, shape[-1]+1, dtype=dtype), shape)
+    ordinal_ranks = xp.broadcast_to(
+        xp.arange(1, shape[-1]+1, dtype=dtype, device=xp_device(x)), shape)
 
     # Ordinal ranks is very easy because ties don't matter. We're done.
     if method == 'ordinal':
@@ -10424,13 +10448,15 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
     # Sort array
     y = xp.take_along_axis(x, j, axis=-1)
     # Logical indices of unique elements
-    i = xp.concat([xp.ones(shape[:-1] + (1,), dtype=xp.bool),
+    i = xp.concat([xp.ones(shape[:-1] + (1,), dtype=xp.bool, device=xp_device(x)),
                    y[..., :-1] != y[..., 1:]], axis=-1)
 
     # Integer indices of unique elements
-    indices = xp.arange(xp_size(y))[xp.reshape(i, (-1,))]  # i gets raveled
+    # `i` gets raveled
+    indices = xp.arange(xp_size(y), device=xp_device(y))[xp.reshape(i, (-1,))]
     # Counts of unique elements
-    counts = xp.diff(indices, append=xp.asarray([xp_size(y)], dtype=indices.dtype))
+    counts = xp.diff(indices, append=xp.asarray([xp_size(y)], dtype=indices.dtype,
+                                                device=xp_device(indices)))
 
     # Compute `'min'`, `'max'`, and `'mid'` ranks of unique elements
     if method == 'min':
@@ -10475,7 +10501,7 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
         #   sorted order, so this does not unnecessarily reorder them.
         # - One exception is `wilcoxon`, which needs the number of zeros. Zeros always
         #   have the lowest rank, so it is easy to find them at the zeroth index.
-        t = xp.zeros(shape, dtype=dtype)
+        t = xp.zeros(shape, dtype=dtype, device=xp_device(x))
         t = xpx.at(t)[i].set(xp.astype(counts, dtype, copy=False))
 
     return ranks, y, t
@@ -10621,7 +10647,7 @@ def expectile(a, alpha=0.5, *, weights=None, axis=None):
 
     # Note that the expectile is the unique solution, so no worries about
     # finding a wrong root.
-    i = xp.arange(a.shape[0])
+    i = xp.arange(a.shape[0], device=xp_device(a))
     res = find_root(first_order, (x0, x1), args=(i,))
     res = xp.reshape(res.x, shape[:-1])
     return res[()] if res.ndim == 0 else res
@@ -10636,7 +10662,8 @@ def _lmoment_iv(sample, order, axis, sorted, standardize, xp):
         raise ValueError(message)
 
     message = "`order` must be a scalar or a non-empty array of positive integers."
-    order = xp.arange(1, 5) if order is None else xp.asarray(order)
+    order = (xp.arange(1, 5, device=xp_device(sample)) if order is None
+             else xp.asarray(order, device=xp_device(sample)))
     if (not xp.isdtype(order.dtype, "integral") or order.size == 0 or order.ndim > 1
             or (not is_lazy_array(order) and xp.any(order <= 0))):
         raise ValueError(message)
@@ -10671,8 +10698,8 @@ def _br(x, *, r=0, xp):
     x = xp.expand_dims(x, axis=-2)
     x = xp.broadcast_to(x, x.shape[:-2] + (r.shape[0], n))
     x = xp.triu(x)
-    j = xp.arange(n, dtype=x.dtype)
-    n = xp.asarray(n, dtype=x.dtype)[()]
+    j = xp.arange(n, dtype=x.dtype, device=xp_device(x))
+    n = xp.asarray(n, dtype=x.dtype, device=xp_device(x))[()]
     binom_j_r = xpx.lazy_apply(special.binom, j, r[:, xp.newaxis])
     binom_nm1_r = xpx.lazy_apply(special.binom, n-1, r)
     return xp.vecdot(binom_j_r, x, axis=-1) / binom_nm1_r / n
@@ -10770,7 +10797,7 @@ def lmoment(sample, order=None, *, axis=0, sorted=False, standardize=True):
     sample, order, axis, sorted, standardize = args
 
     n_moments = 4 if is_lazy_array(order) else int(xp.max(order))
-    k = xp.arange(n_moments, dtype=sample.dtype)
+    k = xp.arange(n_moments, dtype=sample.dtype, device=xp_device(sample))
     prk = _prk(xp.expand_dims(k, axis=tuple(range(1, sample.ndim+1))), k)
     bk = _br(sample, r=k, xp=xp)
 
@@ -10948,7 +10975,7 @@ def linregress(x, y, alternative='two-sided', *, axis=0):
     # R-value
     #   r = ssxym / sqrt( ssxm * ssym )
     degenerate = (ssxm == 0.0) | (ssym == 0.0)
-    NaN = xp.asarray(xp.nan, dtype=ssxym.dtype)
+    NaN = xp.asarray(xp.nan, dtype=ssxym.dtype, device=xp_device(ssxym))
     r = xpx.apply_where(
         ~degenerate,
         (ssxym, ssxm, ssym),
@@ -10964,7 +10991,7 @@ def linregress(x, y, alternative='two-sided', *, axis=0):
         # to estimate the mean and standard deviation
         t = r * xp.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
 
-        dist = _SimpleStudentT(xp.asarray(df, dtype=t.dtype))
+        dist = _SimpleStudentT(xp.asarray(df, dtype=t.dtype, device=xp_device(t)))
         prob = _get_pvalue(t, dist, alternative, xp=xp)
         prob = prob[()] if prob.ndim == 0 else prob
 

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -7,7 +7,7 @@ from ._axis_nan_policy import _broadcast_arrays
 from ._hypotests import _get_wilcoxon_distr
 from scipy._lib._util import _get_nan
 from scipy._lib._array_api import (array_namespace, xp_promote, xp_size, is_jax,
-                                   is_marray, _count_nonmasked)
+                                   is_marray, _count_nonmasked, xp_device)
 import scipy._external.array_api_extra as xpx
 
 
@@ -264,7 +264,7 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
             p = 2 * np.minimum(dist.sf(np.floor(r_plus_np)),
                                dist.cdf(np.ceil(r_plus_np)))
             p = np.clip(p, 0, 1)
-        p = xp.asarray(p, dtype=d.dtype)
+        p = xp.asarray(p, dtype=d.dtype, device=xp_device(d))
     else:  # `PermutationMethod` instance (already validated)
         p = stats.permutation_test(
             # permutation_test always uses `axis=-1` as `_wilcoxon_statistic` assumes


### PR DESCRIPTION
Device-propagation fixes for issue gh-22680: internal array creation that omits `device=` lands on the backend's *default* device and raises (or silently misplaces results) when the input arrays reside elsewhere.

The most important (if simple, mechanical) fix is in `_resampling.py`: `permutation_test` and `bws_test` generated their permutation index arrays on the default device. On a torch CUDA default with CPU-device inputs this did not raise. Indexing with wrong-device indices returned uninitialized memory, silently producing garbage p-values (observed: 0.0079 where the correct value is 1.0). The indices are now created on the device of the data.

The other changes are mechanical, and were resulting in failures before.

This is the fifth PR of the series, following gh-25717

#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see gh-25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.
