### PR TITLE
BUG: preserve superlu allocation ownership across thread exit

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -69,6 +69,44 @@ jmp_buf *superlu_python_jmpbuf(void)
     return &g->jmpbuf;
 }
 
+PyObject *superlu_start_thread_memory_scope(void)
+{
+    SuperLUGlobalObject *g;
+    PyObject *saved_tracker;
+    PyObject *replacement;
+
+    g = get_tls_global();
+    if (g == NULL) {
+        return NULL;
+    }
+    replacement = PyDict_New();
+    if (replacement == NULL) {
+        return NULL;
+    }
+    saved_tracker = g->memory_dict;
+    g->memory_dict = replacement;
+    return saved_tracker;
+}
+
+PyObject *superlu_swap_thread_memory_tracker(PyObject *tracker)
+{
+    SuperLUGlobalObject *g;
+    PyObject *replaced_tracker;
+
+    if (!PyDict_Check(tracker)) {
+        PyErr_SetString(PyExc_TypeError, "memory tracker must be a dictionary");
+        return NULL;
+    }
+    g = get_tls_global();
+    if (g == NULL) {
+        return NULL;
+    }
+    Py_INCREF(tracker);
+    replaced_tracker = g->memory_dict;
+    g->memory_dict = tracker;
+    return replaced_tracker;
+}
+
 void superlu_python_module_abort(char *msg)
 {
     SuperLUGlobalObject *g;
@@ -152,8 +190,8 @@ void superlu_python_module_free(void *ptr)
     /* This will only free the pointer if it could find it in the dictionary
      * of already allocated pointers --- thus after abort, the module can free all
      * the memory that "might" have been allocated to avoid memory leaks on abort
-     * calls. If the key cannot be created, leave the pointer in the dictionary;
-     * SuperLUGlobal_dealloc will free it.
+     * calls. If the key cannot be created, leave the pointer in the dictionary.
+     * The dictionary owner frees residual tracked allocations during deallocation.
      */
     if (key != NULL) {
         if (!PyDict_DelItem(g->memory_dict, key)) {
@@ -166,17 +204,24 @@ void superlu_python_module_free(void *ptr)
 }
 
 
-static void SuperLUGlobal_dealloc(SuperLUGlobalObject *self)
+void superlu_free_tracked_allocations(PyObject *tracker)
 {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
 
+    while (PyDict_Next(tracker, &pos, &key, &value)) {
+        void *ptr;
+        ptr = PyLong_AsVoidPtr(key);
+        free(ptr);
+    }
+    PyDict_Clear(tracker);
+}
+
+
+static void SuperLUGlobal_dealloc(SuperLUGlobalObject *self)
+{
     if (self->memory_dict != NULL) {
-        while (PyDict_Next(self->memory_dict, &pos, &key, &value)) {
-            void *ptr;
-            ptr = PyLong_AsVoidPtr(key);
-            free(ptr);
-        }
+        superlu_free_tracked_allocations(self->memory_dict);
     }
 
     Py_XDECREF(self->memory_dict);

--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -15,7 +15,7 @@
    been allocated.  (It's ok to FREE unallocated memory)---will be ignored.
 */
 
-static SuperLUGlobalObject *get_tls_global(void)
+SuperLUGlobalObject *get_tls_global(void)
 {
     PyObject *thread_dict;
     SuperLUGlobalObject *obj;
@@ -69,39 +69,18 @@ jmp_buf *superlu_python_jmpbuf(void)
     return &g->jmpbuf;
 }
 
-PyObject *superlu_start_thread_memory_scope(void)
+/* Install `tracker` as the thread's allocation tracker, and hand the previously
+ * installed one back to the caller.  Steals a reference to `tracker` and returns
+ * a new reference to the replaced tracker.
+ *
+ * `g` is resolved by the caller, so this is a plain pointer exchange that cannot
+ * fail --- which is what lets the callers swap back on their error paths without
+ * having to invent a recovery strategy for "restoring the tracker failed".
+ */
+PyObject *superlu_swap_memory_tracker(SuperLUGlobalObject *g, PyObject *tracker)
 {
-    SuperLUGlobalObject *g;
-    PyObject *saved_tracker;
-    PyObject *replacement;
-
-    g = get_tls_global();
-    if (g == NULL) {
-        return NULL;
-    }
-    replacement = PyDict_New();
-    if (replacement == NULL) {
-        return NULL;
-    }
-    saved_tracker = g->memory_dict;
-    g->memory_dict = replacement;
-    return saved_tracker;
-}
-
-PyObject *superlu_swap_thread_memory_tracker(PyObject *tracker)
-{
-    SuperLUGlobalObject *g;
     PyObject *replaced_tracker;
 
-    if (!PyDict_Check(tracker)) {
-        PyErr_SetString(PyExc_TypeError, "memory tracker must be a dictionary");
-        return NULL;
-    }
-    g = get_tls_global();
-    if (g == NULL) {
-        return NULL;
-    }
-    Py_INCREF(tracker);
     replaced_tracker = g->memory_dict;
     g->memory_dict = tracker;
     return replaced_tracker;
@@ -204,6 +183,23 @@ void superlu_python_module_free(void *ptr)
 }
 
 
+/* Free every allocation still registered in `tracker` and empty it.
+ *
+ * The keys are the pointers themselves (the values are unused), and every
+ * pointer in a tracker came from `superlu_python_module_malloc`, so freeing all
+ * of them is safe.  Callers must only invoke this on a tracker whose contents
+ * they own:
+ *
+ *  - `Py_gstrf` gives each factorization a tracker of its own, so once it
+ *    succeeds that tracker holds exactly the allocations reachable from the
+ *    factor's L, U, perm_r and perm_c.  Freeing all of them in
+ *    `SuperLU_dealloc` is therefore equivalent to the SUPERLU_FREE /
+ *    Destroy_SuperNode_Matrix / Destroy_CompCol_Matrix sequence it replaces,
+ *    and additionally reclaims anything gstrf left behind that is not
+ *    reachable from L or U.
+ *  - `SuperLUGlobal_dealloc` frees what is left in the thread's own tracker,
+ *    which after the above can only be residue from an aborted call.
+ */
 void superlu_free_tracked_allocations(PyObject *tracker)
 {
     PyObject *key, *value;

--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -208,6 +208,8 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
     PyArrayObject *rowind, *colptr, *nzvals;
     SuperMatrix A = { 0 };
     PyObject *result;
+    PyObject *saved_tracker = NULL;
+    PyObject *factor_tracker = NULL;
     PyObject *py_csc_construct_func = NULL;
     PyObject *option_dict = NULL;
     int type;
@@ -244,6 +246,11 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	return NULL;
     }
 
+    saved_tracker = superlu_start_thread_memory_scope();
+    if (saved_tracker == NULL) {
+        return NULL;
+    }
+
     if (NCFormat_from_spMatrix(&A, N, N, nnz, nzvals, rowind, colptr,
 			       type)) {
 	goto fail;
@@ -256,11 +263,26 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 
     /* arrays of input matrix will not be freed */
     Destroy_SuperMatrix_Store(&A);
+    factor_tracker = superlu_swap_thread_memory_tracker(saved_tracker);
+    if (factor_tracker == NULL) {
+        abort();
+    }
+    Py_DECREF(saved_tracker);
+    ((SuperLUObject *)result)->memory_tracker = factor_tracker;
     return result;
 
   fail:
     /* arrays of input matrix will not be freed */
     XDestroy_SuperMatrix_Store(&A);
+    if (saved_tracker != NULL) {
+        factor_tracker = superlu_swap_thread_memory_tracker(saved_tracker);
+        if (factor_tracker == NULL) {
+            abort();
+        }
+        Py_DECREF(saved_tracker);
+        superlu_free_tracked_allocations(factor_tracker);
+        Py_DECREF(factor_tracker);
+    }
     return NULL;
 }
 

--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -208,6 +208,8 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
     PyArrayObject *rowind, *colptr, *nzvals;
     SuperMatrix A = { 0 };
     PyObject *result;
+    SuperLUGlobalObject *g;
+    PyObject *fresh_tracker = NULL;
     PyObject *saved_tracker = NULL;
     PyObject *factor_tracker = NULL;
     PyObject *py_csc_construct_func = NULL;
@@ -246,10 +248,22 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	return NULL;
     }
 
-    saved_tracker = superlu_start_thread_memory_scope();
-    if (saved_tracker == NULL) {
+    /* Give this factorization an allocation tracker of its own, so that the
+     * resulting factor owns its memory instead of the thread that happened to
+     * create it.  Otherwise the thread's tracker frees the factor's memory when
+     * the thread exits, even though the factor is still alive --- see gh-25404
+     * and the comment on superlu_free_tracked_allocations.
+     */
+    g = get_tls_global();
+    if (g == NULL) {
         return NULL;
     }
+    fresh_tracker = PyDict_New();
+    if (fresh_tracker == NULL) {
+        return NULL;
+    }
+    /* the swap steals our reference to fresh_tracker */
+    saved_tracker = superlu_swap_memory_tracker(g, fresh_tracker);
 
     if (NCFormat_from_spMatrix(&A, N, N, nnz, nzvals, rowind, colptr,
 			       type)) {
@@ -261,28 +275,29 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	goto fail;
     }
 
-    /* arrays of input matrix will not be freed */
+    /* arrays of input matrix will not be freed.  This has to happen before the
+     * tracker is swapped back, so that A's Store is charged to the factorization
+     * tracker it was allocated from rather than being left in the factor's.
+     */
     Destroy_SuperMatrix_Store(&A);
-    factor_tracker = superlu_swap_thread_memory_tracker(saved_tracker);
-    if (factor_tracker == NULL) {
-        abort();
-    }
-    Py_DECREF(saved_tracker);
+    factor_tracker = superlu_swap_memory_tracker(g, saved_tracker);
+    /* `result` was built while `factor_tracker` was installed, so it now owns
+     * every allocation left in it, and frees them in SuperLU_dealloc.
+     */
     ((SuperLUObject *)result)->memory_tracker = factor_tracker;
     return result;
 
   fail:
     /* arrays of input matrix will not be freed */
     XDestroy_SuperMatrix_Store(&A);
-    if (saved_tracker != NULL) {
-        factor_tracker = superlu_swap_thread_memory_tracker(saved_tracker);
-        if (factor_tracker == NULL) {
-            abort();
-        }
-        Py_DECREF(saved_tracker);
-        superlu_free_tracked_allocations(factor_tracker);
-        Py_DECREF(factor_tracker);
-    }
+    /* Nothing survives a failed factorization: newSuperLUObject's own failure
+     * path drops the half-built object without freeing L, U, perm_r or perm_c,
+     * because it has no tracker attached yet.  Reclaiming the whole tracker
+     * here covers those as well as any partial allocations gstrf left behind.
+     */
+    factor_tracker = superlu_swap_memory_tracker(g, saved_tracker);
+    superlu_free_tracked_allocations(factor_tracker);
+    Py_DECREF(factor_tracker);
     return NULL;
 }
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -127,12 +127,10 @@ static void SuperLU_dealloc(SuperLUObject * self)
     self->cached_U = NULL;
     self->cached_L = NULL;
     self->py_csc_construct_func = NULL;
-    SUPERLU_FREE(self->perm_r);
-    SUPERLU_FREE(self->perm_c);
-    self->perm_r = NULL;
-    self->perm_c = NULL;
-    XDestroy_SuperNode_Matrix(&self->L);
-    XDestroy_CompCol_Matrix(&self->U);
+    if (self->memory_tracker != NULL) {
+        superlu_free_tracked_allocations(self->memory_tracker);
+        Py_CLEAR(self->memory_tracker);
+    }
     PyObject_Del(self);
 }
 
@@ -725,6 +723,7 @@ PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
     self->cached_U = NULL;
     self->cached_L = NULL;
     self->py_csc_construct_func = NULL;
+    self->memory_tracker = NULL;
     self->type = intype;
 
     jmpbuf_ptr = (volatile jmp_buf *)superlu_python_jmpbuf();

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -127,6 +127,15 @@ static void SuperLU_dealloc(SuperLUObject * self)
     self->cached_U = NULL;
     self->cached_L = NULL;
     self->py_csc_construct_func = NULL;
+    /* The tracker owns L, U, perm_r and perm_c, so freeing it replaces the
+     * SUPERLU_FREE / XDestroy_* calls that used to live here.  Going through
+     * SUPERLU_FREE would be wrong: it consults the *calling* thread's tracker,
+     * so it silently leaks whenever a factor is dropped on a thread other than
+     * the one that built it.
+     *
+     * The tracker is NULL only for an object abandoned by newSuperLUObject's
+     * failure path; Py_gstrf reclaims that memory wholesale instead.
+     */
     if (self->memory_tracker != NULL) {
         superlu_free_tracked_allocations(self->memory_tracker);
         Py_CLEAR(self->memory_tracker);
@@ -723,6 +732,10 @@ PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
     self->cached_U = NULL;
     self->cached_L = NULL;
     self->py_csc_construct_func = NULL;
+    /* Py_gstrf attaches the tracker once the factorization has succeeded.  Until
+     * then the allocations below belong to whatever tracker the caller has
+     * installed, and it is the caller's job to reclaim them if we fail.
+     */
     self->memory_tracker = NULL;
     self->type = intype;
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.h
@@ -79,12 +79,18 @@ void XDestroy_CompCol_Permuted(SuperMatrix *);
 void XStatFree(SuperLUStat_t *);
 
 jmp_buf *superlu_python_jmpbuf(void);
-/* Start transfers the current TLS tracker to the caller.
- * Swap borrows its argument, gives TLS a reference, and transfers the
- * replaced TLS tracker to the caller.
+
+/* Per-thread SuperLU state, holding the jmp_buf and the allocation tracker.
+ * Returns a borrowed reference, valid until the thread exits, or NULL with an
+ * exception set.
  */
-PyObject *superlu_start_thread_memory_scope(void);
-PyObject *superlu_swap_thread_memory_tracker(PyObject *tracker);
+SuperLUGlobalObject *get_tls_global(void);
+
+/* Steals a reference to `tracker`, returns a new reference to the tracker it
+ * replaced.  Cannot fail.  See the comment on superlu_free_tracked_allocations
+ * for the ownership rules that make this useful.
+ */
+PyObject *superlu_swap_memory_tracker(SuperLUGlobalObject *g, PyObject *tracker);
 void superlu_free_tracked_allocations(PyObject *tracker);
 
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.h
@@ -38,6 +38,7 @@ typedef struct {
     PyObject *cached_U;
     PyObject *cached_L;
     PyObject *py_csc_construct_func;
+    PyObject *memory_tracker;
     int type;
 } SuperLUObject;
 
@@ -78,6 +79,13 @@ void XDestroy_CompCol_Permuted(SuperMatrix *);
 void XStatFree(SuperLUStat_t *);
 
 jmp_buf *superlu_python_jmpbuf(void);
+/* Start transfers the current TLS tracker to the caller.
+ * Swap borrows its argument, gives TLS a reference, and transfers the
+ * replaced TLS tracker to the caller.
+ */
+PyObject *superlu_start_thread_memory_scope(void);
+PyObject *superlu_swap_thread_memory_tracker(PyObject *tracker);
+void superlu_free_tracked_allocations(PyObject *tracker);
 
 
 /* Custom thread begin/end statements: Numpy versions < 1.9 are not safe

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -742,6 +742,43 @@ class TestSplu:
 
             assert_equal(len(oks), 20)
 
+    @pytest.mark.parametrize("solver", [splu, spilu])
+    @pytest.mark.xfail(IS_WASM, reason="cannot start new thread in Pyodide/WASM")
+    def test_factor_outlives_worker_thread(self, solver):
+        size = 64
+        matrices = [
+            scipy.sparse.diags_array(
+                (-np.ones(size - 1), scale * np.ones(size),
+                 -np.ones(size - 1)),
+                offsets=(-1, 0, 1), format="csc",
+            )
+            for scale in (2, 4, 6, 8)
+        ]
+        singular = scipy.sparse.csc_array((size, size))
+        rhs = np.ones(size)
+        factors = []
+
+        def worker(batch):
+            with pytest.raises(RuntimeError):
+                solver(singular)
+            factors.extend(solver(matrix) for matrix in batch)
+
+        for batch in (matrices[:2], matrices[2:]):
+            thread = threading.Thread(target=worker, args=(batch,))
+            thread.start()
+            thread.join()
+
+        assert len(factors) == len(matrices)
+        for index, matrix in enumerate(matrices):
+            assert_allclose(
+                matrix @ factors[index].solve(rhs), rhs, rtol=1e-5
+            )
+
+        thread = threading.Thread(target=factors.clear)
+        thread.start()
+        thread.join()
+        assert not factors
+
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is
         # passed. See gh-20993.

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -1,3 +1,5 @@
+import gc
+import queue
 import sys
 import threading
 import warnings
@@ -745,6 +747,10 @@ class TestSplu:
     @pytest.mark.parametrize("solver", [splu, spilu])
     @pytest.mark.xfail(IS_WASM, reason="cannot start new thread in Pyodide/WASM")
     def test_factor_outlives_worker_thread(self, solver):
+        # A factor built in a worker thread must stay usable after that thread
+        # exits.  The allocation tracker used to belong to the creating thread,
+        # so thread teardown freed memory the factor was still pointing at, and
+        # solving with it segfaulted.  See gh-25404.
         size = 64
         matrices = [
             scipy.sparse.diags_array(
@@ -759,6 +765,8 @@ class TestSplu:
         factors = []
 
         def worker(batch):
+            # A failed factorization first, so the thread also has to survive
+            # the error path reclaiming a partially built factor.
             with pytest.raises(RuntimeError):
                 solver(singular)
             factors.extend(solver(matrix) for matrix in batch)
@@ -774,10 +782,65 @@ class TestSplu:
                 matrix @ factors[index].solve(rhs), rhs, rtol=1e-5
             )
 
+        # Dropping a factor from a thread that did not create it must free that
+        # factor and nothing else, so the one held back stays usable.
+        survivor = factors.pop()
         thread = threading.Thread(target=factors.clear)
         thread.start()
         thread.join()
-        assert not factors
+        assert_allclose(matrices[-1] @ survivor.solve(rhs), rhs, rtol=1e-5)
+
+    @pytest.mark.slow
+    @pytest.mark.skipif(IS_WASM, reason="cannot start new thread in Pyodide/WASM")
+    def test_factor_freed_on_other_thread_is_not_leaked(self):
+        # Freeing a factor releases its memory even when the thread that built
+        # it is still running.  SUPERLU_FREE only frees a pointer it finds in
+        # the calling thread's allocation tracker, so before the factor owned
+        # its allocations outright this leaked the whole L/U factor every time.
+        resource = pytest.importorskip("resource")
+        check_free_memory(500)
+
+        size, iterations = 1000, 12
+        A = (random_array((size, size), density=0.01, format="csc", rng=0)
+             + eye_array(size, format="csc") * 10)
+
+        work = queue.Queue()
+        done = queue.Queue()
+
+        def worker():
+            # Stays alive for the whole test, so nothing is reclaimed as a side
+            # effect of the thread exiting.
+            while True:
+                matrix = work.get()
+                if matrix is None:
+                    return
+                done.put(splu(matrix))
+
+        def maxrss_mb():
+            return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024
+
+        def factor_and_drop():
+            work.put(A)
+            factor = done.get()
+            del factor  # dropped here, on the main thread
+            gc.collect()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        try:
+            for _ in range(3):  # warm up allocator high-water mark
+                factor_and_drop()
+            before = maxrss_mb()
+            for _ in range(iterations):
+                factor_and_drop()
+            growth = maxrss_mb() - before
+        finally:
+            work.put(None)
+            thread.join()
+
+        # Each leaked factor is ~6 MB here, so the pre-fix growth was ~60 MB
+        # over these iterations.  Allow generous headroom for allocator noise.
+        assert growth < 25, f"leaked {growth} MB over {iterations} factorizations"
 
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
A SuperLU factor can remain in use after the thread that created it exits. Its allocation tracker is owned by that thread, so thread cleanup can free memory that the factor still references. Using the factor afterward can trigger a use-after-free, causing a segmentation fault on Linux and access violation `0xC0000005` on Windows. 

This change gives each factorization a separate tracker so that the resulting factor owns any remaining allocations and frees them during destruction.

#### AI Generation Disclosure
Codex (OpenAI) assisted in reproducing the issue across platforms, audited new changes over multiple iterations, recommended refactors and tests, and conducted final completeness and compliance checks before submission.