### PR TITLE
DEV: update CODEOWNERS and fix `tools/` clobbering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,7 @@ benchmarks/asv.conf.json  @larsoner
 
 # Tools
 tools/  @rgommers
-tools/build/  @rgommers
+tools/building/  @rgommers
 tools/linting/  @lucascolley
 tools/refguide/  @ev-br
 tools/release/  @tylerjereddy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,10 +14,10 @@
 
 # Build related files
 pyproject.toml  @rgommers
-tools/generate_requirements.py  @rgommers
-requirements/  @rgommers
-environment.yml  @rgommers
+requirements/  @rgommers @lucascolley
+environment.yml  @rgommers @lucascolley
 scipy/_build_utils/  @rgommers
+scipy/_external  @lucascolley
 
 # Dev CLI
 .spin  @rgommers
@@ -28,9 +28,6 @@ scipy/_build_utils/  @rgommers
 
 # Developer workspace
 *pixi*  @lucascolley
-
-# Linting
-lint*  @lucascolley
 
 # Array API
 *array_api*  @lucascolley
@@ -45,7 +42,7 @@ scipy/optimize/  @andyfaff
 scipy/signal/  @larsoner @ilayn @DietBru
 scipy/sparse/  @perimosocordiae @dschult
 scipy/sparse/csgraph/
-scipy/sparse/linalg/
+scipy/sparse/linalg/  @lucascolley
 scipy/spatial/  @tylerjereddy @peterbell10
 scipy/special/  @steppi
 scipy/stats/_distn_infrastructure/  @andyfaff @ev-br
@@ -62,11 +59,18 @@ scipy/stats/_survival.py  @tupui @mdhaber
 scipy/stats/.unuran/  @tirthasheshpatel
 
 # Testing infrastructure
-tools/refguide/refguide_check.py  @ev-br
-tools/  @larsoner @rgommers
 pytest.ini  @larsoner
 .coveragerc  @larsoner
 benchmarks/asv.conf.json  @larsoner
+
+# Tools
+tools/  @rgommers
+tools/build/  @rgommers
+tools/linting/  @lucascolley
+tools/refguide/  @ev-br
+tools/release/  @tylerjereddy
+tools/vendoring/  @lucascolley
+tools/wheels/  @andyfaff @rgommers
 
 # Doc
 doc/source/conf.py  @tupui


### PR DESCRIPTION
On `main`, the line `tools/  @larsoner @rgommers` unintentionally clobbers all other preceding matches — I discovered this because I was expecting to receive a ping on `tools/linting/lint.toml` but did not. This PR fixes that, alongside introducing some greater precision ownership, following my PR gh-25709 which brought some order to the `tools` directory:
- The default `tools/` ownership is now just @rgommers 
- `building` -> @rgommers
- `linting` -> @lucascolley 
- `refguide` -> @ev-br 
- `release` -> @tylerjereddy 
- `vendoring` -> @lucascolley 
- `wheels` -> @andyfaff @rgommers 

Also, sign myself up for some more pings:
- `scipy/sparse/linalg/`
- `requirements/`
- `environment.yml`
- `scipy/_external`

Friendly ping @larsoner to check whether you still want default ownership of `tools/` (and if you would like to change any of the other entries you have).