### PR TITLE
CI: fix various cache-related issues

### DIFF
--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -7,6 +7,10 @@ inputs:
   job_name:
     description: "Name of the calling job, used as cache key prefix"
     required: true
+  save:
+    description: "Whether to save the cache on main; set to false for matrix variants that build the same thing as another variant"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -23,7 +27,7 @@ runs:
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions
       # are not capable of running post job steps.
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' && inputs.save == 'true' }}
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
@@ -31,7 +35,7 @@ runs:
         restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
     - name: Setup compiler cache
       # Run just the restore if not running on main
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ github.ref != 'refs/heads/main' || inputs.save != 'true' }}
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -28,7 +28,7 @@ runs:
       # Note: we can't simply use restore followed by save because composite actions
       # are not capable of running post job steps.
       if: ${{ github.ref == 'refs/heads/main' && inputs.save == 'true' }}
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
@@ -36,7 +36,7 @@ runs:
     - name: Setup compiler cache
       # Run just the restore if not running on main
       if: ${{ github.ref != 'refs/heads/main' || inputs.save != 'true' }}
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -571,6 +571,8 @@ jobs:
         with:
           workflow_name: ${{ github.workflow }}
           job_name: ${{ github.job }}
+          # the two matrix variants build the same thing, avoid saving twice
+          save: ${{ matrix.parallel == '0' }}
 
       - name: Run tests (full)
         if: ${{ matrix.parallel == '0'}}

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: cache install
         id: cache-install
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
               /opt/intel/oneapi/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,8 +73,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: "environment.yml"
 
       - name: Set rtools location (mingw-w64)
         run: |

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: cache install
         id: cache-install
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
               C:\Program Files (x86)\Intel\oneAPI\compiler

--- a/pixi.toml
+++ b/pixi.toml
@@ -866,6 +866,7 @@ PYTHON_GIL = "0"
 
 [feature.build-freethreading.tasks.build-freethreading]
 cmd = "spin build --build-dir=build-freethreading --setup-args=-Dblas=blas --setup-args=-Dlapack=lapack --setup-args=-Duse-g77-abi=true"
+env = { CC = "ccache $CC", CXX = "ccache $CXX" }
 description = "Build SciPy (freethreaded Python)"
 
 [feature.test-freethreading.tasks.test-freethreading]

--- a/pixi.toml
+++ b/pixi.toml
@@ -907,4 +907,4 @@ description = "Build SciPy with clang-22 and -werror"
 gha-tools = "*"
 
 [feature.gha-update.tasks.gha-update]
-cmd = "gha-tools autoupdate ./.github/workflows/ --write --pin all -s specific"
+cmd = "gha-tools autoupdate ./.github/workflows/ ./.github/ccache/ --write --pin all -s specific"


### PR DESCRIPTION
Each fix is making things consistent with the general usage patterns we already established:

- don't cache `setup-python`
- only upload to GitHub cache from `main`, not from PRs
- fix a `ccache` usage for the free-threaded pixi task (also making ccache in CI job work)
- ensure  `gha-update` takes our composite ccache action into account

This will further clean up the state of our repo-level cache usage.

#### AI Generation Disclosure

Used Claude Opus 4.8 to check consistency across files for the last two commits