### PR TITLE
DOC: mark inverse multidimensional transforms keyword-only

### DIFF
--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -75,7 +75,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 @xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-          workers=None, orthogonalize=None):
+          workers=None, *, orthogonalize=None):
     """
     Return multidimensional Inverse Discrete Cosine Transform along the specified axes.
 
@@ -207,7 +207,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 @xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-          workers=None, orthogonalize=None):
+          workers=None, *, orthogonalize=None):
     """
     Return multidimensional Inverse Discrete Sine Transform along the specified axes.
 


### PR DESCRIPTION
This updates the public `idctn` and `idstn` signatures so `orthogonalize` is keyword-only, matching their backend signatures. This keeps the generated documentation and runtime behavior consistent.

Fixes #25732