### PR TITLE
BUG: fix OOB Memory Access in SciPy SuperLU Path

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -347,6 +347,8 @@ static PyObject *Py_gstrs(PyObject * self, PyObject * args,
             (PyArrayObject*)L_nzvals, (PyArrayObject*)L_rowind, (PyArrayObject*)L_colptr,
             L_type, SLU_SC, SLU_TRLU, L_col_to_sup, L_sup_to_col);
     if (L_conv_err) {
+        SUPERLU_FREE((void*)L_col_to_sup);
+        SUPERLU_FREE((void*)L_sup_to_col);
         return NULL;
     }
     int U_conv_err = SparseFormat_from_spMatrix(
@@ -354,6 +356,8 @@ static PyObject *Py_gstrs(PyObject * self, PyObject * args,
             (PyArrayObject*)U_nzvals, (PyArrayObject*)U_rowind, (PyArrayObject*)U_colptr,
             U_type, SLU_NC, SLU_TRU, NULL, NULL);
     if (U_conv_err) {
+        SUPERLU_FREE((void*)L_col_to_sup);
+        SUPERLU_FREE((void*)L_sup_to_col);
         Destroy_SuperMatrix_Store((SuperMatrix*)&L_super);
         return NULL;
     }

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -369,6 +369,9 @@ int SparseFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz, int csr,
     volatile int ok = 0;
     volatile jmp_buf *jmpbuf_ptr;
 
+    int i;
+    int *ri;
+
     ok = (PyArray_EquivTypenums(PyArray_TYPE(nzvals), typenum) &&
           PyArray_EquivTypenums(PyArray_TYPE(indices), NPY_INT) &&
           PyArray_EquivTypenums(PyArray_TYPE(pointers), NPY_INT) &&
@@ -386,6 +389,15 @@ int SparseFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz, int csr,
                         "sparse matrix arrays must be 1-D C-contiguous and of proper "
                         "sizes and types");
         return -1;
+    }
+
+    ri = (int *)PyArray_DATA(indices);
+    for (i = 0; i < nnz; ++i) {
+        if (ri[i] < 0 || ri[i] >= m) {
+            PyErr_SetString(PyExc_ValueError,
+                            "row index out of bounds for matrix shape");
+            return -1;
+        }
     }
 
     jmpbuf_ptr = (volatile jmp_buf *)superlu_python_jmpbuf();

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -370,7 +370,11 @@ int SparseFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz, int csr,
     volatile jmp_buf *jmpbuf_ptr;
 
     int i;
-    int *ri;
+    int *ri, *pi;
+    /* CSR is row-oriented, CSC (both plain and supernodal) column-oriented */
+    int npointers = (csr == 1 ? m : n) + 1;
+    /* CSR stores column indices, CSC stores row indices */
+    int index_bound = (csr == 1 ? n : m);
 
     ok = (PyArray_EquivTypenums(PyArray_TYPE(nzvals), typenum) &&
           PyArray_EquivTypenums(PyArray_TYPE(indices), NPY_INT) &&
@@ -383,7 +387,7 @@ int SparseFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz, int csr,
           PyArray_IS_C_CONTIGUOUS(pointers) &&
           nnz <= PyArray_DIM(nzvals, 0) &&
           nnz <= PyArray_DIM(indices, 0) &&
-          (csr ? (m+1) : (n+1)) <= PyArray_DIM(pointers, 0));
+          npointers <= PyArray_DIM(pointers, 0));
     if (!ok) {
         PyErr_SetString(PyExc_ValueError,
                         "sparse matrix arrays must be 1-D C-contiguous and of proper "
@@ -391,11 +395,38 @@ int SparseFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz, int csr,
         return -1;
     }
 
+    /*
+     * Validate the index arrays.  SuperLU indexes into them without any bounds
+     * checking, and they may have been mutated in place after the sparse array
+     * was constructed, so the checks done by `check_format` at construction
+     * time are not sufficient.  Check `pointers` first: it is the cheaper scan
+     * (O(n) rather than O(nnz)), and it is what bounds the range of `indices`
+     * that SuperLU actually reads.
+     */
+    pi = (int *)PyArray_DATA(pointers);
+    if (pi[0] != 0) {
+        PyErr_SetString(PyExc_ValueError, "SuperLU: indptr should start with 0");
+        return -1;
+    }
+    for (i = 0; i < npointers - 1; ++i) {
+        if (pi[i] > pi[i + 1]) {
+            PyErr_SetString(PyExc_ValueError,
+                            "SuperLU: indptr must be a non-decreasing sequence");
+            return -1;
+        }
+    }
+    if (pi[npointers - 1] > nnz) {
+        PyErr_Format(PyExc_ValueError,
+                     "SuperLU: last value of indptr should be <= nnz (%d)", nnz);
+        return -1;
+    }
+
     ri = (int *)PyArray_DATA(indices);
     for (i = 0; i < nnz; ++i) {
-        if (ri[i] < 0 || ri[i] >= m) {
-            PyErr_SetString(PyExc_ValueError,
-                            "row index out of bounds for matrix shape");
+        if (ri[i] < 0 || ri[i] >= index_bound) {
+            PyErr_Format(PyExc_ValueError,
+                         "SuperLU: %s indices must be >= 0 and < %d",
+                         csr == 1 ? "column" : "row", index_bound);
             return -1;
         }
     }

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -795,6 +795,88 @@ class TestGstrsErrors:
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr,
                                 self.b.astype(np.uint8))
 
+
+class TestIndexValidation:
+    """The index arrays of a sparse array can be mutated in place after it has
+    been constructed, so ``check_format`` at construction time is not enough:
+    SuperLU indexes into ``indices``/``indptr`` without bounds checking, which
+    used to give an out-of-bounds read/write rather than an exception.
+    """
+    def setup_method(self):
+        use_solver(useUmfpack=False)
+
+    @staticmethod
+    def _matrix():
+        data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        indices = np.array([0, 1, 0, 1], dtype=np.intc)
+        indptr = np.array([0, 2, 4], dtype=np.intc)
+        A = csc_array((data, indices, indptr), shape=(2, 2), copy=False)
+        # skip sum_duplicates, so that the tampered arrays reach SuperLU
+        A._has_canonical_format = True
+        A._has_sorted_indices = True
+        return A
+
+    @pytest.mark.parametrize("bad", [100000, -5])
+    def test_splu_indices_out_of_bounds(self, bad):
+        A = self._matrix()
+        A.indices[1] = bad
+        with assert_raises(ValueError, match="row indices must be"):
+            splu(A, permc_spec='NATURAL')
+
+    @pytest.mark.parametrize("bad", [100000, -5])
+    def test_spsolve_indices_out_of_bounds(self, bad):
+        A = self._matrix()
+        A.indices[1] = bad
+        with assert_raises(ValueError, match="row indices must be"):
+            spsolve(A, np.ones(2))
+
+    @pytest.mark.parametrize("bad", [100000, -100])
+    def test_splu_indptr_out_of_bounds(self, bad):
+        A = self._matrix()
+        A.indptr[1] = bad
+        with assert_raises(ValueError, match="indptr must be|indptr should be"):
+            splu(A, permc_spec='NATURAL')
+
+    def test_splu_indptr_not_starting_at_zero(self):
+        A = self._matrix()
+        A.indptr[0] = 1
+        with assert_raises(ValueError, match="indptr should start with 0"):
+            splu(A, permc_spec='NATURAL')
+
+    def test_gstrf_indptr_beyond_nnz(self):
+        # `indices` are all in range, but `indptr` makes SuperLU read past
+        # `nnz` -- so the two checks are only sound together.
+        A = self._matrix()
+        with assert_raises(ValueError, match="last value of indptr"):
+            _superlu.gstrf(2, 3, A.data, A.indices, A.indptr,
+                           csc_construct_func=csc_array, ilu=False,
+                           options=dict(ColPerm="NATURAL", SymmetricMode=True))
+
+    @pytest.mark.parametrize("bad_L", [True, False])
+    def test_gstrs_indices_out_of_bounds(self, bad_L):
+        A = csc_array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        b = np.array([[1.0], [2.0], [3.0]])
+        L = tril(A, format='csc')
+        U = triu(A, k=1, format='csc')
+        (L if bad_L else U).indices[0] = 100000
+        with assert_raises(ValueError, match="row indices must be"):
+            _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
+                           U.shape[0], U.nnz, U.data, U.indices, U.indptr, b)
+
+    def test_unpruned_arrays_are_accepted(self):
+        # `indices`/`data` longer than nnz is legal; the scan must stop at nnz
+        # and not reject the trailing (meaningless) entries.
+        data = np.array([1.0, 2.0, 3.0, 4.0, 0.0, 0.0])
+        indices = np.array([0, 1, 0, 1, 12345, -7], dtype=np.intc)
+        indptr = np.array([0, 2, 4], dtype=np.intc)
+        lu = _superlu.gstrf(2, 4, data, indices, indptr,
+                            csc_construct_func=csc_array, ilu=False,
+                            options=dict(ColPerm="NATURAL", SymmetricMode=True))
+        assert_allclose(lu.solve(np.array([1.0, 1.0])),
+                        np.linalg.solve(np.array([[1.0, 3.0], [2.0, 4.0]]),
+                                        np.ones(2)))
+
+
 class TestSpsolveTriangular:
     def setup_method(self):
         use_solver(useUmfpack=False)


### PR DESCRIPTION
... from Unvalidated CSC `indices`.

Reported-by: AISLE <security@aisle.com>

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Fix crash that is reproducible through:

```
import numpy as np
from scipy.sparse import csc_matrix
from scipy.sparse.linalg import splu

data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
indices = np.array([0, 1, 0, 1], dtype=np.int32)
indptr = np.array([0, 2, 4], dtype=np.int32)
B = csc_matrix((data, indices, indptr), shape=(2, 2), copy=False)
B.indices[1] = 100000
splu(B, permc_spec='NATURAL')
```


#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Found by AISLE in partnership with Red Hat
