### PR TITLE
MAINT: signal: propagate the input device in array creation

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -20,7 +20,7 @@ from scipy.signal import _polyutils as _pu
 import scipy._external.array_api_extra as xpx
 from scipy._lib._array_api import (
     array_namespace, xp_promote, xp_size, is_jax, xp_float_to_complex,
-    xp_result_type,
+    xp_result_type, xp_device, xp_result_device, _xp_result_devices,
 )
 from scipy._external.array_api_compat import numpy as np_compat
 
@@ -74,7 +74,8 @@ def _real_dtype_for_complex(dtyp, *, xp):
 
 
 # https://github.com/numpy/numpy/blob/v2.2.0/numpy/_core/function_base.py#L195-L302
-def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, *, xp):
+def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, *, xp,
+              device=None):
     if not isinstance(base, float | int) and xp.asarray(base).ndim > 0:
         # If base is non-scalar, broadcast it with the others, since it
         # may influence how axis is interpreted.
@@ -90,7 +91,8 @@ def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, *, xp):
     except ValueError:
         # all of start, stop and base are python scalars
         result_dt = xpx.default_dtype(xp)
-    y = xp.linspace(start, stop, num=num, endpoint=endpoint, dtype=result_dt)
+    y = xp.linspace(start, stop, num=num, endpoint=endpoint, dtype=result_dt,
+                    device=device)
 
     yp = xp.pow(base, y)
     if dtype is None:
@@ -149,7 +151,7 @@ def findfreqs(num, den, N, kind='ba'):
     tz = xp_float_to_complex(tz, xp=xp)
 
     if ep.shape[0] == 0:
-        ep = xp.asarray([-1000], dtype=ep.dtype)
+        ep = xp.asarray([-1000], dtype=ep.dtype, device=xp_device(ep))
 
     ez = xp.concat((
         ep[xp.imag(ep) >= 0],
@@ -168,7 +170,7 @@ def findfreqs(num, den, N, kind='ba'):
         xp.log10(0.1*xp.min(xp.abs(xp.real(ez + integ)) + 2*xp.imag(ez))) - 0.5 - fudge
     )
 
-    w = _logspace(lfreq, hfreq, N, xp=xp)
+    w = _logspace(lfreq, hfreq, N, xp=xp, device=xp_device(ez))
     return w
 
 
@@ -316,7 +318,7 @@ def freqs_zpk(z, p, k, worN=200):
 
     # NB: k is documented to be a scalar; for backwards compat we keep allowing it
     # to be a size-1 array, but it does not influence the namespace calculation.
-    k = xp.asarray(k, dtype=xpx.default_dtype(xp))
+    k = xp.asarray(k, dtype=xpx.default_dtype(xp), device=xp_device(z))
     if xp_size(k) > 1:
         raise ValueError('k must be a single scalar gain')
 
@@ -497,7 +499,13 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
     """
     xp = array_namespace(b, a)
 
-    b, a = map(xp.asarray, (b, a))
+    # `_xp_result_devices` (rather than a single `xp_result_device` anchor)
+    # because each of `b`, `a` may independently be a scalar (e.g. the
+    # default ``a=1``) or an array: scalars are created on the array
+    # partner's device, while arrays keep their own -- a shared anchor
+    # would silently transfer the second of two mismatched arrays.
+    _, devices = _xp_result_devices(b, a)
+    b, a = (xp.asarray(arg, device=d) for arg, d in zip((b, a), devices))
     if xp.isdtype(a.dtype, 'integral'):
         a = xp.astype(a, xpx.default_dtype(xp))
     res_dtype = xp.result_type(b, a)
@@ -523,7 +531,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
         # if include_nyquist is true and whole is false, w should
         # include end point
         w = xp.linspace(0, lastpoint, N,
-                        endpoint=include_nyquist and not whole, dtype=real_dtype)
+                        endpoint=include_nyquist and not whole, dtype=real_dtype,
+                        device=xp_device(b))
         n_fft = N if whole else 2 * (N - 1) if include_nyquist else 2 * N
         if (xp_size(a) == 1 and (b.ndim == 1 or (b.shape[-1] == 1))
                 and n_fft >= b.shape[0]
@@ -538,7 +547,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
 
             h = fft_func(b, n=n_fft, axis=0)
             h = h[:min(N, h.shape[0]), ...]
-            h /= a
+            h /= xp.astype(a, h.dtype)
 
             if fft_func is sp_fft.rfft and whole:
                 # exclude DC and maybe Nyquist (no need to use axis_reverse
@@ -674,9 +683,11 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
 
     if worN is None:
         # For backwards compatibility
-        w = xp.linspace(0, lastpoint, 512, endpoint=False, dtype=res_dtype)
+        w = xp.linspace(0, lastpoint, 512, endpoint=False, dtype=res_dtype,
+                        device=xp_device(z))
     elif _is_int_type(worN):
-        w = xp.linspace(0, lastpoint, worN, endpoint=False, dtype=res_dtype)
+        w = xp.linspace(0, lastpoint, worN, endpoint=False, dtype=res_dtype,
+                        device=xp_device(z))
     else:
         w = xp.asarray(worN)
         if xp.isdtype(w.dtype, 'integral'):
@@ -686,7 +697,8 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
 
     zm1 = xp.exp(1j * w)
     func = _pu.npp_polyvalfromroots
-    h = xp.asarray(k, dtype=res_dtype) * func(zm1, z, xp=xp) / func(zm1, p, xp=xp)
+    h = (xp.asarray(k, dtype=res_dtype, device=xp_device(z))
+         * func(zm1, z, xp=xp) / func(zm1, p, xp=xp))
 
     w = w*(fs/(2*pi))
 
@@ -774,6 +786,7 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
 
     """
     xp = array_namespace(*system, w)
+    device = xp_result_device(*system, w)
     b, a = map(np.atleast_1d, system)
 
     if w is None:
@@ -818,7 +831,7 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
 
     w = w * (fs / (2 * xp.pi))
 
-    return xp.asarray(w), xp.asarray(gd)
+    return xp.asarray(w, device=device), xp.asarray(gd, device=device)
 
 
 def _validate_sos(sos, xp=None):
@@ -1281,8 +1294,10 @@ def zpk2tf(z, p, k):
     (   array([  5., -40.,  60.]), array([ 1., -9.,  8.]))
     """
     xp = array_namespace(z, p)
+    device = xp_result_device(z, p, k)
     z, p = map(xp.asarray, (z, p))
-    k = xp.asarray(k, dtype=xp.result_type(xp.real(z), xp.real(p), k))
+    k = xp.asarray(k, dtype=xp.result_type(xp.real(z), xp.real(p), k),
+                   device=device)
     if xp.isdtype(k.dtype, "integral"):
         k = xp.astype(k, xp.float64)
 
@@ -1292,7 +1307,8 @@ def zpk2tf(z, p, k):
     if z.ndim > 1:
         temp = _pu.poly(z[0, ...], xp=xp)
         result_dtype = xp_result_type(temp, k, force_floating=True, xp=xp)
-        b = xp.empty((z.shape[0], z.shape[1] + 1), dtype=result_dtype)
+        b = xp.empty((z.shape[0], z.shape[1] + 1), dtype=result_dtype,
+                     device=xp_device(z))
         if k.shape[0] == 1:
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
@@ -1410,8 +1426,8 @@ def sos2tf(sos):
     if xp.isdtype(result_type, 'integral'):
         result_type = xpx.default_dtype(xp)
 
-    b = xp.asarray([1], dtype=result_type)
-    a = xp.asarray([1], dtype=result_type)
+    b = xp.asarray([1], dtype=result_type, device=xp_device(sos))
+    a = xp.asarray([1], dtype=result_type, device=xp_device(sos))
 
     n_sections = sos.shape[0]
     for section in range(n_sections):
@@ -1451,8 +1467,8 @@ def sos2zpk(sos):
     sos = xp.asarray(sos)
 
     n_sections = sos.shape[0]
-    z = xp.zeros(n_sections*2, dtype=xp.complex128)
-    p = xp.zeros(n_sections*2, dtype=xp.complex128)
+    z = xp.zeros(n_sections*2, dtype=xp.complex128, device=xp_device(sos))
+    p = xp.zeros(n_sections*2, dtype=xp.complex128, device=xp_device(sos))
     k = 1.
     for section in range(n_sections):
         zpk = tf2zpk(sos[section, :3], sos[section, 3:])
@@ -1664,6 +1680,7 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
     # See the wiki for other potential issues.
 
     xp = array_namespace(z, p)
+    device = xp_result_device(z, p, k)
 
     # convert to numpy, convert back on exit   XXX
     z, p = map(np.asarray, (z, p))
@@ -1682,9 +1699,9 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
 
     if len(z) == len(p) == 0:
         if not analog:
-            return xp.asarray(np.asarray([[k, 0., 0., 1., 0., 0.]]))
+            return xp.asarray(np.asarray([[k, 0., 0., 1., 0., 0.]]), device=device)
         else:
-            return xp.asarray(np.asarray([[0., 0., k, 0., 0., 1.]]))
+            return xp.asarray(np.asarray([[0., 0., k, 0., 0., 1.]]), device=device)
 
     if pairing != 'minimal':
         # ensure we have the same number of poles and zeros, and make copies
@@ -1795,7 +1812,7 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
 
     # put gain in first sos
     sos[0][:3] *= k
-    return xp.asarray(sos)
+    return xp.asarray(sos, device=device)
 
 
 def _align_nums(nums, xp):
@@ -1835,7 +1852,7 @@ def _align_nums(nums, xp):
         max_width = max(xp_size(num) for num in nums)
 
         # pre-allocate
-        aligned_nums = xp.zeros((len(nums), max_width))
+        aligned_nums = xp.zeros((len(nums), max_width), device=xp_device(nums[0]))
 
         # Create numerators with padded zeros
         for index, num in enumerate(nums):
@@ -2021,7 +2038,7 @@ def lp2lp(b, a, wo=1.0):
     d = a.shape[0]
     n = b.shape[0]
     M = max((d, n))
-    pwo = wo ** xp.arange(M - 1, -1, -1, dtype=xp.float64)
+    pwo = wo ** xp.arange(M - 1, -1, -1, dtype=xp.float64, device=xp_device(b))
     start1 = max((n - d, 0))
     start2 = max((d - n, 0))
     b = b * pwo[start1] / pwo[start2:]
@@ -2123,9 +2140,9 @@ def lp2hp(b, a, wo=1.0):
     d = a.shape[0]
     n = b.shape[0]
     if wo != 1:
-        pwo = wo ** xp.arange(max((d, n)), dtype=b.dtype)
+        pwo = wo ** xp.arange(max((d, n)), dtype=b.dtype, device=xp_device(b))
     else:
-        pwo = xp.ones(max((d, n)), dtype=b.dtype)
+        pwo = xp.ones(max((d, n)), dtype=b.dtype, device=xp_device(b))
     if d >= n:
         outa = xp.flip(a) * pwo
         outb = _resize(b, (d,), xp=xp)
@@ -2212,22 +2229,22 @@ def lp2bp(b, a, wo=1.0, bw=1.0):
     ma = max([N, D])
     Np = N + ma
     Dp = D + ma
-    bprime = xp.empty(Np + 1, dtype=b.dtype)
-    aprime = xp.empty(Dp + 1, dtype=a.dtype)
+    bprime = xp.empty(Np + 1, dtype=b.dtype, device=xp_device(b))
+    aprime = xp.empty(Dp + 1, dtype=a.dtype, device=xp_device(a))
     wosq = wo * wo
     for j in range(Np + 1):
         val = 0.0
         for i in range(0, N + 1):
             for k in range(0, i + 1):
                 if ma - i + 2 * k == j:
-                    val += comb(i, k) * b[N - i] * (wosq) ** (i - k) / bw ** i
+                    val += float(comb(i, k)) * b[N - i] * (wosq) ** (i - k) / bw ** i
         bprime = xpx.at(bprime, Np - j).set(val, xp=xp)
     for j in range(Dp + 1):
         val = 0.0
         for i in range(0, D + 1):
             for k in range(0, i + 1):
                 if ma - i + 2 * k == j:
-                    val += comb(i, k) * a[D - i] * (wosq) ** (i - k) / bw ** i
+                    val += float(comb(i, k)) * a[D - i] * (wosq) ** (i - k) / bw ** i
         aprime = xpx.at(aprime, Dp - j).set(val, xp=xp)
 
     return normalize(bprime, aprime)
@@ -2304,15 +2321,15 @@ def lp2bs(b, a, wo=1.0, bw=1.0):
     M = max([N, D])
     Np = M + M
     Dp = M + M
-    bprime = xp.empty(Np + 1, dtype=b.dtype)
-    aprime = xp.empty(Dp + 1, dtype=a.dtype)
+    bprime = xp.empty(Np + 1, dtype=b.dtype, device=xp_device(b))
+    aprime = xp.empty(Dp + 1, dtype=a.dtype, device=xp_device(a))
     wosq = wo * wo
     for j in range(Np + 1):
         val = 0.0
         for i in range(0, N + 1):
             for k in range(0, M - i + 1):
                 if i + 2 * k == j:
-                    val += (comb(M - i, k) * b[N - i] *
+                    val += (float(comb(M - i, k)) * b[N - i] *
                             (wosq) ** (M - i - k) * bw ** i)
         bprime = xpx.at(bprime, Np - j).set(val, xp=xp)
     for j in range(Dp + 1):
@@ -2320,7 +2337,7 @@ def lp2bs(b, a, wo=1.0, bw=1.0):
         for i in range(0, D + 1):
             for k in range(0, M - i + 1):
                 if i + 2 * k == j:
-                    val += (comb(M - i, k) * a[D - i] *
+                    val += (float(comb(M - i, k)) * a[D - i] *
                             (wosq) ** (M - i - k) * bw ** i)
         aprime = xpx.at(aprime, Dp - j).set(val, xp=xp)
 
@@ -2445,6 +2462,7 @@ def bilinear(b, a, fs=1.0):
     reduce those deviations.
     """
     xp = array_namespace(b, a)
+    device = xp_result_device(b, a)
 
     b, a = map(np.asarray, (b, a))
     b, a = np.atleast_1d(b), np.atleast_1d(a)  # convert scalars, if needed
@@ -2467,8 +2485,8 @@ def bilinear(b, a, fs=1.0):
     denominator = sum(a_ * zp1**(N-p) * zm1**p for p, a_ in enumerate(a[::-1]))
 
     return normalize(
-        xp.asarray(numerator.coef[::-1].copy()),
-        xp.asarray(denominator.coef[::-1].copy())
+        xp.asarray(numerator.coef[::-1].copy(), device=device),
+        xp.asarray(denominator.coef[::-1].copy(), device=device)
     )
 
 
@@ -2807,10 +2825,11 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='bandpass', analog=False,
 
     """
     xp = array_namespace(Wn)
+    device = xp_result_device(Wn)
     # For now, outputs will have float64 base dtype regardless of
     # the dtype of Wn, so cast to float64 here to ensure 64 bit
     # precision for all calculations.
-    Wn = xp.asarray(Wn, dtype=xp.float64)
+    Wn = xp.asarray(Wn, dtype=xp.float64, device=device)
 
     fs = _validate_fs(fs, allow_none=True)
     ftype, btype, output = (x.lower() for x in (ftype, btype, output))
@@ -2846,24 +2865,24 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='bandpass', analog=False,
 
     # Get analog lowpass prototype
     if typefunc == buttap:
-        z, p, k = typefunc(N, xp=xp)
+        z, p, k = typefunc(N, xp=xp, device=device)
     elif typefunc == besselap:
-        z, p, k = typefunc(N, norm=bessel_norms[ftype], xp=xp)
+        z, p, k = typefunc(N, norm=bessel_norms[ftype], xp=xp, device=device)
     elif typefunc == cheb1ap:
         if rp is None:
             raise ValueError("passband ripple (rp) must be provided to "
                              "design a Chebyshev I filter.")
-        z, p, k = typefunc(N, rp, xp=xp)
+        z, p, k = typefunc(N, rp, xp=xp, device=device)
     elif typefunc == cheb2ap:
         if rs is None:
             raise ValueError("stopband attenuation (rs) must be provided to "
                              "design a Chebyshev II filter.")
-        z, p, k = typefunc(N, rs, xp=xp)
+        z, p, k = typefunc(N, rs, xp=xp, device=device)
     elif typefunc == ellipap:
         if rs is None or rp is None:
             raise ValueError("Both rp and rs must be provided to design an "
                              "elliptic filter.")
-        z, p, k = typefunc(N, rp, rs, xp=xp)
+        z, p, k = typefunc(N, rp, rs, xp=xp, device=device)
     else:
         raise NotImplementedError(f"'{ftype}' not implemented in iirfilter.")
 
@@ -3009,7 +3028,7 @@ def bilinear_zpk(z, p, k, fs):
     p_z = (fs2 + p) / (fs2 - p)
 
     # Any zeros that were at infinity get moved to the Nyquist frequency
-    z_z = xp.concat((z_z, -xp.ones(degree)))
+    z_z = xp.concat((z_z, -xp.ones(degree, device=xp_device(z))))
 
     # Compensate for gain change
     k_z = k * xp.real(xp.prod(fs2 - z) / xp.prod(fs2 - p))
@@ -3170,7 +3189,7 @@ def lp2hp_zpk(z, p, k, wo=1.0):
     p_hp = wo / p
 
     # If lowpass had zeros at infinity, inverting moves them to origin.
-    z_hp = xp.concat((z_hp, xp.zeros(degree)))
+    z_hp = xp.concat((z_hp, xp.zeros(degree, device=xp_device(z))))
 
     # Cancel out gain change caused by inversion
     k_hp = k * xp.real(xp.prod(-z) / xp.prod(-p))
@@ -3271,7 +3290,7 @@ def lp2bp_zpk(z, p, k, wo=1.0, bw=1.0):
                       p_lp - xp.sqrt(p_lp**2 - wo**2)))
 
     # Move degree zeros to origin, leaving degree zeros at infinity for BPF
-    z_bp = xp.concat((z_bp, xp.zeros(degree)))
+    z_bp = xp.concat((z_bp, xp.zeros(degree, device=xp_device(z))))
 
     # Cancel out gain change from frequency scaling
     k_bp = k * bw**degree
@@ -3371,8 +3390,8 @@ def lp2bs_zpk(z, p, k, wo=1.0, bw=1.0):
                       p_hp - xp.sqrt(p_hp**2 - wo**2)))
 
     # Move any zeros that were at infinity to the center of the stopband
-    z_bs = xp.concat((z_bs, xp.full(degree, +1j*wo)))
-    z_bs = xp.concat((z_bs, xp.full(degree, -1j*wo)))
+    z_bs = xp.concat((z_bs, xp.full(degree, +1j*wo, device=xp_device(z))))
+    z_bs = xp.concat((z_bs, xp.full(degree, -1j*wo, device=xp_device(z))))
 
     # Cancel out gain change caused by inversion
     k_bs = k * xp.real(xp.prod(-z) / xp.prod(-p))
@@ -4181,6 +4200,9 @@ def _pre_warp(wp, ws, analog, *, xp):
 
 
 def _validate_wp_ws(wp, ws, fs, analog, *, xp):
+    # `_xp_result_devices` for the same reason as in `freqz`
+    _, devices = _xp_result_devices(wp, ws)
+    wp, ws = (xp.asarray(arg, device=d) for arg, d in zip((wp, ws), devices))
     wp = xpx.atleast_nd(wp, ndim=1, xp=xp)
     ws = xpx.atleast_nd(ws, ndim=1, xp=xp)
     wp, ws = xp_promote(wp, ws, force_floating=True, xp=xp)
@@ -4204,7 +4226,7 @@ def _find_nat_freq(stopb, passb, gpass, gstop, filter_type, filter_kind, *, xp):
     elif filter_type == 2:          # high
         nat = passb / stopb
     elif filter_type == 3:          # stop
-
+        device = xp_result_device(passb, stopb)
         passb, stopb = np.asarray(passb), np.asarray(stopb)    # XXX fminbound array API
         wp0 = optimize.fminbound(band_stop_obj, passb[0], stopb[0] - 1e-12,
                                  args=(0, passb, stopb, gpass, gstop,
@@ -4215,7 +4237,8 @@ def _find_nat_freq(stopb, passb, gpass, gstop, filter_type, filter_kind, *, xp):
                                        filter_kind),
                                  disp=0)
         passb = [float(wp0), float(wp1)]
-        passb, stopb = xp.asarray(passb), xp.asarray(stopb)
+        passb = xp.asarray(passb, device=device)
+        stopb = xp.asarray(stopb, device=device)
         nat = ((stopb * (passb[0] - passb[1])) /
                (stopb ** 2 - passb[0] * passb[1]))
     elif filter_type == 4:          # pass
@@ -4316,8 +4339,6 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     """
     xp = array_namespace(wp, ws)
-    wp, ws = map(xp.asarray, (wp, ws))
-
     _validate_gpass_gstop(gpass, gstop)
     fs = _validate_fs(fs, allow_none=True)
     wp, ws, filter_type = _validate_wp_ws(wp, ws, fs, analog, xp=xp)
@@ -4353,11 +4374,11 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
                      4 * W0 ** 2 * passb[0] * passb[1])
         WN0 = ((passb[1] - passb[0]) + discr) / (2 * W0)
         WN1 = ((passb[1] - passb[0]) - discr) / (2 * W0)
-        WN = xp.asarray([float(WN0), float(WN1)])
+        WN = xp.asarray([float(WN0), float(WN1)], device=xp_device(passb))
         WN = xp.sort(xp.abs(WN))
 
     elif filter_type == 4:  # pass
-        W0 = xp.asarray([-W0, W0], dtype=xp.float64)
+        W0 = xp.asarray([-W0, W0], dtype=xp.float64, device=xp_device(passb))
         WN = (-W0 * (passb[1] - passb[0]) / 2.0 +
               xp.sqrt(W0 ** 2 / 4.0 * (passb[1] - passb[0]) ** 2 +
                    passb[0] * passb[1]))
@@ -4447,8 +4468,6 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     """
     xp = array_namespace(wp, ws)
-    wp, ws = map(xp.asarray, (wp, ws))
-
     fs = _validate_fs(fs, allow_none=True)
     _validate_gpass_gstop(gpass, gstop)
     wp, ws, filter_type = _validate_wp_ws(wp, ws, fs, analog, xp=xp)
@@ -4545,8 +4564,6 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     """
     xp = array_namespace(wp, ws)
-    wp, ws = map(xp.asarray, (wp, ws))
-
     fs = _validate_fs(fs, allow_none=True)
     _validate_gpass_gstop(gpass, gstop)
     wp, ws, filter_type = _validate_wp_ws(wp, ws, fs, analog, xp=xp)
@@ -4573,13 +4590,13 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
                   math.sqrt(new_freq ** 2 * (passb[1] - passb[0]) ** 2 / 4.0 +
                        passb[1] * passb[0]))
         nat1 = passb[1] * passb[0] / nat0
-        nat = xp.asarray([float(nat0), float(nat1)])
+        nat = xp.asarray([float(nat0), float(nat1)], device=xp_device(passb))
     elif filter_type == 4:
         nat0 = (1.0 / (2.0 * new_freq) * (passb[0] - passb[1]) +
                   math.sqrt((passb[1] - passb[0]) ** 2 / (4.0 * new_freq ** 2) +
                        passb[1] * passb[0]))
         nat1 = passb[0] * passb[1] / nat0
-        nat = xp.asarray([float(nat0), float(nat1)])
+        nat = xp.asarray([float(nat0), float(nat1)], device=xp_device(passb))
 
     wn = _postprocess_wn(nat, analog, fs, xp=xp)
 
@@ -4671,8 +4688,6 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     """
     xp = array_namespace(wp, ws)
-    wp, ws = map(xp.asarray, (wp, ws))
-
     fs = _validate_fs(fs, allow_none=True)
     _validate_gpass_gstop(gpass, gstop)
     wp, ws, filter_type = _validate_wp_ws(wp, ws, fs, analog, xp=xp)

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -12,7 +12,7 @@ from scipy.signal._arraytools import _validate_fs
 from .windows import get_window
 from . import _sigtools
 
-from scipy._lib._array_api import array_namespace, xp_size
+from scipy._lib._array_api import array_namespace, xp_size, xp_device, xp_result_device
 import scipy._external.array_api_extra as xpx
 
 
@@ -534,7 +534,10 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     # Insert 0 and/or 1 at the ends of cutoff so that the length of cutoff
     # is even, and each pair in cutoff corresponds to passband.
-    cutoff = xp.concat((xp.zeros(int(pass_zero)), cutoff, xp.ones(int(pass_nyquist))))
+    device = xp_device(cutoff)
+    cutoff = xp.concat((xp.zeros(int(pass_zero), device=device),
+                        cutoff,
+                        xp.ones(int(pass_nyquist), device=device)))
 
 
     # `bands` is a 2-D array; each row gives the left and right edges of
@@ -543,7 +546,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     # Build up the coefficients.
     alpha = 0.5 * (numtaps - 1)
-    m = xp.arange(0, numtaps, dtype=cutoff.dtype) - alpha
+    m = xp.arange(0, numtaps, dtype=cutoff.dtype, device=device) - alpha
     h = 0
     for j in range(bands.shape[0]):
         left, right = bands[j, 0], bands[j, 1]
@@ -551,7 +554,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         h -= left * xpx.sinc(left * m, xp=xp)
 
     # Get and apply the window function.
-    win = get_window(window, numtaps, fftbins=False, xp=xp)
+    win = get_window(window, numtaps, fftbins=False, xp=xp, device=device)
     h *= win
 
     # Now handle scaling if desired.
@@ -677,6 +680,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
 
     """
     xp = array_namespace(freq, gain)
+    device = xp_result_device(freq, gain)
     freq, gain = xp.asarray(freq), xp.asarray(gain)
 
     fs = _validate_fs(fs, allow_none=True)
@@ -747,8 +751,8 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)
     fx = np.interp(x, np.asarray(freq), np.asarray(gain))  # XXX array-api-extra#193
-    x = xp.asarray(x)
-    fx = xp.asarray(fx)
+    x = xp.asarray(x, device=device)
+    fx = xp.asarray(fx, device=device)
 
     # Adjust the phases of the coefficients so that the first `ntaps` of the
     # inverse FFT are the desired filter coefficients.
@@ -763,7 +767,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
 
     if window is not None:
         # Create the window to apply to the filter coefficients.
-        wind = get_window(window, numtaps, fftbins=False, xp=xp)
+        wind = get_window(window, numtaps, fftbins=False, xp=xp, device=device)
     else:
         wind = 1
 
@@ -927,6 +931,7 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
 
     """
     xp = array_namespace(bands, desired, weight)
+    device = xp_result_device(bands, desired, weight)
     bands = np.asarray(bands)
     desired = np.asarray(desired)
     if weight is not None:
@@ -949,7 +954,7 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
     bands = np.asarray(bands).copy()
     result = _sigtools._remez(numtaps, bands, desired, weight, tnum, fs,
                               maxiter, grid_density)
-    return xp.asarray(result)
+    return xp.asarray(result, device=device)
 
 
 def firls(numtaps, bands, desired, *, weight=None, fs=None):
@@ -1063,6 +1068,7 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
 
     """
     xp = array_namespace(bands, desired)
+    device = xp_result_device(bands, desired, weight)
     bands = np.asarray(bands)
     desired = np.asarray(desired)
 
@@ -1169,7 +1175,7 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
 
     # make coefficients symmetric (linear phase)
     coeffs = np.hstack((a[:0:-1], 2 * a[0], a[1:]))
-    return xp.asarray(coeffs)
+    return xp.asarray(coeffs, device=device)
 
 
 def _dhtm(mag, xp):
@@ -1183,7 +1189,7 @@ def _dhtm(mag, xp):
     """
     # Adapted based on code by Niranjan Damera-Venkata,
     # Brian L. Evans and Shawn R. McCaslin (see refs for `minimum_phase`)
-    sig = xp.zeros(mag.shape[0])
+    sig = xp.zeros(mag.shape[0], device=xp_device(mag))
     # Leave Nyquist and DC at 0, knowing np.abs(fftfreq(N)[midpt]) == 0.5
     midpt = mag.shape[0] // 2
     sig = xpx.at(sig)[1:midpt].set(1.0)
@@ -1370,7 +1376,8 @@ def minimum_phase(h,
         raise ValueError(f'n_fft must be at least len(h)=={len(h)}')
 
     if method == 'hilbert':
-        w = xp.arange(n_fft, dtype=xp.float64) * (2 * xp.pi / n_fft * n_half)
+        w = (xp.arange(n_fft, dtype=xp.float64, device=xp_device(h))
+             * (2 * xp.pi / n_fft * n_half))
         H = xp.real(fft(h, n_fft) * xp.exp(1j * w))
         dp = max(H) - 1
         ds = 0 - min(H)
@@ -1394,7 +1401,7 @@ def minimum_phase(h,
         # lmin[n] = 2u[n] - d[n]
         # i.e., double the positive frequencies and zero out the negative ones;
         # Oppenheim+Shafer 3rd ed p991 eq13.42b and p1004 fig13.7
-        win = xp.zeros(n_fft, dtype=h_temp.dtype)
+        win = xp.zeros(n_fft, dtype=h_temp.dtype, device=xp_device(h_temp))
         win = xpx.at(win)[0].set(1)
         stop = n_fft // 2
         win = xpx.at(win)[1:stop].set(2)

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -9,7 +9,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
 from scipy import linalg
 
 from scipy._lib._array_api import (array_namespace, xp_size, xp_promote,
-                                   xp_result_type)
+                                   xp_result_type, xp_device)
 import scipy._external.array_api_extra as xpx
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
@@ -198,13 +198,16 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
         raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
     xp = array_namespace(A, B, C, D)
+    # after `xp_promote` all non-None inputs share one device; at least one
+    # of A, B, C is not None per the checks above
     A, B, C, D = xp_promote(A, B, C, D, xp=xp, force_floating=True)
     dtype = xp_result_type(A, B, C, D, xp=xp)
+    device = xp_device(next(M_ for M_ in (A, B, C, D) if M_ is not None))
 
     # convert inputs into 2d arrays (zero-size 2d array if None):
     A, B, C, D = (
         xpx.atleast_nd(xp.asarray(M_), ndim=2, xp=xp)
-        if M_ is not None else xp.zeros((0, 0), dtype=dtype)
+        if M_ is not None else xp.zeros((0, 0), dtype=dtype, device=device)
         for M_ in (A, B, C, D)
     )
 
@@ -213,10 +216,10 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     q = C.shape[0] or D.shape[0]
 
     # Create zero matrices as needed:
-    A = xp.zeros((n, n), dtype=dtype) if xp_size(A) == 0 else A
-    B = xp.zeros((n, p), dtype=dtype) if xp_size(B) == 0 else B
-    C = xp.zeros((q, n), dtype=dtype) if xp_size(C) == 0 else C
-    D = xp.zeros((q, p), dtype=dtype) if xp_size(D) == 0 else D
+    A = xp.zeros((n, n), dtype=dtype, device=device) if xp_size(A) == 0 else A
+    B = xp.zeros((n, p), dtype=dtype, device=device) if xp_size(B) == 0 else B
+    C = xp.zeros((q, n), dtype=dtype, device=device) if xp_size(C) == 0 else C
+    D = xp.zeros((q, p), dtype=dtype, device=device) if xp_size(D) == 0 else D
 
     if A.shape != (n, n):
         raise ValueError(f"Parameter A has shape {A.shape} but should be ({n}, {n})!")

--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -31,7 +31,7 @@ def polyroots(coef, *, xp):
     """numpy.roots, best-effor replacement
     """
     if coef.shape[0] < 2:
-        return xp.asarray([], dtype=coef.dtype)
+        return xp.asarray([], dtype=coef.dtype, device=xp_device(coef))
 
     root_func = getattr(xp, 'roots', None)
     if root_func:
@@ -41,7 +41,7 @@ def polyroots(coef, *, xp):
 
     # companion matrix
     n = coef.shape[0]
-    a = xp.eye(n - 1, n - 1, k=-1, dtype=coef.dtype)
+    a = xp.eye(n - 1, n - 1, k=-1, dtype=coef.dtype, device=xp_device(coef))
     a[:, -1] = -xp.flip(coef[1:]) / coef[0]
 
     # non-symmetric eigenvalue problem is not in the spec but is available on e.g. torch
@@ -95,13 +95,13 @@ def _lstsq(a, b, xp=None, rcond=None):
         sing_val_mask = s > rcond
         s = xpx.apply_where(sing_val_mask, (s,), lambda x: 1. / x, fill_value=0.)
 
-        sigma = xp.eye(s.shape[0]) * s    # == np.diag(s)
+        sigma = xp.eye(s.shape[0], device=xp_device(a)) * s    # == np.diag(s)
         x = vt.T @ sigma @ u.T @ b
 
         rank = xp.count_nonzero(sing_val_mask)
 
         # XXX actually compute residuals, when there's a use case
-        residuals = xp.asarray([])
+        residuals = xp.asarray([], device=xp_device(a))
         return x, residuals, rank, s
 
 
@@ -117,7 +117,7 @@ def _poly1d(c_or_r, *, xp):
         raise ValueError("Polynomial must be 1d only.")
     c_or_r = _trim_zeros(c_or_r, trim='f')
     if c_or_r.shape[0] == 0:
-        c_or_r = xp.asarray([0], dtype=c_or_r.dtype)
+        c_or_r = xp.asarray([0], dtype=c_or_r.dtype, device=xp_device(c_or_r))
     return c_or_r
 
 
@@ -143,7 +143,8 @@ def poly(seq_of_zeros, *, xp):
     seq_of_zeros = xpx.atleast_nd(seq_of_zeros, ndim=1, xp=xp)
 
     if seq_of_zeros.shape[0] == 0:
-        return xp.asarray(1.0, dtype=xp.real(seq_of_zeros).dtype)
+        return xp.asarray(1.0, dtype=xp.real(seq_of_zeros).dtype,
+                          device=xp_device(seq_of_zeros))
 
     # prefer np.convolve etc, if available
     convolve_func = getattr(xp, 'convolve', None)
@@ -151,7 +152,7 @@ def poly(seq_of_zeros, *, xp):
         from scipy.signal import convolve as convolve_func
 
     dt = seq_of_zeros.dtype
-    a = xp.ones((1,), dtype=dt)
+    a = xp.ones((1,), dtype=dt, device=xp_device(seq_of_zeros))
     one = xp.ones_like(seq_of_zeros[0])
     for zero in seq_of_zeros:
         a = convolve_func(a, xp.stack((one, -zero)), mode='full')

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -1,6 +1,6 @@
 from scipy._lib._util import float_factorial
-from scipy._external.array_api_compat import numpy as np_compat
-from scipy._lib._array_api import array_namespace, xp_swapaxes, xp_device
+from scipy._lib._array_api import (array_namespace, xp_compat_namespace,
+                                   xp_swapaxes, xp_device)
 import scipy._external.array_api_extra as xpx
 
 from scipy.ndimage import convolve1d
@@ -126,8 +126,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     if use not in ['conv', 'dot']:
         raise ValueError("`use` must be 'conv' or 'dot'")
 
-    # cf windows/_windows.py
-    xp = np_compat if xp is None else array_namespace(xp.empty(0))
+    xp = xp_compat_namespace(xp)
 
     if deriv > polyorder:
         coeffs = xp.zeros(window_length, dtype=xp.float64, device=device)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -26,8 +26,8 @@ from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
-    array_namespace, is_torch, is_numpy, xp_copy, xp_size,
-    xp_promote, xp_swapaxes,)
+    xp_result_device, array_namespace, is_torch, is_numpy, xp_copy, xp_size,
+    xp_promote, xp_result_type, xp_swapaxes, xp_device,)
 from scipy._external.array_api_compat import is_array_api_obj
 import scipy._external.array_api_extra as xpx
 
@@ -233,6 +233,7 @@ def correlate(in1, in2, mode='full', method='auto'):
 
     """
     xp = array_namespace(in1, in2)
+    device = xp_result_device(in1, in2)
 
     in1 = xp.asarray(in1)
     in2 = xp.asarray(in2)
@@ -262,7 +263,7 @@ def correlate(in1, in2, mode='full', method='auto'):
             a_in1 = np.asarray(in1)
             a_in2 = np.asarray(in2)
             out = np.correlate(a_in1, a_in2, mode)
-            return xp.asarray(out)
+            return xp.asarray(out, device=device)
 
         # _correlateND is far slower when in2.size > in1.size, so swap them
         # and then undo the effect afterward if mode == 'full'.  Also, it fails
@@ -299,7 +300,7 @@ def correlate(in1, in2, mode='full', method='auto'):
 
             z = _sigtools._correlateND(in1zpadded, a_in2, out, val)
 
-        z = xp.asarray(z)
+        z = xp.asarray(z, device=device)
 
         if swapped_inputs:
             # Reverse and conjugate to undo the effect of swapping inputs
@@ -698,7 +699,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     elif in1.ndim != in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
     elif xp_size(in1) == 0 or xp_size(in2) == 0:  # empty arrays
-        return xp.asarray([])
+        return xp.asarray([], device=xp_device(in1))
 
     in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes,
                                           sorted_axes=False)
@@ -945,7 +946,7 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     elif in1.ndim != in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
     elif in1.size == 0 or in2.size == 0:  # empty arrays
-        return xp.asarray([])
+        return xp.asarray([], device=xp_device(in1))
     elif in1.shape == in2.shape:  # Equivalent to fftconvolve
         return fftconvolve(in1, in2, mode=mode, axes=axes)
 
@@ -1497,6 +1498,7 @@ def convolve(in1, in2, mode='full', method='auto'):
 
     """
     xp = array_namespace(in1, in2)
+    device = xp_result_device(in1, in2)
 
     volume = xp.asarray(in1)
     kernel = xp.asarray(in2)
@@ -1534,7 +1536,7 @@ def convolve(in1, in2, mode='full', method='auto'):
             a_volume = np.asarray(volume)
             a_kernel = np.asarray(kernel)
             out = np.convolve(a_volume, a_kernel, mode)
-            return xp.asarray(out)
+            return xp.asarray(out, device=device)
 
         return correlate(volume, _reverse_and_conj(kernel, xp), mode, 'direct')
     else:
@@ -1683,7 +1685,7 @@ def medfilt(volume, kernel_size=None):
 
     if kernel_size is None:
         kernel_size = [3] * volume.ndim
-    kernel_size = xp.asarray(kernel_size)
+    kernel_size = xp.asarray(kernel_size, device=xp_device(volume))
     if kernel_size.shape == ():
         kernel_size = xp.repeat(kernel_size, volume.ndim)
 
@@ -1762,12 +1764,13 @@ def wiener(im, mysize=None, noise=None):
 
     # Estimate the local mean
     size = math.prod(mysize)
-    lMean = correlate(im, xp.ones(mysize), 'same')
+    lMean = correlate(im, xp.ones(mysize, device=xp_device(im)), 'same')
     lsize = float(size)
     lMean = lMean / lsize
 
     # Estimate the local variance
-    lVar = (correlate(im ** 2, xp.ones(mysize), 'same') / lsize - lMean ** 2)
+    lVar = (correlate(im ** 2, xp.ones(mysize, device=xp_device(im)), 'same')
+            / lsize - lMean ** 2)
 
     # Estimate the noise power if needed.
     if noise is None:
@@ -1857,6 +1860,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     """
     xp = array_namespace(in1, in2)
+    device = xp_result_device(in1, in2)
 
     # NB: do work in NumPy, only convert the output
 
@@ -1872,7 +1876,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
     out = _sigtools._convolve2d(in1, in2, 1, val, bval, fillvalue)
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
@@ -1958,6 +1962,8 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     """
     xp = array_namespace(in1, in2)
+    device = xp_result_device(in1, in2)
+
     in1 = np.asarray(in1)
     in2 = np.asarray(in2)
 
@@ -1975,7 +1981,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     if swapped_inputs:
         out = out[::-1, ::-1]
 
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def medfilt2d(input, kernel_size=3):
@@ -2067,13 +2073,14 @@ def medfilt2d(input, kernel_size=3):
 
     """
     xp = array_namespace(input)
+    device = xp_result_device(input)
 
     image = np.asarray(input)
 
     # checking dtype.type, rather than just dtype, is necessary for
     # excluding np.longdouble with MS Visual C.
     if image.dtype.type not in (np.ubyte, np.float32, np.float64):
-        return xp.asarray(medfilt(image, kernel_size))
+        return xp.asarray(medfilt(image, kernel_size), device=device)
 
     if kernel_size is None:
         kernel_size = [3] * 2
@@ -2086,7 +2093,7 @@ def medfilt2d(input, kernel_size=3):
             raise ValueError("Each element of kernel_size should be odd.")
 
     result_np = _sigtools._medfilt2d(image, kernel_size)
-    return xp.asarray(result_np)
+    return xp.asarray(result_np, device=device)
 
 
 def lfilter(b, a, x, axis=-1, zi=None):
@@ -2214,6 +2221,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
 
     """
     xp = array_namespace(b, a, x, zi)
+    device = xp_result_device(b, a, x, zi)
 
     b = np.atleast_1d(b)
     a = np.atleast_1d(a)
@@ -2283,18 +2291,18 @@ def lfilter(b, a, x, axis=-1, zi=None):
         out = out_full[tuple(ind)]
 
         if zi is None:
-            return xp.asarray(out)
+            return xp.asarray(out, device=device)
         else:
             ind[axis] = slice(out_full.shape[axis] - len(b) + 1, None)
             zf = out_full[tuple(ind)]
-            return xp.asarray(out), xp.asarray(zf)
+            return xp.asarray(out, device=device), xp.asarray(zf, device=device)
     else:
         if zi is None:
             result =_sigtools._linear_filter(b, a, x, axis)
-            return xp.asarray(result)
+            return xp.asarray(result, device=device)
         else:
             out, zf = _sigtools._linear_filter(b, a, x, axis, zi)
-            return xp.asarray(out), xp.asarray(zf)
+            return xp.asarray(out, device=device), xp.asarray(zf, device=device)
 
 
 def lfiltic(b, a, y, x=None):
@@ -2357,7 +2365,7 @@ def lfiltic(b, a, y, x=None):
         result_type = xp.result_type(b, a, y)
         if xp.isdtype(result_type, ('bool', 'integral')):  #'bui':
             result_type = xp.float64
-        x = xp.zeros(M, dtype=result_type)
+        x = xp.zeros(M, dtype=result_type, device=xp_device(b))
     else:
         x = xp.asarray(x)
 
@@ -2368,14 +2376,14 @@ def lfiltic(b, a, y, x=None):
 
         L = xp_size(x)
         if L < M:
-            x = xp.concat((x, xp.zeros(M - L)))
+            x = xp.concat((x, xp.zeros(M - L, device=xp_device(x))))
 
     y = xp.astype(y, result_type)
-    zi = xp.zeros(K, dtype=result_type)
+    zi = xp.zeros(K, dtype=result_type, device=xp_device(b))
 
     L = xp_size(y)
     if L < N:
-        y = xp.concat((y, xp.zeros(N - L)))
+        y = xp.concat((y, xp.zeros(N - L, device=xp_device(y))))
 
     for m in range(M):
         zi = xpx.at(zi)[m].set(xp.sum(b[m + 1:] * x[:M - m], axis=0))
@@ -2449,7 +2457,7 @@ def deconvolve(signal, divisor):
         quot = []
         rem = num
     else:
-        input = xp.zeros(N - D + 1, dtype=xp.float64)
+        input = xp.zeros(N - D + 1, dtype=xp.float64, device=xp_device(num))
         input = xpx.at(input)[0].set(1)
         quot = lfilter(num, den, input)
         rem = num - convolve(den, quot, mode='full')
@@ -3867,14 +3875,15 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     if window is None: # Determine spectral windowing function:
         W = None
     elif callable(window):
-        W = window(sp_fft.fftfreq(n_x))
+        W = window(sp_fft.fftfreq(n_x, xp=xp, device=xp_device(x)))
     elif hasattr(window, 'shape'): # must be an array object
         if window.shape != (n_x,):
             raise ValueError(f"{window.shape=} != ({n_x},), i.e., window length " +
                              "is not equal to number of frequency bins!")
         W = xp.asarray(window, copy=True)  # prevent modifying the function parameters
     else:
-        W = sp_fft.fftshift(get_window(window, n_x, xp=xp))
+        W = sp_fft.fftshift(get_window(window, n_x, xp=xp,
+                                       device=xp_device(x)))
         W = xp.astype(W, xpx.default_dtype(xp))   # get_window always returns float64
 
     if domain == 'time' and not xp.isdtype(x.dtype, 'complex floating'):  # use rfft():
@@ -3892,7 +3901,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
         X = sp_fft.fft(x) if domain == 'time' else x
         if W is not None:
             X = X * W  # writing X *= W could modify parameter x
-        Y = xp.zeros(X.shape[:-1] + (num,), dtype=X.dtype)
+        Y = xp.zeros(X.shape[:-1] + (num,), dtype=X.dtype, device=xp_device(X))
         Y = xpx.at(Y)[..., :m2].set(X[..., :m2])  # copy up to Nyquist
         if m2 < m:  # == m > 2
             Y = xpx.at(Y)[..., m2-m:].set(X[..., m2-m:])  # copy negative frequencies
@@ -3907,7 +3916,9 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     if x_r.ndim > 1:  # moving active axis back to original position:
         x_r = xp.moveaxis(x_r, -1, axis)
     if t is not None:
-        return x_r, t[0] + (t[1] - t[0]) * s_fac * xp.arange(num)
+        t_new_dtype = xp_result_type(t, force_floating=True, xp=xp)
+        t_new = xp.arange(num, dtype=t_new_dtype, device=xp_device(x))
+        return x_r, t[0] + (t[1] - t[0]) * s_fac * t_new
     return x_r
 
 
@@ -4074,10 +4085,10 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
         if xp.isdtype(x.dtype, ("real floating", "complex floating")):
             h = firwin(2 * half_len + 1, f_c, window=window)
-            h = xp.asarray(h, dtype=x.dtype)    # match dtype of x
+            h = xp.asarray(h, dtype=x.dtype, device=xp_device(x))
         else:
             h = firwin(2 * half_len + 1, f_c, window=window)
-            h = xp.asarray(h)
+            h = xp.asarray(h, device=xp_device(x))
 
     h *= up
 
@@ -4089,13 +4100,14 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     while _output_len(h.shape[0] + n_pre_pad + n_post_pad, n_in,
                       up, down) < n_out + n_pre_remove:
         n_post_pad += 1
-    h = xp.concat((xp.zeros(n_pre_pad, dtype=h.dtype), h,
-                   xp.zeros(n_post_pad, dtype=h.dtype)))
+    h = xp.concat((xp.zeros(n_pre_pad, dtype=h.dtype, device=xp_device(h)), h,
+                   xp.zeros(n_post_pad, dtype=h.dtype, device=xp_device(h))))
     n_pre_remove_end = n_pre_remove + n_out
 
     # XXX consider using stats.quantile, which is natively Array API compatible
     def _median(x, *args, **kwds):
-        return xp.asarray(np.median(np.asarray(x), *args, **kwds))
+        return xp.asarray(np.median(np.asarray(x), *args, **kwds),
+                          device=xp_device(x))
 
     # Remove background depending on the padtype option
     funcs = {'mean': xp.mean, 'median': _median,
@@ -4367,6 +4379,7 @@ def detrend(data: np.ndarray, axis: int = -1,
         raise ValueError("Trend type must be 'linear' or 'constant'.")
 
     xp = array_namespace(data, bp)
+    device = xp_result_device(data, bp)
 
     data = np.asarray(data)
     dtype = data.dtype.char
@@ -4374,7 +4387,7 @@ def detrend(data: np.ndarray, axis: int = -1,
         dtype = 'd'
     if type in ['constant', 'c']:
         ret = data - np.mean(data, axis, keepdims=True)
-        return xp.asarray(ret)
+        return xp.asarray(ret, device=device)
     else:
         dshape = data.shape
         N = dshape[axis]
@@ -4411,7 +4424,7 @@ def detrend(data: np.ndarray, axis: int = -1,
         # Put data back in original shape.
         newdata = newdata.reshape(newdata_shape)
         ret = np.moveaxis(newdata, 0, axis)
-        return xp.asarray(ret)
+        return xp.asarray(ret, device=device)
 
 
 def lfilter_zi(b, a):
@@ -4612,7 +4625,7 @@ def sosfilt_zi(sos):
         sos = xp.astype(sos, xp.float64)
 
     n_sections = sos.shape[0]
-    zi = xp.empty((n_sections, 2), dtype=sos.dtype)
+    zi = xp.empty((n_sections, 2), dtype=sos.dtype, device=xp_device(sos))
     scale = 1.0
     for section in range(n_sections):
         b = sos[section, :3]
@@ -4964,6 +4977,7 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 
     """
     xp = array_namespace(b, a, x)
+    device = xp_result_device(b, a, x)
 
     b = np.atleast_1d(np.asarray(b))
     a = np.atleast_1d(np.asarray(a))
@@ -4974,7 +4988,9 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 
     if method == "gust":
         y, z1, z2 = _filtfilt_gust(b, a, x, axis=axis, irlen=irlen)
-        return xp.asarray(y)
+        if is_torch(xp):
+            y = y.copy()    # pytorch/pytorch#59786 : no negative strides in pytorch
+        return xp.asarray(y, device=device)
 
     # method == "pad"
     edge, ext = _validate_pad(padtype, padlen, x, axis,
@@ -5005,10 +5021,11 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     if edge > 0:
         # Slice the actual signal from the extended signal.
         y = axis_slice(y, start=edge, stop=-edge, axis=axis)
-        if is_torch(xp):
-            y = y.copy()    #  pytorch/pytorch#59786 : no negative strides in pytorch
 
-    return xp.asarray(y)
+    if is_torch(xp):
+        y = y.copy()    #  pytorch/pytorch#59786 : no negative strides in pytorch
+
+    return xp.asarray(y, device=device)
 
 
 def _validate_pad(padtype, padlen, x, axis, ntaps):
@@ -5125,6 +5142,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     """
     xp = array_namespace(sos, x, zi)
+    device = xp_result_device(sos, x, zi)
 
     x = _validate_x(x)
     sos, n_sections = _validate_sos(sos)
@@ -5171,9 +5189,9 @@ def sosfilt(sos, x, axis=-1, zi=None):
     if return_zi:
         zi = zi.reshape(zi_shape)
         zi = np.moveaxis(zi, (-2, -1), (0, axis + 1))
-        out = (xp.asarray(x), xp.asarray(zi))
+        out = (xp.asarray(x, device=device), xp.asarray(zi, device=device))
     else:
-        out = xp.asarray(x)
+        out = xp.asarray(x, device=device)
     return out
 
 
@@ -5267,6 +5285,7 @@ def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
 
     """
     xp = array_namespace(sos, x)
+    device = xp_result_device(sos, x)
 
     sos, n_sections = _validate_sos(sos)
     x = _validate_x(x)
@@ -5289,7 +5308,9 @@ def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
     y = axis_reverse(y, axis=axis)
     if edge > 0:
         y = axis_slice(y, start=edge, stop=-edge, axis=axis)
-    return xp.asarray(y)
+    if is_torch(xp):
+        y = y.copy()    #  pytorch/pytorch#59786 : no negative strides in pytorch
+    return xp.asarray(y, device=device)
 
 
 def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -3,7 +3,7 @@
 import numpy as np
 import numpy.typing as npt
 from scipy import fft as sp_fft
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import xp_result_device, array_namespace
 from . import _signaltools
 from ._short_time_fft import ShortTimeFFT
 from .windows import get_window
@@ -663,13 +663,15 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
         if isinstance(window, str | tuple)
         else array_namespace(x, window)
     )
+    device = xp_result_device(x, window)
     x_np = np.asarray(x)
     freqs_np, Pxx_np = csd(x_np, x_np, fs=fs, window=window, nperseg=nperseg,
                            noverlap=noverlap, nfft=nfft, detrend=detrend,
                            return_onesided=return_onesided, scaling=scaling,
                            axis=axis, average=average)
 
-    return xp.asarray(freqs_np), xp.asarray(Pxx_np.real)
+    return (xp.asarray(freqs_np, device=device),
+            xp.asarray(Pxx_np.real, device=device))
 
 
 def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -5,7 +5,8 @@ from numpy import (zeros_like, array, tan, arange, floor,
                    moveaxis, abs, complex64, float32)
 import numpy as np
 
-from scipy._lib._array_api import array_namespace, xp_promote
+from scipy._lib._array_api import (xp_result_device, array_namespace,
+                                   xp_promote)
 
 from scipy._lib._util import normalize_axis_index
 
@@ -61,6 +62,7 @@ def spline_filter(Iin, lmbda=5.0):
 
     """
     xp = array_namespace(Iin)
+    device = xp_result_device(Iin)
     Iin = np.asarray(Iin)
 
     if Iin.dtype not in [np.float32, np.float64, np.complex64, np.complex128]:
@@ -79,7 +81,7 @@ def spline_filter(Iin, lmbda=5.0):
     ck = cspline2d(Iin, lmbda)
     out = sepfir2d(ck, hcol, hcol)
     out = out.astype(intype)
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def gauss_spline(x, n):
@@ -134,22 +136,24 @@ def gauss_spline(x, n):
 
 def _cubic(x):
     xp = array_namespace(x)
+    device = xp_result_device(x)
 
     x = np.asarray(x, dtype=float)
     b = BSpline.basis_element([-2, -1, 0, 1, 2], extrapolate=False)
     out = b(x)
     out[(x < -2) | (x > 2)] = 0
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def _quadratic(x):
     xp = array_namespace(x)
+    device = xp_result_device(x)
 
     x = abs(np.asarray(x, dtype=float))
     b = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5], extrapolate=False)
     out = b(x)
     out[(x < -1.5) | (x > 1.5)] = 0
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def _coeff_smooth(lam):
@@ -344,12 +348,13 @@ def cspline1d(signal, lamb=0.0):
 
     """
     xp = array_namespace(signal)
+    device = xp_result_device(signal)
 
     if lamb != 0.0:
         ret = _cubic_smooth_coeff(signal, lamb)
     else:
         ret = _cubic_coeff(signal)
-    return xp.asarray(ret)
+    return xp.asarray(ret, device=device)
 
 
 def qspline1d(signal, lamb=0.0):
@@ -398,11 +403,12 @@ def qspline1d(signal, lamb=0.0):
 
     """
     xp = array_namespace(signal)
+    device = xp_result_device(signal)
 
     if lamb != 0.0:
         raise ValueError("Smoothing quadratic splines not supported yet.")
     else:
-        return xp.asarray(_quadratic_coeff(signal))
+        return xp.asarray(_quadratic_coeff(signal), device=device)
 
 
 def collapse_2d(x, axis):
@@ -571,6 +577,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
 
     """
     xp = array_namespace(cj, newx)
+    device = xp_result_device(cj, newx)
 
     newx = (np.asarray(newx) - x0) / float(dx)
     cj = np.asarray(cj)
@@ -580,7 +587,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
 
     res = zeros_like(newx, dtype=cj.dtype)
     if res.size == 0:
-        return xp.asarray(res)
+        return xp.asarray(res, device=device)
     N = len(cj)
     cond1 = newx < 0
     cond2 = newx > (N - 1)
@@ -590,7 +597,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     res[cond2] = cspline1d_eval(cj, 2 * (N - 1) - newx[cond2])
     newx = newx[cond3]
     if newx.size == 0:
-        return xp.asarray(res)
+        return xp.asarray(res, device=device)
     result = zeros_like(newx, dtype=cj.dtype)
     jlower = floor(newx - 2).astype(int) + 1
     for i in range(4):
@@ -598,7 +605,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
         indj = thisj.clip(0, N - 1)  # handle edge cases
         result += cj[indj] * _cubic(newx - thisj)
     res[cond3] = result
-    return xp.asarray(res)
+    return xp.asarray(res, device=device)
 
 
 def qspline1d_eval(cj, newx, dx=1.0, x0=0):
@@ -654,11 +661,12 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
 
     """
     xp = array_namespace(newx, cj)
+    device = xp_result_device(cj, newx)
 
     newx = (np.asarray(newx) - x0) / dx
     res = np.zeros_like(newx)
     if res.size == 0:
-        return xp.asarray(res)
+        return xp.asarray(res, device=device)
 
     cj = np.asarray(cj)
     if cj.size == 0:
@@ -673,7 +681,7 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
     res[cond2] = qspline1d_eval(cj, 2 * (N - 1) - newx[cond2])
     newx = newx[cond3]
     if newx.size == 0:
-        return xp.asarray(res)
+        return xp.asarray(res, device=device)
     result = zeros_like(newx)
     jlower = floor(newx - 1.5).astype(int) + 1
     for i in range(3):
@@ -681,7 +689,7 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
         indj = thisj.clip(0, N - 1)  # handle edge cases
         result += cj[indj] * _quadratic(newx - thisj)
     res[cond3] = result
-    return xp.asarray(res)
+    return xp.asarray(res, device=device)
 
 
 def symiirorder1(signal, c0, z1, precision=-1.0):
@@ -717,6 +725,7 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
     """
     xp = array_namespace(signal)
     signal = xp_promote(signal, force_floating=True, xp=xp)
+    device = xp_result_device(signal)
     # This function uses C internals
     signal = np.asarray(signal)
 
@@ -759,7 +768,7 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
     if squeeze_dim:
         out = out[0]
 
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)
 
 
 def symiirorder2(input, r, omega, precision=-1.0):
@@ -797,6 +806,7 @@ def symiirorder2(input, r, omega, precision=-1.0):
     """
     xp = array_namespace(input)
     input = xp_promote(input, force_floating=True, xp=xp)
+    device = xp_result_device(input)
     # This function uses C internals
     input = np.ascontiguousarray(input)
 
@@ -841,4 +851,4 @@ def symiirorder2(input, r, omega, precision=-1.0):
     if squeeze_dim:
         out = out[0]
 
-    return xp.asarray(out)
+    return xp.asarray(out, device=device)

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -33,7 +33,7 @@
 
 import numpy as np
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import xp_result_device, array_namespace
 from ._upfirdn_apply import _output_len, _apply, mode_enum
 
 __all__ = ['upfirdn', '_output_len']
@@ -212,8 +212,9 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
            [ 6.,  7.]])
     """
     xp = array_namespace(h, x)
+    device = xp_result_device(h, x)
 
     x = np.asarray(x)
     ufd = _UpFIRDn(h, x.dtype, up, down)
     # This is equivalent to (but faster than) using np.apply_along_axis
-    return xp.asarray(ufd.apply_filter(x, axis, mode, cval))
+    return xp.asarray(ufd.apply_filter(x, axis, mode, cval), device=device)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -33,7 +33,7 @@ from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
     assert_array_almost_equal, assert_almost_equal,
     xp_copy, xp_size, array_namespace, make_xp_test_case,
-    make_xp_pytest_param, SCIPY_DEVICE, _xp_copy_to_numpy
+    make_xp_pytest_param, SCIPY_DEVICE, _xp_copy_to_numpy, xp_device
 )
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
@@ -1376,7 +1376,7 @@ class TestResample:
         # window.shape must equal to sig.shape[0]
         sig = xp.arange(128, dtype=xp.float64)
         num = 256
-        win = signal.get_window(('kaiser', 8.0), 160, xp=xp)
+        win = signal.get_window(('kaiser', 8.0), 160, xp=xp, device=xp_device(sig))
         assert_raises(ValueError, signal.resample, sig, num, window=win)
         assert_raises(ValueError, signal.resample, sig, num, domain='INVALID')
 
@@ -1401,6 +1401,17 @@ class TestResample:
         x1 = signal.resample_poly(sig, 2, 1, padtype='constant', cval=0)
         xp_assert_equal(x1, x_ref)
         xp_assert_equal(x0, x_ref)
+
+    @skip_xp_backends("cupy",
+                      reason="delegated to cupyx, whose time vector is float64")
+    @make_xp_test_case(signal.resample)
+    def test_t_dtype(self, xp):
+        # the returned time vector follows `t`'s precision
+        for dtype in (xp.float32, xp.float64):
+            x = xp.arange(16, dtype=dtype)
+            t = xp.arange(16, dtype=dtype)
+            _, t_new = signal.resample(x, 32, t=t)
+            assert t_new.dtype == dtype
 
     @pytest.mark.parametrize('window', (None, 'hamming'))
     @pytest.mark.parametrize('N', (20, 19))
@@ -1501,11 +1512,12 @@ class TestResample:
         # Sinusoids, windowed to avoid edge artifacts
         t = xp.arange(rate, dtype=xp.float64) / float(rate)
         freqs = xp.asarray((1., 10., 40.))[:, xp.newaxis]
-        x = xp.sin(2 * xp.pi * freqs * t) * hann(rate, xp=xp)
+        x = xp.sin(2 * xp.pi * freqs * t) * hann(rate, xp=xp, device=xp_device(t))
 
         for rate_to in rates_to:
             t_to = xp.arange(rate_to, dtype=xp.float64) / float(rate_to)
-            y_tos = xp.sin(2 * xp.pi * freqs * t_to) * hann(rate_to, xp=xp)
+            y_tos = (xp.sin(2 * xp.pi * freqs * t_to)
+                     * hann(rate_to, xp=xp, device=xp_device(t_to)))
             if method == 'fft':
                 y_resamps = signal.resample(x, rate_to, axis=-1)
             else:

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -7,8 +7,8 @@ import warnings
 from scipy._lib import doccer
 
 from scipy import linalg, special, fft as sp_fft
-from scipy._external.array_api_compat import numpy as np_compat
-from scipy._lib._array_api import array_namespace, xp_device
+from scipy._lib._array_api import (array_namespace, xp_compat_namespace,
+                                   xp_device)
 from scipy._lib._array_api import xp_capabilities
 from scipy._external import array_api_extra as xpx
 
@@ -49,7 +49,7 @@ def _namespace(xp):
     Will be able to replace with `np_compat if xp is None else xp` when we drop
     support for numpy 1.x and cupy 13.x
     """
-    return np_compat if xp is None else array_namespace(xp.empty(0))
+    return xp_compat_namespace(xp)
 
 
 def _general_cosine_impl(M, a, xp, device, sym=True):
@@ -1480,7 +1480,7 @@ def kaiser(M, beta, sym=True, *, xp=None, device=None):
     n = xp.arange(0, M, dtype=xp.float64, device=device)
     alpha = (M - 1) / 2.0
     w = (special.i0(beta * xp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
-         special.i0(xp.asarray(beta, dtype=xp.float64)))
+         special.i0(xp.asarray(beta, dtype=xp.float64, device=device)))
 
     return _truncate(w, needs_trunc)
 
@@ -1561,7 +1561,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
             "shapes"
         )
     elif M < 1:
-        return xp.asarray([])
+        return xp.asarray([], device=device)
     elif M % 2:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for even number "
@@ -2315,11 +2315,12 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
         singleton = False
     if _len_guards(M):
         if not return_ratios:
-            return xp.ones(M, dtype=xp.float64)
+            return xp.ones(M, dtype=xp.float64, device=device)
         elif singleton:
-            return xp.ones(M, dtype=xp.float64), 1.
+            return xp.ones(M, dtype=xp.float64, device=device), 1.
         else:
-            return xp.ones(M, dtype=xp.float64), xp.ones(1, dtype=xp.float64)
+            return (xp.ones(M, dtype=xp.float64, device=device),
+                    xp.ones(1, dtype=xp.float64, device=device))
     Kmax = operator.index(Kmax)
     if not 0 < Kmax <= M:
         raise ValueError('Kmax must be greater than 0 and less than M')
@@ -2393,7 +2394,8 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
                 correction = M**2 / float(M**2 + NW)
             else:
                 s = sp_fft.rfft(windows[0])
-                shift = -(1 - 1./M) * xp.arange(1, M//2 + 1, dtype=xp.float64)
+                shift = -(1 - 1./M) * xp.arange(1, M//2 + 1, dtype=xp.float64,
+                                                device=device)
                 s[1:] *= 2 * xp.exp(-1j * xp.pi * shift)
                 correction = M / s.real.sum()
             windows *= correction
@@ -2496,14 +2498,16 @@ def lanczos(M, *, sym=True, xp=None, device=None):
     # half of the window and the flipped one which is the left hand half of
     # the window.
     def _calc_right_side_lanczos(n, m):
-        return xpx.sinc(2. * xp.arange(n, m, dtype=xp.float64) / (m - 1) - 1.0, xp=xp)
+        return xpx.sinc(
+            2. * xp.arange(n, m, dtype=xp.float64, device=device) / (m - 1) - 1.0, xp=xp
+        )
 
     if M % 2 == 0:
         wh = _calc_right_side_lanczos(M/2, M)
         w = xp.concat([xp.flip(wh), wh])
     else:
         wh = _calc_right_side_lanczos((M+1)/2, M)
-        w = xp.concat([xp.flip(wh), xp.ones(1), wh])
+        w = xp.concat([xp.flip(wh), xp.ones(1, device=device), wh])
 
     return _truncate(w, needs_trunc)
 


### PR DESCRIPTION
Device-propagation fixes for gh-22680: internal array creation that omits `device=` lands on the backend's *default* device and raises (or silently misplaces results) when the input arrays reside elsewhere.

Pretty much all of this is standard plumbing through of `device` keywords. There are a couple of minor bug fixes; the `torch` negative stride fixes were needed to get testing with the 'meta' device to work; there will be a separate follow-up PR to unskip all tests that touch those code paths, that was a bit too different from the focus of this PR to include here.

This is the seventh PR of the series, following gh-25738

#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see gh-25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.
