### PR TITLE
MAINT: special: migrate `nctdtridf` to XSF ufunc machinery

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4216,65 +4216,6 @@ add_newdoc("nctdtr",
 
     """)
 
-add_newdoc("nctdtridf",
-    """
-    nctdtridf(p, nc, t, out=None)
-
-    Calculate degrees of freedom for non-central t distribution.
-
-    See `nctdtr` for more details.
-
-    Parameters
-    ----------
-    p : array_like
-        CDF values, in range (0, 1].
-    nc : array_like
-        Noncentrality parameter. Should be in range (-1e6, 1e6).
-    t : array_like
-        Quantiles, i.e., the upper limit of integration.
-    out : ndarray, optional
-        Optional output array for the function results
-
-    Returns
-    -------
-    df : scalar or ndarray
-        The degrees of freedom. If all inputs are scalar, the return will be a
-        float. Otherwise, it will be an array.
-
-    See Also
-    --------
-    nctdtr :  CDF of the non-central `t` distribution.
-    nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
-    nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
-
-    Notes
-    -----
-    This function calculates the degrees of freedom of the non-central t
-    distribution given a probability, quantile and non-centrality parameter
-    using the Boost Math C++ library [1]_.
-
-    References
-    ----------
-    .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
-
-    Examples
-    --------
-    >>> from scipy.special import nctdtr, nctdtridf
-
-    Compute the CDF for several values of `df`:
-
-    >>> df = [1, 2, 3]
-    >>> p = nctdtr(df, 0.25, 1)
-    >>> p
-    array([0.67491974, 0.716464  , 0.73349456])
-
-    Compute the inverse. We recover the values of `df`, as expected:
-
-    >>> nctdtridf(p, 0.25, 1)
-    array([1., 2., 3.])
-
-    """)
-
 add_newdoc("nctdtrinc",
     """
     nctdtrinc(df, p, t, out=None)

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -224,6 +224,7 @@ special_ufuncs = [
     "modfresnelm",
     "modfresnelp",
     "modstruve",
+    "nctdtridf",
     "ndtr",
     "ndtri",
     "ndtri_exp",

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -200,6 +200,7 @@ extern const char *mathieu_modsem2_doc;
 extern const char *mathieu_sem_doc;
 extern const char *modfresnelm_doc;
 extern const char *modfresnelp_doc;
+extern const char *nctdtridf_doc;
 extern const char *ndtr_doc;
 extern const char *ndtri_doc;
 extern const char *ndtri_exp_doc;
@@ -653,6 +654,12 @@ _special_ufuncs_module_exec(PyObject *module)
                            static_cast<xsf::numpy::F_F>(xsf::dawsn), static_cast<xsf::numpy::D_D>(xsf::dawsn)},
                           "dawsn", dawsn_doc);
     PyModule_AddObjectRef(module, "dawsn", dawsn);
+
+    PyObject *nctdtridf =
+        xsf::numpy::ufunc({static_cast<xsf::numpy::fff_f>(nct_find_degrees_of_freedom_float),
+                           static_cast<xsf::numpy::ddd_d>(nct_find_degrees_of_freedom_double)},
+                          "nctdtridf", nctdtridf_doc);
+    PyModule_AddObjectRef(module, "nctdtridf", nctdtridf);
 
     PyObject *ndtr =
         xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::ndtr), static_cast<xsf::numpy::d_d>(xsf::ndtr),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -8233,6 +8233,64 @@ const char *obl_ang1_doc = R"(
 
     )";
 
+const char *nctdtridf_doc = R"(
+    nctdtridf(p, nc, t, out=None)
+
+    Calculate degrees of freedom for non-central t distribution.
+
+    See `nctdtr` for more details.
+
+    Parameters
+    ----------
+    p : array_like
+        CDF values, in range (0, 1].
+    nc : array_like
+        Noncentrality parameter. Should be in range (-1e6, 1e6).
+    t : array_like
+        Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    df : scalar or ndarray
+        The degrees of freedom. If all inputs are scalar, the return will be a
+        float. Otherwise, it will be an array.
+
+    See Also
+    --------
+    nctdtr :  CDF of the non-central `t` distribution.
+    nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
+    nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
+
+    Notes
+    -----
+    This function calculates the degrees of freedom of the non-central t
+    distribution given a probability, quantile and non-centrality parameter
+    using the Boost Math C++ library [1]_.
+
+    References
+    ----------
+    .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+
+    Examples
+    --------
+    >>> from scipy.special import nctdtr, nctdtridf
+
+    Compute the CDF for several values of `df`:
+
+    >>> df = [1, 2, 3]
+    >>> p = nctdtr(df, 0.25, 1)
+    >>> p
+    array([0.67491974, 0.716464  , 0.73349456])
+
+    Compute the inverse. We recover the values of `df`, as expected:
+
+    >>> nctdtridf(p, 0.25, 1)
+    array([1., 2., 3.])
+
+    )";
+
 const char *ndtr_doc = R"(
     ndtr(x, out=None)
 

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1402,6 +1402,7 @@ cdef extern from r"cython_special_wrappers.h":
 
     double boost_bdtrik(double y, double n, double p) nogil
     double boost_bdtrin(double k, double y, double p) nogil
+    double boost_nctdtridf(double p, double nc, double t) nogil
 
 from ._legacy cimport bdtr_unsafe as _func_bdtr_unsafe
 ctypedef double _proto_bdtr_unsafe_t(double, double, double) noexcept nogil
@@ -3113,7 +3114,7 @@ cpdef df_number_t nctdtr(df_number_t x0, df_number_t x1, df_number_t x2) noexcep
 
 cpdef double nctdtridf(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nctdtridf"""
-    return (<double(*)(double, double, double) noexcept nogil>scipy.special._ufuncs_cxx._export_nct_find_degrees_of_freedom_double)(x0, x1, x2)
+    return boost_nctdtridf(x0, x1, x2)
 
 cpdef double nctdtrinc(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nctdtrinc"""

--- a/scipy/special/cython_special_wrappers.cpp
+++ b/scipy/special/cython_special_wrappers.cpp
@@ -716,3 +716,8 @@ double xsf_radian(double d, double m, double s) { return xsf::radian(d, m, s); }
  double boost_bdtrik(double y, double n, double p) { return bdtrik_double(y, n, p); }
 
 double boost_bdtrin(double k, double y, double p) { return bdtrin_double(k, y, p); }
+
+double boost_nctdtridf(double p, double nc, double t)
+{
+    return nct_find_degrees_of_freedom_double(p, nc, t);
+}

--- a/scipy/special/cython_special_wrappers.h
+++ b/scipy/special/cython_special_wrappers.h
@@ -396,6 +396,7 @@ double xsf_radian(double d, double m, double s);
 
 double boost_bdtrik(double y, double n, double p);
 double boost_bdtrin(double k, double y, double p);
+double boost_nctdtridf(double p, double nc, double t);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -391,12 +391,6 @@
             "nct_cdf_float": "fff->f",
             "nct_cdf_double": "ddd->d"    }
     },
-    "nctdtridf": {
-        "boost_special_functions.h++": {
-            "nct_find_degrees_of_freedom_float": "fff->f",
-            "nct_find_degrees_of_freedom_double": "ddd->d"
-        }
-    },
     "nctdtrinc": {
         "boost_special_functions.h++": {
             "nct_find_non_centrality_float": "fff->f",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue


#### What does this implement/fix?
Same pattern as https://github.com/scipy/scipy/pull/25701 for `special.nctdtridf`

#### Additional information
<!--Any additional information you think is important.-->
For now, I chose to only do one function.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I used Codex to match the migration used in https://github.com/scipy/scipy/pull/25701