### PR TITLE
DOC: fix duplicated word and incorrect frequency values in fft tutorial

### DIFF
--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -352,7 +352,7 @@ determine the periodic components, a magnitude spectrum of :math:`x(t)` and of
 
 The signal's trend manifests as a decreasing slope in the spectrum's low-frequency part.
 Removing the linear trend steepens this slope significantly, making the peaks at
-:math:`100`, :math:`200`, and :math:`300\,`\ Hz much better distinguishable. These peaks, which
+:math:`200`, :math:`300`, and :math:`400\,`\ Hz much better distinguishable. These peaks, which
 correspond to the sinusoidal components of :math:`x(t)`, would have a magnitude of
 :math:`0.5` in a noise- and trend-free signal.
 
@@ -374,7 +374,7 @@ its non-negative frequencies. The gray stems represent the periodic continuation
 left and to the right. The center row shows the :func:`~scipy.fft.fft` with the shifted
 frequencies produced by :func:`~scipy.fft.fftfreq`, where the two highest frequencies
 are shifted to the negative side. The last row depicts the one-sided
-:func:`~scipy.fft.rfft`, which only produces only the non-negative frequencies of the
+:func:`~scipy.fft.rfft`, which produces only the non-negative frequencies of the
 (two-sided) :func:`~scipy.fft.fft`.
 
 .. plot:: tutorial/examples/fft_compare_DFT_fft_rfft.py


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- Removed the duplicate word "only" from the `rfft` description
- Corrected the frequency values ​​in the trend example (200/300/400 Hz instead of 100/200/300 - the signal in the code is constructed from precisely these frequencies via `x_sines`).

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used
