### PR TITLE
ENH: spatial: Rotation: improve `as_rotvec` performance (xp backend)

### DIFF
--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -327,16 +327,9 @@ def as_rotvec(quat: Array, degrees: bool = False) -> Array:
     quat = _quat_canonical(quat)
     ax_norm = xp_vector_norm(quat[..., :3], axis=-1, keepdims=True, xp=xp)
     angle = 2 * xp.atan2(ax_norm, quat[..., 3][..., None])
-    small_angle = angle <= 1e-3
-    angle2 = angle**2
-    small_scale = 2 + angle2 / 12 + 7 * angle2**2 / 2880
-    # We need to handle the case where sin(angle/2) is 0 to avoid division by zero. We
-    # use the value of the Taylor series approximation, but non-branching operations
-    # require that we still divide by the sin. Since we do not use the result where the
-    # angle is close to 0, adding one to the sin where we discard the result is safe.
-    div_sin = xp.sin(angle / 2.0) + xp.asarray(small_angle, dtype=angle.dtype)
-    large_scale = angle / div_sin
-    scale = xp.where(small_angle, small_scale, large_scale)
+    # Guard against division by zero. The rotvec is zero in that case.
+    div_norm = ax_norm + xp.astype(ax_norm == 0, ax_norm.dtype)
+    scale = angle / div_norm
     if degrees:
         scale = _rad2deg(scale)
     rotvec = scale * quat[..., :3]


### PR DESCRIPTION
Follow-up from #25691. Optimizes the performance of `Rotation.as_rotvec`.

@lucascolley @scottshambaugh I am still evaluating 3 more Cython backend improvements, then this stream of PRs is hopefully done (and we can move to #25734) :D

Edit: The Cython patches did not yield significant performance benefits, so I dropped them.

### What does this implement/fix?
It turns out we do not need the Taylor approximations in the rotvec functions, yielding mediocre, but consistent speedups on the generic backend.

@scottshambaugh Since you mentioned in #25735 that the approximation was needed in one place, it would be good to ensure we are not unintentionally making the numerics worse. Do you know if there was a regression test against the numerical issue you mentioned?

### Benchmark
<img width="1500" height="1200" alt="image" src="https://github.com/user-attachments/assets/b4066bde-fc41-49d2-b9a2-308fac50bc0e" />

### AI Generation Disclosure
Claude