### PR TITLE
DOC: explain convolve2d kernel rotation

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1788,6 +1788,9 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     Convolve `in1` and `in2` with output size determined by `mode`, and
     boundary conditions determined by `boundary` and `fillvalue`.
 
+    The second input is rotated by 180 degrees as part of the convolution.
+    To apply a kernel without this rotation, use :func:`correlate2d` instead.
+
     Parameters
     ----------
     in1 : array_like
@@ -1881,6 +1884,9 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     Cross correlate `in1` and `in2` with output size determined by `mode`, and
     boundary conditions determined by `boundary` and `fillvalue`.
+
+    The second input is rotated by 180 degrees as part of the convolution.
+    To apply a kernel without this rotation, use :func:`correlate2d` instead.
 
     Parameters
     ----------


### PR DESCRIPTION
This clarifies that `convolve2d` rotates the second input by 180 degrees as part of convolution, and points readers to `correlate2d` when they need the kernel without that rotation.

Fixes #23444