### PR TITLE
DOC: fix typo in "Design Conventions for Modules"

### DIFF
--- a/doc/source/dev/api-dev/design_conventions_modules.rst
+++ b/doc/source/dev/api-dev/design_conventions_modules.rst
@@ -1,4 +1,4 @@
-.. The contents of this file previousy resided in file `reference/inex.rst`
+.. The contents of this file previously resided in file `reference/inex.rst`
 
 .. _design_conventions_modules:
 


### PR DESCRIPTION
#### Reference issue

No issue. Trivial change.

#### What does this implement/fix?

Fix typo `previousy` should be `previously`

#### Additional information

Detected with typos-cli: https://github.com/crate-ci/typos

#### AI Generation Disclosure

No AI tools used.