### PR TITLE
ENH: Remove redundant calls to objective and constraint function for differential_evolution at the start of each iteration

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -988,6 +988,7 @@ class DifferentialEvolutionSolver:
                 raise ValueError(self.__init_error_msg)
         else:
             self.init_population_array(init)
+        self._init_energized = False
 
         if x0 is not None:
             # scale to within unit interval and
@@ -1210,7 +1211,7 @@ class DifferentialEvolutionSolver:
         # Although this is also done in the evolve generator it's possible
         # that someone can set maxiter=0, at which point we still want the
         # initial energies to be calculated (the following loop isn't run).
-        if np.all(np.isinf(self.population_energies)):
+        if not self._init_energized and np.all(np.isinf(self.population_energies)):
             self.feasible, self.constraint_violation = (
                 self._calculate_population_feasibilities(self.population))
 
@@ -1220,6 +1221,7 @@ class DifferentialEvolutionSolver:
                     self.population[self.feasible]))
 
             self._promote_lowest_energy()
+            self._init_energized = True
 
         # do the optimization.
         for nit in range(1, self.maxiter + 1):
@@ -1609,9 +1611,9 @@ class DifferentialEvolutionSolver:
         fun : float
             Value of objective function obtained from the best solution.
         """
-        # the population may have just been initialized (all entries are
-        # np.inf). If it has you have to calculate the initial energies
-        if np.all(np.isinf(self.population_energies)):
+        # the population may have just been initialized and their energies
+        # not calculated. If it has you have to calculate the initial energies
+        if not self._init_energized:
             self.feasible, self.constraint_violation = (
                 self._calculate_population_feasibilities(self.population))
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1070,7 +1070,7 @@ class TestDifferentialEvolutionSolver:
         bounds = [(0, 1)]*9 + [(0, 100)]*3 + [(0, 1)]
 
         # using a lower popsize to speed the test up
-        rng = np.random.default_rng(np.random.MT19937(12345))
+        rng = np.random.default_rng(np.random.PCG64(12345))
         res = differential_evolution(
             f, bounds, strategy='best1bin', rng=rng, constraints=(L,),
             popsize=5, tol=0.01
@@ -1094,7 +1094,7 @@ class TestDifferentialEvolutionSolver:
         L = LinearConstraint(csr_array(A), -np.inf, b)
 
         # using a lower popsize to speed the test up
-        rng = np.random.default_rng(np.random.MT19937(12345))
+        rng = np.random.default_rng(np.random.PCG64(12345))
         res = differential_evolution(
             f, bounds, strategy='best1bin', rng=rng, constraints=(L,),
             popsize=5, tol=0.01
@@ -1127,7 +1127,7 @@ class TestDifferentialEvolutionSolver:
         constraints = (L, N, L2, N2)
 
         with warnings.catch_warnings():
-            rng = np.random.default_rng(np.random.MT19937(12345))
+            rng = np.random.default_rng(np.random.PCG64(12345))
             warnings.simplefilter("ignore", UserWarning)
             res = differential_evolution(
                 f, bounds, strategy='best1bin', rng=rng,


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
There is no reference issue.

#### What does this implement/fix?
(see `DifferentialEvolutionSolver.__next__`). At the start of each iteration, a check is performed on the energies of the population to check if they are all infinity. Supposedly, this is in case the population is just been initialized and calculate the energies (and the feasibility). However, before invoking `__next__`, the same piece of script is already called in `DifferentialEvolutionSolver.solve`. In the case where we start with a population with no feasible candidates then we will be running the same piece of script twice. In subsequent iterations the same unnecessary recalculation of energies and feasibility will again be performed if no feasible candidate is found from the previous iteration, causing redundant calls to the objective function and constraint function (since at the end of the iteration we would have calculated the energies and feasibility, and also promote the best candidate). In fact, skipping this piece of script from `__next__` will not affect the result, see Additional information for comparison of the final population.

Skipping the recalculation of energies and feasibility at the start of each iteration would reduce calls to the objective and constraint function and speed up the calculation when the initial population is all infeasible. (Note: in my own use case starting from an all infeasible population can still lead to feasible final solution, although the example given below couldnt find a feasible solution).

To implement this, I introduce a new flag `_init_energized` to indicate if the energies and feasibility of the initial population is calculation. The flag will be initialized as False after population initiation, and will be toggle to True once the energies and feasibility is calculated as the start of `solve` method. At every iteration, we will check the value of this flag to determine if a recalculation is needed.

#### Additional information
I'll give a simple case where we have a sparsity constraint. This example will show that the patched version give exactly same final output as the current version:
```
import numpy as np
from scipy.optimize import differential_evolution, NonlinearConstraint, Bounds, OptimizeResult, minimize
from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
from scipy._lib._util import _transition_to_rng
from scipy.optimize._optimize import _status_message
_MACHEPS = np.finfo(np.float64).eps
from functools import partial
import warnings

class DifferentialEvolutionSolverPatched(DifferentialEvolutionSolver):
    '''Patched differential evolution that skips invoking _calculate_population_feasibilities
    in every iteration'''
    def __init__(self, func, bounds, args=(),
                 strategy='best1bin', maxiter=1000, popsize=15,
                 tol=0.01, mutation=(0.5, 1), recombination=0.7, rng=None,
                 maxfun=np.inf, callback=None, disp=False, polish=True,
                 init='latinhypercube', atol=0, updating='immediate',
                 workers=1, constraints=(), x0=None, *, integrality=None,
                 vectorized=False):
        super().__init__(
            func, bounds, args=args, strategy=strategy, maxiter=maxiter,
            popsize=popsize, tol=tol, mutation=mutation, recombination=recombination,
            rng=rng, maxfun=maxfun, callback=callback, disp=disp, polish=polish,
            init=init, atol=atol, updating=updating, workers=workers,
            constraints=constraints, x0=x0, integrality=integrality,
            vectorized=vectorized)
        self._init_energized = False

    def __next__(self):
        """
        Evolve the population by a single generation

        Returns
        -------
        x : ndarray
            The best solution from the solver.
        fun : float
            Value of objective function obtained from the best solution.
        """
        # the population may have just been initialized and their energies
        # not calculated. If it has you have to calculate the initial energies
        if not self._init_energized:
            self.feasible, self.constraint_violation = (
                self._calculate_population_feasibilities(self.population))

            # only need to work out population energies for those that are
            # feasible
            self.population_energies[self.feasible] = (
                self._calculate_population_energies(
                    self.population[self.feasible]))

            self._promote_lowest_energy()

        if self.dither is not None:
            self.scale = self.random_number_generator.uniform(self.dither[0],
                                                              self.dither[1])

        if self._updating == 'immediate':
            # update best solution immediately
            for candidate in range(self.num_population_members):
                if self._nfev > self.maxfun:
                    raise StopIteration

                # create a trial solution
                trial = self._mutate(candidate)

                # ensuring that it's in the range [0, 1)
                self._ensure_constraint(trial)

                # scale from [0, 1) to the actual parameter value
                parameters = self._scale_parameters(trial)

                # determine the energy of the objective function
                if self._wrapped_constraints:
                    cv = self._constraint_violation_fn(parameters)
                    feasible = False
                    energy = np.inf
                    if not np.sum(cv) > 0:
                        # solution is feasible
                        feasible = True
                        energy = self.func(parameters)
                        self._nfev += 1
                else:
                    feasible = True
                    cv = np.atleast_2d([0.])
                    energy = self.func(parameters)
                    self._nfev += 1

                # compare trial and population member
                if self._accept_trial(energy, feasible, cv,
                                      self.population_energies[candidate],
                                      self.feasible[candidate],
                                      self.constraint_violation[candidate]):
                    self.population[candidate] = trial
                    self.population_energies[candidate] = np.squeeze(energy)
                    self.feasible[candidate] = feasible
                    self.constraint_violation[candidate] = cv

                    # if the trial candidate is also better than the best
                    # solution then promote it.
                    if self._accept_trial(energy, feasible, cv,
                                          self.population_energies[0],
                                          self.feasible[0],
                                          self.constraint_violation[0]):
                        self._promote_lowest_energy()

        elif self._updating == 'deferred':
            # update best solution once per generation
            if self._nfev >= self.maxfun:
                raise StopIteration

            # 'deferred' approach, vectorised form.
            # create trial solutions
            trial_pop = self._mutate_many(
                np.arange(self.num_population_members)
            )

            # enforce bounds
            self._ensure_constraint(trial_pop)

            # determine the energies of the objective function, but only for
            # feasible trials
            feasible, cv = self._calculate_population_feasibilities(trial_pop)
            trial_energies = np.full(self.num_population_members, np.inf)

            # only calculate for feasible entries
            trial_energies[feasible] = self._calculate_population_energies(
                trial_pop[feasible])

            # which solutions are 'improved'?
            loc = [self._accept_trial(*val) for val in
                   zip(trial_energies, feasible, cv, self.population_energies,
                       self.feasible, self.constraint_violation)]
            loc = np.array(loc)
            self.population = np.where(loc[:, np.newaxis],
                                       trial_pop,
                                       self.population)
            self.population_energies = np.where(loc,
                                                trial_energies,
                                                self.population_energies)
            self.feasible = np.where(loc,
                                     feasible,
                                     self.feasible)
            self.constraint_violation = np.where(loc[:, np.newaxis],
                                                 cv,
                                                 self.constraint_violation)

            # make sure the best solution is updated if updating='deferred'.
            # put the lowest energy into the best solution position.
            self._promote_lowest_energy()

        return self.x, self.population_energies[0]

    def solve(self):
        """
        Runs the DifferentialEvolutionSolver.

        Returns
        -------
        res : OptimizeResult
            The optimization result represented as a `OptimizeResult` object.
            Important attributes are: ``x`` the solution array, ``success`` a
            Boolean flag indicating if the optimizer exited successfully,
            ``message`` which describes the cause of the termination,
            ``population`` the solution vectors present in the population, and
            ``population_energies`` the value of the objective function for
            each entry in ``population``.
            See `OptimizeResult` for a description of other attributes. If
            `polish` was employed, and a lower minimum was obtained by the
            polishing, then OptimizeResult also contains the ``jac`` attribute.
            If the eventual solution does not satisfy the applied constraints
            ``success`` will be `False`.
        """
        nit, warning_flag = 0, False
        status_message = _status_message['success']

        # The population may have just been initialized (all entries are
        # np.inf). If it has you have to calculate the initial energies.
        # Although this is also done in the evolve generator it's possible
        # that someone can set maxiter=0, at which point we still want the
        # initial energies to be calculated (the following loop isn't run).
        if not self._init_energized and np.all(np.isinf(self.population_energies)):
            self.feasible, self.constraint_violation = (
                self._calculate_population_feasibilities(self.population))

            # only work out population energies for feasible solutions
            self.population_energies[self.feasible] = (
                self._calculate_population_energies(
                    self.population[self.feasible]))

            self._promote_lowest_energy()
            self._init_energized = True

        # do the optimization.
        for nit in range(1, self.maxiter + 1):
            # evolve the population by a generation
            try:
                next(self)
            except StopIteration:
                warning_flag = True
                if self._nfev > self.maxfun:
                    status_message = _status_message['maxfev']
                elif self._nfev == self.maxfun:
                    status_message = ('Maximum number of function evaluations'
                                      ' has been reached.')
                break

            if self.disp:
                print(f"differential_evolution step {nit}: f(x)="
                      f" {self.population_energies[0]}"
                      )

            if self.callback:
                c = self.tol / (self.convergence + _MACHEPS)
                res = self._result(nit=nit, message="in progress")
                res.convergence = c
                try:
                    warning_flag = bool(self.callback(res))
                except StopIteration:
                    warning_flag = True

                if warning_flag:
                    status_message = 'callback function requested stop early'

            # should the solver terminate?
            if warning_flag or self.converged():
                break

        else:
            status_message = _status_message['maxiter']
            warning_flag = True

        DE_result = self._result(
            nit=nit, message=status_message, warning_flag=warning_flag
        )

        if self.polish and not np.all(self.integrality):
            # can't polish if all the parameters are integers
            if np.any(self.integrality):
                # set the lower/upper bounds equal so that any integrality
                # constraints work.
                limits, integrality = self.limits, self.integrality
                limits[0, integrality] = DE_result.x[integrality]
                limits[1, integrality] = DE_result.x[integrality]

            polish_method = 'L-BFGS-B'

            if self._wrapped_constraints:
                polish_method = 'trust-constr'

                constr_violation = self._constraint_violation_fn(DE_result.x)
                if np.any(constr_violation > 0.):
                    warnings.warn("differential evolution didn't find a "
                                  "solution satisfying the constraints, "
                                  "attempting to polish from the least "
                                  "infeasible solution",
                                  UserWarning, stacklevel=2)

            pf = self.polish
            _f = self.original_func
            if not callable(pf):
                pf = partial(minimize, method=polish_method)
                def _f(x):
                    return list(self._mapwrapper(self.func, np.atleast_2d(x)))[0]

                if self.disp:
                    print(f"Polishing solution with '{polish_method}'")

            result = pf(
                _f,
                np.copy(DE_result.x),
                bounds=Bounds(lb=self.limits[0], ub=self.limits[1]),
                constraints=self.constraints
            )

            if not isinstance(result, OptimizeResult):
                raise ValueError(
                    "The result from a user defined polishing function "
                     "should return an OptimizeResult."
                )

            self._nfev += result.get("nfev", 0)
            DE_result.nfev = self._nfev

            # Polishing solution is only accepted if there is an improvement in
            # cost function, the polishing was successful and the solution lies
            # within the bounds.
            if (result.fun < DE_result.fun and
                    result.success and
                    np.all(result.x <= self.limits[1]) and
                    np.all(self.limits[0] <= result.x)):
                DE_result.fun = result.fun
                DE_result.x = result.x
                DE_result.jac = result.get("jac", None)
                # to keep internal state consistent
                self.population_energies[0] = result.fun
                self.population[0] = self._unscale_parameters(result.x)

        if self._wrapped_constraints:
            DE_result.constr = [c.violation(DE_result.x) for
                                c in self._wrapped_constraints]
            DE_result.constr_violation = np.max(
                np.concatenate(DE_result.constr))
            DE_result.maxcv = DE_result.constr_violation
            if DE_result.maxcv > 0:
                # if the result is infeasible then success must be False
                DE_result.success = False
                DE_result.message = ("The solution does not satisfy the "
                                     f"constraints, MAXCV = {DE_result.maxcv}")

        return DE_result

@_transition_to_rng("seed", position_num=9)
def differential_evolution_patched(func, bounds, args=(), strategy='best1bin',
                           maxiter=1000, popsize=15, tol=0.01,
                           mutation=(0.5, 1), recombination=0.7, rng=None,
                           callback=None, disp=False, polish=True,
                           init='latinhypercube', atol=0, updating='immediate',
                           workers=1, constraints=(), x0=None, *,
                           integrality=None, vectorized=False):
    '''See scipy docstring for the same function in
    `scipy.optimize._differentialevolution`'''

    # using a context manager means that any created Pool objects are
    # cleared up.
    with DifferentialEvolutionSolverPatched(func, bounds, args=args,
                                     strategy=strategy,
                                     maxiter=maxiter,
                                     popsize=popsize, tol=tol,
                                     mutation=mutation,
                                     recombination=recombination,
                                     rng=rng, polish=polish,
                                     callback=callback,
                                     disp=disp, init=init, atol=atol,
                                     updating=updating,
                                     workers=workers,
                                     constraints=constraints,
                                     x0=x0,
                                     integrality=integrality,
                                     vectorized=vectorized) as solver:
        ret = solver.solve()

    return ret

count_nonzero = lambda x: np.sum(~np.isclose(x, 0))
constraint = NonlinearConstraint(count_nonzero, lb=0., ub=3)
n = 10
a = np.random.randn(n)
fun = lambda x: np.sum((x - a) ** 2)
bounds = Bounds(lb=-10 * np.ones(n), ub=10 * np.ones(n))

rng = np.random.default_rng(5555)
res = differential_evolution(
    fun, rng=rng, bounds=bounds, constraints=constraint, polish=False)
rng = np.random.default_rng(5555)
res_patched = differential_evolution_patched(
    fun, rng=rng, bounds=bounds, constraints=constraint, polish=False)
print(np.all(res.x == res_patched.x)) # print True, both version give exactly same final population
```

#### AI Generation Disclosure
No AI tools used
