### PR TITLE
MAINT: interpolate: propagate the input device in array creation

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -17,7 +17,7 @@ from itertools import combinations
 
 from scipy._lib._array_api import (
     array_namespace, concat_1d, xp_capabilities, scipy_namespace_for, is_numpy,
-    is_cupy
+    is_cupy, xp_device, xp_result_device
 )
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
@@ -191,7 +191,8 @@ def _validate_clamp_values(clamp_values, k, t, y, x, xp, check_finite=True):
     # used elsewhere in scipy, rather than special-casing clamp_values.
     # Raises TypeError on mismatch, consistent with array_namespace's
     # behavior throughout the rest of the library.
-    array_namespace(*clamp_values, xp.empty(0))
+    # `empty(0)` is a throwaway used only to resolve the namespace
+    array_namespace(*clamp_values, xp.empty(0))  # skip device check
 
     def _prepare(val, side):
         try:
@@ -849,6 +850,9 @@ class BSpline:
 
         xp = array_namespace(t, c)
         xp_bspline_cls, xp_internal = _get_xp_bspline_cls(xp)
+        # a NumPy round-trip in the delegate must return results on the
+        # device of the inputs, not on the backend's default device
+        device = xp_result_device(t, c)
         if not is_numpy(xp):
             # only convert t and c to internal namespace if it is not NumPy
             # to preserve NumPy behavior with lists.
@@ -867,13 +871,15 @@ class BSpline:
         # keeping modules in attributes like this.
         self._xp = xp
         self._xp_internal = xp_internal
+        self._device = device
 
     @classmethod
-    def _construct_from_xp(cls, xp_bspline, *, xp_external):
+    def _construct_from_xp(cls, xp_bspline, *, xp_external, device=None):
         self = object.__new__(cls)
         self._delegate_to = xp_bspline
         self._xp = xp_external
         self._xp_internal = array_namespace(xp_bspline.t)
+        self._device = device
         return self
 
     @classmethod
@@ -885,6 +891,7 @@ class BSpline:
         """
         xp = array_namespace(t, c)
         xp_bspline_cls, xp_internal = _get_xp_bspline_cls(xp)
+        device = xp_result_device(t, c)
         return cls._construct_from_xp(
             xp_bspline_cls.construct_fast(
                 xp_internal.asarray(t),
@@ -893,6 +900,7 @@ class BSpline:
                 extrapolate=extrapolate, axis=axis,
             ),
             xp_external=xp,
+            device=device,
         )
 
     @property
@@ -903,7 +911,7 @@ class BSpline:
 
     @property
     def t(self):
-        return self._xp.asarray(self._delegate_to.t)
+        return self._xp.asarray(self._delegate_to.t, device=self._device)
 
     @t.setter
     def t(self, t):
@@ -915,7 +923,7 @@ class BSpline:
 
     @property
     def c(self):
-        return self._xp.asarray(self._delegate_to.c)
+        return self._xp.asarray(self._delegate_to.c, device=self._device)
 
     @c.setter
     def c(self, c):
@@ -1007,11 +1015,13 @@ class BSpline:
         """
         xp = array_namespace(t)
         xp_bspline_cls, xp_internal = _get_xp_bspline_cls(xp)
+        device = xp_result_device(t)
         return cls._construct_from_xp(
             xp_bspline_cls.basis_element(
                 xp_internal.asarray(t), extrapolate=extrapolate,
             ),
             xp_external=xp,
+            device=device,
         )
 
     @classmethod
@@ -1118,10 +1128,14 @@ class BSpline:
             in the coefficient array with the shape of `x`.
 
         """
+        device = xp_result_device(x)
+        if device is None:
+            device = self._device
         return self._xp.asarray(
             self._delegate_to(
                 self._xp_internal.asarray(x), nu=nu, extrapolate=extrapolate
-            )
+            ),
+            device=device,
         )
 
     def derivative(self, nu=1):
@@ -1149,6 +1163,7 @@ class BSpline:
             return self._construct_from_xp(
                 self._delegate_to.derivative(nu=nu),
                 xp_external=self._xp,
+                device=self._device,
             )
 
         ## Array-agnostic codepath
@@ -1159,7 +1174,7 @@ class BSpline:
         # pad the c array if needed
         ct = t.shape[0] - c.shape[0]
         if ct > 0:
-            c = concat_1d(xp, c, xp.zeros((ct,) + c.shape[1:]))
+            c = concat_1d(xp, c, xp.zeros((ct,) + c.shape[1:], device=xp_device(c)))
         tck = _fitpack_impl.splder((t, c, self.k), nu)
         return self.construct_fast(*tck, extrapolate=self.extrapolate, axis=self.axis)
 
@@ -1194,6 +1209,7 @@ class BSpline:
             return self._construct_from_xp(
                 self._delegate_to.antiderivative(nu=nu),
                 xp_external=self._xp,
+                device=self._device,
             )
 
         ## Array-agnostic codepath
@@ -1204,7 +1220,7 @@ class BSpline:
         # pad the c array if needed
         ct = t.shape[0] - c.shape[0]
         if ct > 0:
-            c = concat_1d(xp, c, xp.zeros((ct,) + c.shape[1:]))
+            c = concat_1d(xp, c, xp.zeros((ct,) + c.shape[1:], device=xp_device(c)))
         tck = _fitpack_impl.splantider((t, c, self.k), nu)
 
         if self.extrapolate == 'periodic':
@@ -1263,7 +1279,8 @@ class BSpline:
 
         """
         return self._xp.asarray(
-            self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+            self._delegate_to.integrate(a, b, extrapolate=extrapolate),
+            device=self._device,
         )
 
     @classmethod
@@ -1345,10 +1362,11 @@ class BSpline:
         """
         xp = array_namespace(pp.x, pp.c)
         xp_bspline_cls, _ = _get_xp_bspline_cls(xp)
+        device = xp_result_device(pp.x, pp.c)
         # from_power_basis isn't available in CuPy as of version 14 causing this to
         # raise with an AttributeError when xp_internal is CuPy.
         spl = xp_bspline_cls.from_power_basis(pp, bc_type=bc_type)
-        return cls._construct_from_xp(spl, xp_external=xp)
+        return cls._construct_from_xp(spl, xp_external=xp, device=device)
 
     def insert_knot(self, x, m=1):
         """Insert a new knot at `x` of multiplicity `m`.
@@ -1422,16 +1440,22 @@ class BSpline:
         # insert_knot isn't available in CuPy as of version 14 causing this to
         # raise with an AttributeError when xp_internal is CuPy.
         return self._construct_from_xp(
-            self._delegate_to.insert_knot(x, m=m), xp_external=self._xp
+            self._delegate_to.insert_knot(x, m=m), xp_external=self._xp,
+            device=self._device,
         )
 
     def __getstate__(self):
         # need custom __getstate__ and __setstate__ methods to allow pickling
         # while holding onto namespaces.
-        return (self._delegate_to, self._xp.empty(0))
+        # `empty(0)` is a pickling sentinel, never combined with input data
+        return (
+            self._delegate_to,
+            self._xp.empty(0),  # skip device check
+            self._device,
+        )
 
     def __setstate__(self, state):
-        self._delegate_to, sentinel_array = state
+        self._delegate_to, sentinel_array, self._device = state
         self._xp_internal = array_namespace(self._delegate_to.t)
         self._xp = array_namespace(sentinel_array)
 
@@ -1773,7 +1797,7 @@ def _handle_lhs_derivatives(t, k, xval, ab, kl, ku, deriv_ords, offset=0):
             ab[kl + ku + offset + row - clmn, clmn] = wrk[a]
 
 
-def _make_periodic_spline(x, y, t, k, axis, *, xp):
+def _make_periodic_spline(x, y, t, k, axis, *, xp, device=None):
     '''
     Compute the (coefficients of) interpolating B-spline with periodic
     boundary conditions.
@@ -1824,7 +1848,7 @@ def _make_periodic_spline(x, y, t, k, axis, *, xp):
         for i in range(extradim):
             c[:, i] = _make_interp_per_full_matr(x, y_new[:, i], t, k)
         c = np.ascontiguousarray(c.reshape((n + k - 1,) + y.shape[1:]))
-        t, c = xp.asarray(t), xp.asarray(c)
+        t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
         return BSpline.construct_fast(t, c, k, extrapolate='periodic', axis=axis)
 
     nt = len(t) - k - 1
@@ -1864,7 +1888,7 @@ def _make_periodic_spline(x, y, t, k, axis, *, xp):
         cc = _woodbury_algorithm(A, ur, ll, y_new[:, i][:-1], k)
         c[:, i] = np.concatenate((cc[-kul:], cc, cc[:kul + k % 2]))
     c = np.ascontiguousarray(c.reshape((n + k - 1,) + y.shape[1:]))
-    t, c = xp.asarray(t), xp.asarray(c)
+    t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
     return BSpline.construct_fast(t, c, k, extrapolate='periodic', axis=axis)
 
 
@@ -2006,6 +2030,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     """
     xp = array_namespace(x, y, t)
+    # the NumPy round-trip must return the result on the inputs' device
+    device = xp_result_device(x, y, t)
     if is_cupy(xp):
         # delegate to CuPy, *and* return a SciPy BSpline object
         import cupyx.scipy.interpolate as csi
@@ -2048,7 +2074,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         t = np.r_[x, x[-1]]
         c = np.asarray(y)
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
-        t, c = xp.asarray(t), xp.asarray(c)
+        t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
         return BSpline.construct_fast(t, c, k, axis=axis)
 
     # special-case k=1 (e.g., Lyche and Morken, Eq.(2.16))
@@ -2058,7 +2084,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         t = np.r_[x[0], x, x[-1]]
         c = np.asarray(y)
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
-        t, c = xp.asarray(t), xp.asarray(c)
+        t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
         return BSpline.construct_fast(t, c, k, axis=axis)
 
     k = operator.index(k)
@@ -2090,7 +2116,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         raise ValueError(f'Out of bounds w/ x = {x}.')
 
     if bc_type == 'periodic':
-        return _make_periodic_spline(x, y, t, k, axis, xp=xp)
+        return _make_periodic_spline(x, y, t, k, axis, xp=xp, device=device)
 
     # Here : deriv_l, r = [(nu, value), ...]
     deriv_l = _convert_string_aliases(deriv_l, y.shape[1:])
@@ -2118,6 +2144,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     # bail out if the `y` array is zero-sized
     if y.size == 0:
         c = np.zeros((nt,) + y.shape[1:], dtype=float)
+        t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
         return BSpline.construct_fast(t, c, k, axis=axis)
 
     # set up the LHS: the colocation matrix + derivatives at boundaries
@@ -2153,7 +2180,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     elif info < 0:
         raise ValueError(f'illegal value in {-info}-th argument of internal gbsv')
     c = np.ascontiguousarray(c.reshape((nt,) + y.shape[1:]))
-    t, c = xp.asarray(t), xp.asarray(c)
+    t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
     return BSpline.construct_fast(t, c, k, axis=axis)
 
 
@@ -2289,6 +2316,8 @@ clamp_values=None):
 
     """
     xp = array_namespace(x, y, t, w)
+    # the NumPy round-trip must return the result on the inputs' device
+    device = xp_result_device(x, y, t, w)
 
     x = _as_float_array(x, check_finite)
     y = _as_float_array(y, check_finite)
@@ -2388,7 +2417,7 @@ clamp_values=None):
     # restore the shape of `c` for both single and multiple r.h.s.
     c = c.reshape((n,) + y.shape[1:])
     c = np.ascontiguousarray(c)
-    t, c = xp.asarray(t), xp.asarray(c)
+    t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
     return BSpline.construct_fast(t, c, k, axis=axis)
 
 
@@ -2938,6 +2967,8 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
 
     """  # noqa:E501
     xp = array_namespace(x, y)
+    # the NumPy round-trip must return the result on the inputs' device
+    device = xp_result_device(x, y)
 
     x = np.ascontiguousarray(x, dtype=float)
     y = np.ascontiguousarray(y, dtype=float)
@@ -3037,7 +3068,7 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
                cm0 * (t[-4] - t[-6]) + cm1,
                cm0 * (2 * t[-4] - t[-5] - t[-6]) + cm1]
 
-    t, c_ = xp.asarray(t), xp.asarray(c_)
+    t, c_ = xp.asarray(t, device=device), xp.asarray(c_, device=device)
     return BSpline.construct_fast(t, c_, 3, axis=axis)
 
 

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from scipy.linalg import solve, solve_banded
 from scipy._lib._array_api import (
-    array_namespace, xp_size, xp_capabilities, is_cupy, scipy_namespace_for
+    array_namespace, xp_size, xp_capabilities, is_cupy, scipy_namespace_for,
+    xp_device, xp_result_device
 )
 from scipy._external.array_api_compat import numpy as np_compat
 import scipy._external.array_api_extra as xpx
@@ -563,7 +564,8 @@ class Akima1DInterpolator(CubicHermiteSpline):
             t = xpx.at(t)[...].set(mk)
         else:
             # determine slopes between breakpoints
-            m = xp.empty((x.shape[0] + 3, ) + y.shape[1:], dtype=x.dtype)
+            m = xp.empty((x.shape[0] + 3, ) + y.shape[1:], dtype=x.dtype,
+                         device=xp_device(x))
             dx = dx[(slice(None), ) + (None, ) * (y.ndim - 1)]
             m = xpx.at(m)[2:-2, ...].set(xp.diff(y, axis=0) / dx)
 
@@ -821,6 +823,8 @@ class CubicSpline(CubicHermiteSpline):
             )
             return
 
+        # the NumPy round-trip must return the result on the inputs' device
+        device = xp_result_device(x, y)
         x, dx, y, axis, _ = prepare_input(x, y, axis, xp=np_compat)
         n = len(x)
 
@@ -986,7 +990,7 @@ class CubicSpline(CubicHermiteSpline):
                                      overwrite_b=True, check_finite=False)
                     s = s.reshape(b.shape)
 
-        x, y, s = map(xp.asarray, (x, y, s))
+        x, y, s = (xp.asarray(arr, device=device) for arr in (x, y, s))
         super().__init__(x, y, s, axis=0, extrapolate=extrapolate)
         self.axis = axis
 

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -29,7 +29,9 @@ import numpy as np
 from . import _fitpack
 from numpy import (atleast_1d, array, ones, zeros, sqrt, ravel, empty, iinfo, asarray)
 
-from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, concat_1d, xp_capabilities, xp_device
+)
 
 
 dfitpack_int = np.int32
@@ -783,7 +785,7 @@ def splder(tck, n=1, xp=None):
                 c = (c[1:-1-k, ...] - c[:-2-k, ...]) * k / dt
                 # Pad coefficient array to same size as knots (FITPACK
                 # convention)
-                c = concat_1d(xp, c, xp.zeros((k,) + c.shape[1:]))
+                c = concat_1d(xp, c, xp.zeros((k,) + c.shape[1:], device=xp_device(c)))
                 # Adjust knots
                 t = t[1:-1]
                 k -= 1
@@ -817,7 +819,7 @@ def splantider(tck, n=1, *, xp=None):
         c = xp.cumulative_sum(c[:-k-1, ...] * dt, axis=0) / (k + 1)
         c = concat_1d(
             xp,
-            xp.zeros((1,) + c.shape[1:]),
+            xp.zeros((1,) + c.shape[1:], device=xp_device(c)),
             c,
             xp.stack([c[-1, ...]] * (k+2)),
         )

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -21,7 +21,9 @@ import warnings
 import operator
 import numpy as np
 
-from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, concat_1d, xp_capabilities, xp_result_device
+)
 
 from ._bsplines import (
     _not_a_knot, make_interp_spline, BSpline, fpcheck, _lsq_solve_qr,
@@ -251,6 +253,8 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None,
 
     """
     xp = array_namespace(x, y, w)
+    # the NumPy round-trip must return the results on the inputs' device
+    device = xp_result_device(x, y, w)
     bc_type = _validate_bc_type(bc_type)
     periodic = bc_type == 'periodic'
 
@@ -263,7 +267,7 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None,
             t = _periodic_knots(x, k)
         else:
             t = _not_a_knot(x, k)
-        yield xp.asarray(t)
+        yield xp.asarray(t, device=device)
         return
 
     x, y, w, k, s, xb, xe = _validate_inputs(
@@ -271,10 +275,11 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None,
         periodic=periodic
     )
 
-    yield from _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=xp)
+    yield from _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic,
+                                    xp=xp, device=device)
 
 
-def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=np):
+def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=np, device=None):
 
     acc = s * TOL
     m = x.size    # the number of data points
@@ -353,7 +358,7 @@ def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=np):
             for j in range(1, k + 1):
                 t[k - j] = t[n - k - j - 1] - per
                 t[n - k + j - 1] = t[k + j] + per
-        yield xp.asarray(t)
+        yield xp.asarray(t, device=device)
 
         # construct the LSQ spline with this set of knots
         fpold = fp
@@ -391,13 +396,13 @@ def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=np):
                     t = _not_a_knot(x, k)
                 else:
                     t = _periodic_knots(x, k)
-                yield xp.asarray(t)
+                yield xp.asarray(t, device=device)
                 return
 
             # c  if n=nest we cannot increase the number of knots because of
             # c  the storage capacity limitation.
             if n >= nest:
-                yield xp.asarray(t)
+                yield xp.asarray(t, device=device)
                 return
 
             # recompute if needed
@@ -917,7 +922,8 @@ def root_rati(f, p0, bracket, acc, maxit=MAXIT):
 
     return Bunch(converged=converged, root=p, iterations=it, ier=ier)
 
-def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np):
+def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np,
+                      device=None):
     """Shared infra for make_splrep and make_splprep.
     """
     acc = s * TOL
@@ -946,7 +952,7 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np):
     if t.shape[0] == 2 * (k + 1):
         # nothing to optimize
         _, _, c, _, _ = _lsq_solve_qr(x, y, t, k, w, periodic=periodic)
-        t, c = xp.asarray(t), xp.asarray(c)
+        t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
         return BSpline(t, c, k)
 
     ### solve ###
@@ -1006,7 +1012,7 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np):
     # f.spl is the spline corresponding to the found `p` value
     t, c, k = f.spl.tck
     axis, extrap = f.spl.axis, f.spl.extrapolate
-    t, c = xp.asarray(t), xp.asarray(c)
+    t, c = xp.asarray(t, device=device), xp.asarray(c, device=device)
     spl = BSpline.construct_fast(t, c, k, axis=axis, extrapolate=extrap)
     return spl
 
@@ -1143,8 +1149,10 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
     .. versionadded:: 1.15.0
     """  # noqa:E501
     xp = array_namespace(x, y, w, t)
+    # the NumPy round-trip must return the result on the inputs' device
+    device = xp_result_device(x, y, w, t)
     if t is not None:
-        t = xp.asarray(t)
+        t = xp.asarray(t, device=device)
     bc_type = _validate_bc_type(bc_type)
 
     if s == 0:
@@ -1157,7 +1165,8 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
     x, y, w, k, s, xb, xe = _validate_inputs(x, y, w, k, s, xb, xe,
                                              parametric=False, periodic=periodic)
 
-    spl = _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=xp)
+    spl = _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=xp,
+                            device=device)
 
     # postprocess: squeeze out the last dimension: was added to simplify the internals.
     spl.c = spl.c[:, 0]
@@ -1309,8 +1318,12 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     # x can be either a 2D array or a list of 1D arrays
     if isinstance(x, list):
         xp = array_namespace(*x, w, u, t)
+        x_seq = x
     else:
         xp = array_namespace(x, w, u, t)
+        x_seq = (x,)
+    # the NumPy round-trip must return the result on the inputs' device
+    device = xp_result_device(*x_seq, w, u, t)
 
     x = xp.stack(x, axis=1)
 
@@ -1329,10 +1342,10 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
                                              parametric=True, periodic=periodic)
 
     if t is not None:
-        t = xp.asarray(t)
+        t = xp.asarray(t, device=device)
 
     spl = _make_splrep_impl(u, x, w, ub, ue, k, s, t,
-                            nest, periodic=periodic, xp=xp)
+                            nest, periodic=periodic, xp=xp, device=device)
 
     # posprocess: `axis=1` so that spl(u).shape == np.shape(x)
     # when `x` is a list of 1D arrays (cf original splPrep)
@@ -1342,4 +1355,4 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
         extrapolate='periodic' if periodic else True
     )
 
-    return spl1, xp.asarray(u)
+    return spl1, xp.asarray(u, device=device)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -13,7 +13,8 @@ from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
-    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy
+    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy,
+    xp_result_device
 )
 
 from . import _fitpack_py
@@ -1399,11 +1400,15 @@ class PPoly:
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        # a NumPy round-trip in the delegate must return results on the
+        # device of the inputs, not on the backend's default device
+        device = xp_result_device(c, x)
         if not is_numpy(xp):
             c, x = xp_internal.asarray(c), xp_internal.asarray(x)
         self._delegate_to = xp_ppoly_cls(c, x, extrapolate=extrapolate, axis=axis)
         self._xp = xp
         self._xp_internal = xp_internal
+        self._device = device
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1416,13 +1421,15 @@ class PPoly:
         _, xp_internal = _get_xp_ppoly_cls(self._xp)
         self._xp_internal = xp_internal
         self.__dict__.update(state)
+        self.__dict__.setdefault("_device", None)
 
     @classmethod
-    def _construct_from_xp(cls, xp_ppoly, *, xp_external):
+    def _construct_from_xp(cls, xp_ppoly, *, xp_external, device=None):
         self = object.__new__(cls)
         self._delegate_to = xp_ppoly
         self._xp = xp_external
         self._xp_internal = array_namespace(xp_ppoly.c)
+        self._device = device
         return self
 
     @classmethod
@@ -1437,17 +1444,19 @@ class PPoly:
         """
         xp = array_namespace(c, x)
         xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        device = xp_result_device(c, x)
         c, x = xp_internal.asarray(c), xp_internal.asarray(x)
         return cls._construct_from_xp(
             xp_ppoly_cls.construct_fast(
                 c, x, extrapolate=extrapolate, axis=axis
             ),
             xp_external=xp,
+            device=device,
         )
 
     @property
     def c(self):
-        return self._xp.asarray(self._delegate_to.c)
+        return self._xp.asarray(self._delegate_to.c, device=self._device)
 
     @c.setter
     def c(self, c):
@@ -1457,7 +1466,7 @@ class PPoly:
 
     @property
     def x(self):
-        return self._xp.asarray(self._delegate_to.x)
+        return self._xp.asarray(self._delegate_to.x, device=self._device)
 
     @x.setter
     def x(self, x):
@@ -1535,10 +1544,14 @@ class PPoly:
         ``[a, b)``, except for the last interval which is closed
         ``[a, b]``.
         """
+        device = xp_result_device(x)
+        if device is None:
+            device = self._device
         return self._xp.asarray(
             self._delegate_to(
                 self._xp_internal.asarray(x), nu=nu, extrapolate=extrapolate
-            )
+            ),
+            device=device,
         )
 
     def derivative(self, nu=1):
@@ -1568,6 +1581,7 @@ class PPoly:
         return self._construct_from_xp(
             self._delegate_to.derivative(nu=nu),
             xp_external=self._xp,
+            device=self._device,
         )
 
     def antiderivative(self, nu=1):
@@ -1603,6 +1617,7 @@ class PPoly:
         return self._construct_from_xp(
             self._delegate_to.antiderivative(nu=nu),
             xp_external=self._xp,
+            device=self._device,
         )
 
     def integrate(self, a, b, extrapolate=None):
@@ -1627,7 +1642,8 @@ class PPoly:
             Definite integral of the piecewise polynomial over [a, b]
         """
         return self._xp.asarray(
-            self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+            self._delegate_to.integrate(a, b, extrapolate=extrapolate),
+            device=self._device,
         )
 
     def solve(self, y=0, discontinuity=True, extrapolate=None):
@@ -1682,7 +1698,8 @@ class PPoly:
         return self._xp.asarray(
             self._delegate_to.solve(
                 y=y, discontinuity=discontinuity, extrapolate=extrapolate
-            )
+            ),
+            device=self._device,
         )
 
     def roots(self, discontinuity=True, extrapolate=None):
@@ -1790,9 +1807,10 @@ class PPoly:
             t, c, k = tck
             xp = array_namespace(t, c)
         xp_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        device = xp_result_device(t, c)
         t, c = xp_internal.asarray(t), xp_internal.asarray(c)
         pp = xp_cls.from_spline((t, c, k), extrapolate=extrapolate)
-        return cls._construct_from_xp(pp, xp_external=xp)
+        return cls._construct_from_xp(pp, xp_external=xp, device=device)
 
     @classmethod
     def from_bernstein_basis(cls, bp, extrapolate=None):
@@ -1815,7 +1833,7 @@ class PPoly:
         xp = bp._xp
         xp_cls, _ = _get_xp_ppoly_cls(xp)
         pp = xp_cls.from_bernstein_basis(bp._delegate_to, extrapolate=extrapolate)
-        return cls._construct_from_xp(pp, xp_external=xp)
+        return cls._construct_from_xp(pp, xp_external=xp, device=bp._device)
 
 
 _bpoly_extra_note = (
@@ -1933,11 +1951,15 @@ class BPoly:
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_bpoly_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        # a NumPy round-trip in the delegate must return results on the
+        # device of the inputs, not on the backend's default device
+        device = xp_result_device(c, x)
         if not is_numpy(xp):
             c, x = xp_internal.asarray(c), xp_internal.asarray(x)
         self._delegate_to = xp_bpoly_cls(c, x, extrapolate=extrapolate, axis=axis)
         self._xp = xp
         self._xp_internal = xp_internal
+        self._device = device
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1950,13 +1972,15 @@ class BPoly:
         _, xp_internal = _get_xp_bpoly_cls(self._xp)
         self._xp_internal = xp_internal
         self.__dict__.update(state)
+        self.__dict__.setdefault("_device", None)
 
     @classmethod
-    def _construct_from_xp(cls, xp_bpoly, *, xp_external):
+    def _construct_from_xp(cls, xp_bpoly, *, xp_external, device=None):
         self = object.__new__(cls)
         self._delegate_to = xp_bpoly
         self._xp = xp_external
         self._xp_internal = array_namespace(xp_bpoly.c)
+        self._device = device
         return self
 
     @classmethod
@@ -1971,17 +1995,19 @@ class BPoly:
         """
         xp = array_namespace(c, x)
         xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        device = xp_result_device(c, x)
         c, x = xp_internal.asarray(c), xp_internal.asarray(x)
         return cls._construct_from_xp(
             xp_ppoly_cls.construct_fast(
                 c, x, extrapolate=extrapolate, axis=axis
             ),
             xp_external=xp,
+            device=device,
         )
 
     @property
     def c(self):
-        return self._xp.asarray(self._delegate_to.c)
+        return self._xp.asarray(self._delegate_to.c, device=self._device)
 
     @c.setter
     def c(self, c):
@@ -1991,7 +2017,7 @@ class BPoly:
 
     @property
     def x(self):
-        return self._xp.asarray(self._delegate_to.x)
+        return self._xp.asarray(self._delegate_to.x, device=self._device)
 
     @x.setter
     def x(self, x):
@@ -2069,10 +2095,14 @@ class BPoly:
         ``[a, b)``, except for the last interval which is closed
         ``[a, b]``.
         """
+        device = xp_result_device(x)
+        if device is None:
+            device = self._device
         return self._xp.asarray(
             self._delegate_to(
                 self._xp_internal.asarray(x), nu=nu, extrapolate=extrapolate
-            )
+            ),
+            device=device,
         )
 
     def derivative(self, nu=1):
@@ -2095,6 +2125,7 @@ class BPoly:
         return self._construct_from_xp(
             self._delegate_to.derivative(nu=nu),
             xp_external=self._xp,
+            device=self._device,
         )
 
     def antiderivative(self, nu=1):
@@ -2123,6 +2154,7 @@ class BPoly:
         return self._construct_from_xp(
             self._delegate_to.antiderivative(nu=nu),
             xp_external=self._xp,
+            device=self._device,
         )
 
     def integrate(self, a, b, extrapolate=None):
@@ -2147,7 +2179,8 @@ class BPoly:
 
         """
         return self._xp.asarray(
-            self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+            self._delegate_to.integrate(a, b, extrapolate=extrapolate),
+            device=self._device,
         )
 
     @classmethod
@@ -2171,7 +2204,7 @@ class BPoly:
         xp = pp._xp
         xp_cls, _ = _get_xp_bpoly_cls(xp)
         bp = xp_cls.from_power_basis(pp._delegate_to, extrapolate=extrapolate)
-        return cls._construct_from_xp(bp, xp_external=xp)
+        return cls._construct_from_xp(bp, xp_external=xp, device=pp._device)
 
     @classmethod
     def from_derivatives(cls, xi, yi, orders=None, extrapolate=None):
@@ -2246,6 +2279,8 @@ class BPoly:
         else:
             xp = array_namespace(xi, yi)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        yi_seq = yi if isinstance(yi, (list, tuple)) else (yi,)
+        device = xp_result_device(xi, *yi_seq)
         xi = xp_internal.asarray(xi)
         if isinstance(yi, (list, tuple)):
             # If yi is a ragged list or tuple of arrays, then need to apply
@@ -2257,7 +2292,7 @@ class BPoly:
         bp = xp_cls.from_derivatives(
             xi, yi, orders=orders, extrapolate=extrapolate
         )
-        return cls._construct_from_xp(bp, xp_external=xp)
+        return cls._construct_from_xp(bp, xp_external=xp, device=device)
 
     @staticmethod
     def _construct_from_derivatives(xa, xb, ya, yb):
@@ -2316,8 +2351,10 @@ class BPoly:
         """
         xp = array_namespace(ya, yb)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        device = xp_result_device(ya, yb)
         ya, yb = xp_internal.asarray(ya), xp_internal.asarray(yb)
-        return xp.asarray(xp_cls._construct_from_derivatives(xa, xb, ya, yb))
+        return xp.asarray(
+            xp_cls._construct_from_derivatives(xa, xb, ya, yb), device=device)
 
     @staticmethod
     def _raise_degree(c, d):
@@ -2349,7 +2386,9 @@ class BPoly:
         """
         xp = array_namespace(c)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
-        return xp.asarray(xp_cls._raise_degree(xp_internal.asarray(c), d))
+        device = xp_result_device(c)
+        return xp.asarray(
+            xp_cls._raise_degree(xp_internal.asarray(c), d), device=device)
 
 class NdPPoly:
     """

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -10,7 +10,9 @@ from . import _dierckx
 
 import scipy.sparse.linalg as ssl
 from scipy.sparse import csr_array, diags_array
-from scipy._lib._array_api import array_namespace, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, xp_capabilities, xp_result_device
+)
 
 from ._bsplines import _not_a_knot, BSpline
 
@@ -91,7 +93,10 @@ class NdBSpline:
     def __init__(self, t, c, k, *, extrapolate=None):
         self._k, self._indices_k1d, (self._t, self._len_t) = _preprocess_inputs(k, t)
 
-        self._asarray = array_namespace(c, *t).asarray
+        # the NumPy round-trip must return results on the inputs' device
+        device = xp_result_device(c, *t)
+        self._asarray = functools.partial(
+            array_namespace(c, *t).asarray, device=device)
 
         if extrapolate is None:
             extrapolate = True

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -9,7 +9,7 @@ from . import _rbfinterp_np
 from . import _rbfinterp_xp
 
 from scipy._lib._array_api import (
-    _asarray, array_namespace, xp_size, is_numpy, xp_capabilities
+    _asarray, array_namespace, xp_size, is_numpy, xp_capabilities, xp_device
 )
 import scipy._external.array_api_extra as xpx
 
@@ -264,7 +264,8 @@ class RBFInterpolator:
         d = d.view(float)     # NB not Array API compliant (and jax copies)
 
         if isinstance(smoothing, int | float) or smoothing.shape == ():
-            smoothing = xp.full(ny, smoothing, dtype=xp.float64)
+            smoothing = xp.full(ny, smoothing, dtype=xp.float64,
+                                device=xp_device(y))
         else:
             smoothing = _asarray(smoothing, dtype=float, order="C", xp=xp)
             if smoothing.shape != (ny,):
@@ -313,7 +314,8 @@ class RBFInterpolator:
             neighbors = int(min(neighbors, ny))
             nobs = neighbors
 
-        powers = _backend._monomial_powers(ndim, degree, xp)
+        powers = _backend._monomial_powers(ndim, degree, xp,
+                                           device=xp_device(y))
         # The polynomial matrix must have full column rank in order for the
         # interpolant to be well-posed, which is not possible if there are
         # fewer observations than monomials.
@@ -418,7 +420,8 @@ class RBFInterpolator:
         # in each chunk we consume the same space we already occupy
         chunksize = memory_budget // (self.powers.shape[0] + nnei) + 1
         if chunksize <= nx:
-            out = self._xp.empty((nx, self.d.shape[1]), dtype=self._xp.float64)
+            out = self._xp.empty((nx, self.d.shape[1]), dtype=self._xp.float64,
+                                 device=xp_device(self.d))
             for i in range(0, nx, chunksize):
                 chunk = _backend.compute_interpolation(
                     x[i:i + chunksize, :],

--- a/scipy/interpolate/_rbfinterp_np.py
+++ b/scipy/interpolate/_rbfinterp_np.py
@@ -25,7 +25,7 @@ def polynomial_matrix(x, powers, xp):
     return _pythran_polynomial_matrix(x, powers)
 
 
-def _monomial_powers(ndim, degree, xp):
+def _monomial_powers(ndim, degree, xp, device=None):
     out = _monomial_powers_impl(ndim, degree)
     out = np.asarray(out, dtype=np.int64)
     if len(out) == 0:

--- a/scipy/interpolate/_rbfinterp_xp.py
+++ b/scipy/interpolate/_rbfinterp_xp.py
@@ -26,12 +26,14 @@ In general, we would prefer less code duplication. The main blocker ATM is
 that pythran cannot compile functions with an xp= argument where xp is numpy.
 """
 from numpy.linalg import LinAlgError
+from scipy._lib._array_api import xp_device
 from ._rbfinterp_common import _monomial_powers_impl
 
 
-def _monomial_powers(ndim, degree, xp):
+def _monomial_powers(ndim, degree, xp, device=None):
     out = _monomial_powers_impl(ndim, degree)
-    out = xp.asarray(out)
+    # `out` is a NumPy array; convert onto the data's device (gh-22680)
+    out = xp.asarray(out, device=device)
     if out.shape[0] == 0:
         out = xp.reshape(out, (0, ndim))
     return out
@@ -202,11 +204,11 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers, xp):
     lhs = xp.concat(
         [
          xp.concat((out_kernels, out_poly), axis=1),
-         xp.concat((out_poly.T, xp.zeros((r, r))), axis=1)
+         xp.concat((out_poly.T, xp.zeros((r, r), device=xp_device(y))), axis=1)
         ]
-    , axis=0) + xp.diag(xp.concat([smoothing, xp.zeros(r)]))
+    , axis=0) + xp.diag(xp.concat([smoothing, xp.zeros(r, device=xp_device(y))]))
 
-    rhs = xp.concat([d, xp.zeros((r, s))], axis=0)
+    rhs = xp.concat([d, xp.zeros((r, s), device=xp_device(d))], axis=0)
 
     return lhs, rhs, shift, scale
 

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -1,12 +1,15 @@
 __all__ = ['RegularGridInterpolator', 'interpn']
 
+import functools
 import itertools
 from types import GenericAlias
 
 import numpy as np
 
 import scipy.sparse.linalg as ssl
-from scipy._lib._array_api import array_namespace, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, xp_capabilities, xp_result_device
+)
 from scipy._external.array_api_compat import is_array_api_obj
 
 from ._interpnd import _ndim_coords_from_arrays
@@ -307,7 +310,9 @@ class RegularGridInterpolator:
                 if xp_v != xp:
                     raise e
 
-        self._asarray = xp.asarray
+        # the NumPy round-trip must return results on the inputs' device
+        device = xp_result_device(*points, values)
+        self._asarray = functools.partial(xp.asarray, device=device)
         self.method = method
         self._spline = None
         self.bounds_error = bounds_error


### PR DESCRIPTION
Device-propagation fixes for issue gh-22680: internal array creation that omits `device=` lands on the backend's default device and raises (or silently misplaces results) when the input arrays reside elsewhere.

- The `BSpline`/`PPoly`/`BPoly` delegation wrappers store the inputs' device (`self._device`) and thread it through construction classmethods, properties, evaluation, calculus and conversions, so results of the internal NumPy round-trips return on the input's device.
- `RegularGridInterpolator` and `NdBSpline` convert internal arrays via a device-bound `functools.partial(xp.asarray, device=...)`.
- `make_interp_spline`/`make_lsq_spline`/`make_splrep`/`make_splprep` and the fitpack paths anchor knots, coefficients and workspace arrays on the common device of their inputs (via `xp_result_device` and `concat_1d`).
- The RBF interpolator creates its internal coefficient and evaluation arrays on the device of the data points.

This is the sixth PR of the series, following gh-25722


#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see gh-25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.
