### PR TITLE
DOC: deprecate trim_mean - add deprecation note in docstring

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3714,6 +3714,15 @@ def trim_mean(a, proportiontocut, axis=0):
     >>> stats.trim_mean(x2, 0.25, axis=1)
     array([ 2.5, 25. ])
 
+    .. deprecated:: 1.16.0
+       `trim_mean` is deprecated and will be removed in a future version.
+       The behavior of this function is ambiguous when ``proportiontocut * n``
+       is not an integer: the number of trimmed elements is rounded down
+       silently, which may not match user expectations. See
+       :gh:`25757` for more details. Consider using
+       :func:`scipy.stats.mstats.trimmed_mean` or a third-party package
+       such as `sgmean <https://pypi.org/project/sgmean/>`_ as alternatives.
+
     """
     xp = array_namespace(a)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3717,10 +3717,9 @@ def trim_mean(a, proportiontocut, axis=0):
     .. note::
 
        This is a legacy function and could be removed in future versions of SciPy.
-        See `Trimming and winsorization transition guide 
+        See `Trimming and winsorization transition guide
         <https://docs.scipy.org/doc/scipy/tutorial/stats/outliers.html>`_ for the
         reasoning.
-
     """
     xp = array_namespace(a)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3717,10 +3717,10 @@ def trim_mean(a, proportiontocut, axis=0):
     .. note::
 
        This is a legacy function and could be removed in future versions of SciPy.
-        See `Trimming and winsorization transition guide
-        <https://docs.scipy.org/doc/scipy/tutorial/stats/outliers.html>`_ for the
-        reasoning.
-        
+       See `Trimming and winsorization transition guide
+       <https://docs.scipy.org/doc/scipy/tutorial/stats/outliers.html>`_ for the
+       reasoning.
+
     """
     xp = array_namespace(a)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3714,14 +3714,12 @@ def trim_mean(a, proportiontocut, axis=0):
     >>> stats.trim_mean(x2, 0.25, axis=1)
     array([ 2.5, 25. ])
 
-    .. deprecated:: 1.16.0
-       `trim_mean` is deprecated and will be removed in a future version.
-       The behavior of this function is ambiguous when ``proportiontocut * n``
-       is not an integer: the number of trimmed elements is rounded down
-       silently, which may not match user expectations. See
-       :gh:`25757` for more details. Consider using
-       :func:`scipy.stats.mstats.trimmed_mean` or a third-party package
-       such as `sgmean <https://pypi.org/project/sgmean/>`_ as alternatives.
+    .. note::
+
+       This is a legacy function and could be removed in future versions of SciPy.
+        See `Trimming and winsorization transition guide 
+        <https://docs.scipy.org/doc/scipy/tutorial/stats/outliers.html>`_ for the
+        reasoning.
 
     """
     xp = array_namespace(a)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3720,6 +3720,7 @@ def trim_mean(a, proportiontocut, axis=0):
         See `Trimming and winsorization transition guide
         <https://docs.scipy.org/doc/scipy/tutorial/stats/outliers.html>`_ for the
         reasoning.
+        
     """
     xp = array_namespace(a)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-25757

#### What does this implement/fix?
Add a `.. deprecated:: 1.16.0` note to the `trim_mean` docstring.

The behavior of `trim_mean` is ambiguous when `proportiontocut * n` is not an integer: the number of trimmed elements is rounded down silently, which may not match user expectations. As discussed in gh-25757, `trim_mean` is expected to be removed in a future version.
The deprecation note points users to `scipy.stats.mstats.trimmed_mean` or third-party alternatives such as `sgmean` (https://pypi.org/project/sgmean/).
#### Additional information
The same silent truncation behavior exists in R base `mean(..., trim)` and has been reported to the R Core Team.
#### AI Generation Disclosure
AI tools were used to help structure and draft text. The technical discovery of the problem, verification against Statgraphics, and the decision to report it are entirely the author's own work.
