### PR TITLE
BUG: integrate.ode.set_integrator: add ValueError for method argument

### DIFF
--- a/scipy/integrate/_ivp/tests/test_rk.py
+++ b/scipy/integrate/_ivp/tests/test_rk.py
@@ -1,7 +1,8 @@
+from itertools import product
 import pytest
 from numpy.testing import assert_allclose, assert_
 import numpy as np
-from scipy.integrate import RK23, RK45, DOP853
+from scipy.integrate import ode, RK23, RK45, DOP853
 from scipy.integrate._ivp import dop853_coefficients
 
 
@@ -35,3 +36,12 @@ def test_error_estimation_complex(solver_class):
     solver.step()
     err_norm = solver._estimate_error_norm(solver.K, h, scale=[1])
     assert np.isrealobj(err_norm)
+
+p = product(['lsoda', 'dopri5', 'dop853'], ['adams', 'bdf'])
+
+@pytest.mark.parametrize("solver_method", list(p))
+def test_compatible_method_solvers(solver_method):
+    solver, method = solver_method
+    if solver in ["lsoda", "dopri5", "dop853"] and method is not None:
+        with pytest.raises(ValueError):
+            ode(lambda t, y: y).set_integrator(solver, method=method)

--- a/scipy/integrate/_ivp/tests/test_rk.py
+++ b/scipy/integrate/_ivp/tests/test_rk.py
@@ -1,4 +1,3 @@
-from itertools import product
 import pytest
 from numpy.testing import assert_allclose, assert_
 import numpy as np
@@ -37,11 +36,8 @@ def test_error_estimation_complex(solver_class):
     err_norm = solver._estimate_error_norm(solver.K, h, scale=[1])
     assert np.isrealobj(err_norm)
 
-p = product(['lsoda', 'dopri5', 'dop853'], ['adams', 'bdf'])
-
-@pytest.mark.parametrize("solver_method", list(p))
-def test_compatible_method_solvers(solver_method):
-    solver, method = solver_method
-    if solver in ["lsoda", "dopri5", "dop853"] and method is not None:
-        with pytest.raises(ValueError):
-            ode(lambda t, y: y).set_integrator(solver, method=method)
+@pytest.mark.parametrize("solver", ['lsoda', 'dopri5', 'dop853'])
+@pytest.mark.parametrize("method", ['adams', 'bdf'])
+def test_compatible_method_solvers(solver, method):
+    with pytest.raises(ValueError):
+        ode(lambda t, y: y).set_integrator(solver, method=method)

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1136,6 +1136,11 @@ class dopri5(IntegratorBase):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
+        
+        if method is not None:
+            raise ValueError(f'Integration method must be None for dopri5, got \
+                             {method}')
+        
         self.rtol = rtol
         self.atol = atol
         self.nsteps = nsteps
@@ -1213,6 +1218,11 @@ class dop853(dopri5):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
+
+        if method is not None:
+                    raise ValueError(f'Integration method must be None for dop853, \
+                                     got {method}')
+
         super().__init__(rtol, atol, nsteps, max_step, first_step, safety,
                          ifactor, dfactor, beta, method, verbosity)
 
@@ -1266,6 +1276,10 @@ class lsoda(IntegratorBase):
                  max_order_s=5,
                  method=None
                  ):
+
+        if method is not None:
+            raise ValueError(f'Integration method must be None for lsoda, \
+                             got {method}')
 
         self.with_jacobian = with_jacobian
         self.rtol = rtol

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1138,8 +1138,8 @@ class dopri5(IntegratorBase):
                  ):
 
         if method is not None:
-            raise ValueError(f'Integration method must be None for dopri5, got \
-                             {method}')
+            raise ValueError(f'Integration method must be None '
+                             f'for dopri5, got {method}')
 
         self.rtol = rtol
         self.atol = atol
@@ -1220,8 +1220,8 @@ class dop853(dopri5):
                  ):
 
         if method is not None:
-                    raise ValueError(f'Integration method must be None for dop853, \
-                                     got {method}')
+            raise ValueError(f'Integration method must be None '
+                             f'for dop853, got {method}')
 
         super().__init__(rtol, atol, nsteps, max_step, first_step, safety,
                          ifactor, dfactor, beta, method, verbosity)
@@ -1278,8 +1278,8 @@ class lsoda(IntegratorBase):
                  ):
 
         if method is not None:
-            raise ValueError(f'Integration method must be None for lsoda, \
-                             got {method}')
+            raise ValueError(f'Integration method must be None '
+                             f'for lsoda, got {method}')
 
         self.with_jacobian = with_jacobian
         self.rtol = rtol

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1136,11 +1136,11 @@ class dopri5(IntegratorBase):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
-        
+
         if method is not None:
             raise ValueError(f'Integration method must be None for dopri5, got \
                              {method}')
-        
+
         self.rtol = rtol
         self.atol = atol
         self.nsteps = nsteps

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -174,15 +174,16 @@ def test_banded_ode_solvers():
         assert_allclose(y, y_exact)
 
     for idx in range(len(real_matrices)):
-        p = [[None, 'bdf', 'adams'],   # method
+        solver_method = [['vode', 'adams'],  # solver and method
+                         ['vode', 'bdf'],
+                         ['lsoda', None]]
+        p = [solver_method,
              [False, True],      # use_jac
              [False, True],      # with_jacobian
              [False, True]]      # banded
-        for meth, use_jac, with_jac, banded in itertools.product(*p):
-            if meth is None:
-                check_real(idx, 'lsoda', meth, use_jac, with_jac, banded)
-            else:
-                check_real(idx, 'vode', meth, use_jac, with_jac, banded)
+        for solver_method, use_jac, with_jac, banded in itertools.product(*p):
+            check_real(idx, solver_method[0], solver_method[1], use_jac, with_jac,
+                       banded)
 
     # --- Complex arrays for testing the "zvode" solver ---
 

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -174,13 +174,15 @@ def test_banded_ode_solvers():
         assert_allclose(y, y_exact)
 
     for idx in range(len(real_matrices)):
-        p = [['vode', 'lsoda'],  # solver
-             ['bdf', 'adams'],   # method
+        p = [[None, 'bdf', 'adams'],   # method
              [False, True],      # use_jac
              [False, True],      # with_jacobian
              [False, True]]      # banded
-        for solver, meth, use_jac, with_jac, banded in itertools.product(*p):
-            check_real(idx, solver, meth, use_jac, with_jac, banded)
+        for meth, use_jac, with_jac, banded in itertools.product(*p):
+            if meth is None:
+                check_real(idx, 'lsoda', meth, use_jac, with_jac, banded)
+            else:
+                check_real(idx, 'vode', meth, use_jac, with_jac, banded)
 
     # --- Complex arrays for testing the "zvode" solver ---
 

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -174,9 +174,9 @@ def test_banded_ode_solvers():
         assert_allclose(y, y_exact)
 
     for idx in range(len(real_matrices)):
-        solver_method = [['vode', 'adams'],  # solver and method
-                         ['vode', 'bdf'],
-                         ['lsoda', None]]
+        solver_method = [('vode', 'adams'),  # solver and method
+                         ('vode', 'bdf'),
+                         ('lsoda', None)]
         p = [solver_method,
              [False, True],      # use_jac
              [False, True],      # with_jacobian

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -181,9 +181,8 @@ def test_banded_ode_solvers():
              [False, True],      # use_jac
              [False, True],      # with_jacobian
              [False, True]]      # banded
-        for solver_method, use_jac, with_jac, banded in itertools.product(*p):
-            check_real(idx, solver_method[0], solver_method[1], use_jac, with_jac,
-                       banded)
+        for (solver, method), use_jac, with_jac, banded in itertools.product(*p):
+            check_real(idx, solver, method, use_jac, with_jac, banded)
 
     # --- Complex arrays for testing the "zvode" solver ---
 

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -117,7 +117,7 @@ class TestOde(TestODEClass):
             problem = problem_cls()
             if problem.cmplx:
                 continue
-            self._do_problem(problem, 'lsoda')
+            self._do_problem(problem, 'lsoda', method=None)
 
     def test_dopri5(self):
         # Check the dopri5 solver
@@ -129,7 +129,7 @@ class TestOde(TestODEClass):
                 continue
             if hasattr(problem, 'jac'):
                 continue
-            self._do_problem(problem, 'dopri5')
+            self._do_problem(problem, 'dopri5', method=None)
 
     def test_dop853(self):
         # Check the dop853 solver
@@ -141,7 +141,7 @@ class TestOde(TestODEClass):
                 continue
             if hasattr(problem, 'jac'):
                 continue
-            self._do_problem(problem, 'dop853')
+            self._do_problem(problem, 'dop853', method=None)
 
     def test_concurrent_fail(self):
         # Test concurrent usage behavior for different solvers
@@ -220,7 +220,7 @@ class TestComplexOde(TestODEClass):
         # Check the lsoda solver
         for problem_cls in PROBLEMS:
             problem = problem_cls()
-            self._do_problem(problem, 'lsoda')
+            self._do_problem(problem, 'lsoda', method=None)
 
     def test_dopri5(self):
         # Check the dopri5 solver
@@ -230,7 +230,7 @@ class TestComplexOde(TestODEClass):
                 continue
             if hasattr(problem, 'jac'):
                 continue
-            self._do_problem(problem, 'dopri5')
+            self._do_problem(problem, 'dopri5', method=None)
 
     def test_dop853(self):
         # Check the dop853 solver
@@ -240,7 +240,7 @@ class TestComplexOde(TestODEClass):
                 continue
             if hasattr(problem, 'jac'):
                 continue
-            self._do_problem(problem, 'dop853')
+            self._do_problem(problem, 'dop853', method=None)
 
 
 class TestSolout:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#5399

#### What does this implement/fix?
Currently, the ``ode.set_integrator`` and ``complex_ode.set_integrator`` methods silently ignore the ``method`` keyword argument for the ``'lsoda'``, ``'dopri5'``, and ``'dop853'`` integrators. The ``meth`` object attributes for these integrators correspond to ``None``. This commit updates the ``set_integrator`` methods so they return a ``ValueError`` when a user tries to specify a value for ``method`` other than ``None``.

#### Additional information
This is my first time editing code instead of docstrings, so please keep an eagle eye out for newbie mistakes!

#### AI Generation Disclosure
I asked Claude for help with determining what tests I should run and the general grammatical structure of error messages. It was not very helpful so please let me know if there's some sort of style guide I should be following.
