### PR TITLE
STY: Make `spin lint --all` happy

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -176,7 +176,8 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction, *, x
 
 @xp_capabilities(skip_backends=[('dask.array', "")], cpu_only=True,
                  reason="binomial distribution ufuncs only available for NumPy",
-                 extra_note="`alternative='two-sided'` is incompatible with JAX arrays.")
+                 extra_note=("`alternative='two-sided'` is incompatible with JAX "
+                             "arrays."))
 def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.


### PR DESCRIPTION
#### What does this implement/fix?
Running `spin lint --all` on the codebase will throw a lint error.
This was uncaught since the lint job only runs on changes, not all files.
Fix the respective line-length violation.

#### AI Generation Disclosure
No AI tools used

[lint only]