### PR TITLE
MNT/TST: Use pytest-split for Emscripten/Pyodide CI

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 3
+
 jobs:
   get_commit_message:
     name: Get commit message

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -40,7 +40,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp314-pyodide_wasm32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ PKG_CONFIG_PATH = "{project}"
 [tool.cibuildwheel.pyodide]
 before-build = "bash {project}/tools/wheels/cibw_before_build_pyodide.sh {project}"
 repair-wheel-command = "pyodide auditwheel repair --libdir {project}/.blis/lib --output-dir {dest_dir} {wheel}"
-test-requires = ["pytest", "pytest-split", "pytest-reportlog", "hypothesis", "threadpoolctl", "pooch"]
+test-requires = ["pytest", "pytest-split", "hypothesis", "threadpoolctl", "pooch"]
 test-command = "bash {project}/tools/wheels/cibw_test_command_pyodide.sh"
 [tool.cibuildwheel.pyodide.config-settings]
 setup-args = ["-Dblas=blis", "-Dlapack=semicolon-lapack"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,10 +270,6 @@ PKG_CONFIG_PATH = "{project}"
 # set CIBW_ENVIRONMENT_WINDOWS=PKG_CONFIG_PATH=PWD.replace('\\', '/')
 
 [tool.cibuildwheel.pyodide]
-# cibuildwheel 4.1.0 pins pyodide-build 0.35.0. Override to 0.36.0 to fix the
-# cross-build NumPy meson dependency detection. TODO: drop this once it makes
-# it to a released version of cibuildwheel
-dependency-versions = "packages: pyodide-build==0.36.0"
 before-build = "bash {project}/tools/wheels/cibw_before_build_pyodide.sh {project}"
 repair-wheel-command = "pyodide auditwheel repair --libdir {project}/.blis/lib --output-dir {dest_dir} {wheel}"
 test-command = "python -m pytest -vra --pyargs scipy -m 'not slow'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,8 +272,8 @@ PKG_CONFIG_PATH = "{project}"
 [tool.cibuildwheel.pyodide]
 before-build = "bash {project}/tools/wheels/cibw_before_build_pyodide.sh {project}"
 repair-wheel-command = "pyodide auditwheel repair --libdir {project}/.blis/lib --output-dir {dest_dir} {wheel}"
-test-command = "python -m pytest -vra --pyargs scipy -m 'not slow'"
-
+test-requires = ["pytest", "pytest-split", "pytest-reportlog", "hypothesis", "threadpoolctl", "pooch"]
+test-command = "bash {project}/tools/wheels/cibw_test_command_pyodide.sh"
 [tool.cibuildwheel.pyodide.config-settings]
 setup-args = ["-Dblas=blis", "-Dlapack=semicolon-lapack"]
 

--- a/tools/wheels/cibw_test_command_pyodide.sh
+++ b/tools/wheels/cibw_test_command_pyodide.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
-# Run the SciPy test suite for the WebAssembly/Pyodide build, in splits to
-# avoid memory corruption issues noticed when not doing so, and combine the
-# logs, see gh-25713
+# Run the SciPy test suite for the WebAssembly/Pyodide build in splits, to
+# avoid memory corruption issues noticed when not doing so, see gh-25713
 
-logdir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/scipy-reportlogs"
-mkdir -p "$logdir"
 ret=0
-
-echo "Writing per-group report logs to $logdir"
 
 # number of pytest-split groups to run
 N=10
@@ -17,14 +12,11 @@ i=1
 
 while [ "$i" -le "$N" ]; do
   echo "::group::SciPy test group $i of $N"
-  python -m pytest -vra --pyargs scipy -m 'not slow' --splits "$N" --group "$i" --report-log="$logdir/group-$i.jsonl"
+  python -m pytest -vra --pyargs scipy -m 'not slow' --splits "$N" --group "$i"
   rc=$?
   echo "::endgroup::"
   if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then ret=1; echo "!! pytest-split group $i failed (exit $rc)"; fi
   i=$((i + 1))
 done
-
-echo "Combined SciPy Pyodide test suite report log: $logdir/full.jsonl"
-cat "$logdir"/group-*.jsonl > "$logdir/full.jsonl" 2>/dev/null || true
 
 exit $ret

--- a/tools/wheels/cibw_test_command_pyodide.sh
+++ b/tools/wheels/cibw_test_command_pyodide.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Run the SciPy test suite for the WebAssembly/Pyodide build, in splits to
+# avoid memory corruption issues noticed when not doing so, and combine the
+# logs, see gh-25713
+
+logdir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/scipy-reportlogs"
+mkdir -p "$logdir"
+ret=0
+
+echo "Writing per-group report logs to $logdir"
+
+# number of pytest-split groups to run
+N=10
+
+# iteration number of the current group
+i=1
+
+while [ "$i" -le "$N" ]; do
+  echo "::group::SciPy test group $i of $N"
+  python -m pytest -vra --pyargs scipy -m 'not slow' --splits "$N" --group "$i" --report-log="$logdir/group-$i.jsonl"
+  rc=$?
+  echo "::endgroup::"
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then ret=1; echo "!! pytest-split group $i failed (exit $rc)"; fi
+  i=$((i + 1))
+done
+
+echo "Combined SciPy Pyodide test suite report log: $logdir/full.jsonl"
+cat "$logdir"/group-*.jsonl > "$logdir/full.jsonl" 2>/dev/null || true
+
+exit $ret


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

xref gh-25713

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR adds pytest-split to the Emscripten/Pyodide CI job established in gh-25618. The idea is that there are hard-to-diagnose issues when the entirety of the test suite runs in SciPy's CI here that are not seen locally, leading to hangs roughly every third run at 31%. Skipping those tests does not help and opens another Pandora's box, as noticed in gh-25729. This PR is a means to pacify this problem by collecting and running about 8.5K tests at a time so as not to exhaust the machine.

Note that this is not the conventional way that pytest-split is used as a plugin, as the title may suggest, in that the splits are shared on the same runner and run sequentially, rather than running across a matrix of splitted/chunked tests that occupy more than one runner.

I've also bumped the cibuildwheel version, which drops the workaround for using pyodide-build 0.36.0 preemptively. It's now included in the cibuildwheel constraints.

Lastly, I added the `FORCE_COLOR` variable to GHA – I find it useful because it makes the logs a bit more readable compared to a job that doesn't have it. Please feel free to suggest if this needs to be removed. 

#### Additional information
<!--Any additional information you think is important.-->

This was validated in my fork at https://github.com/agriyakhetarpal/scipy/pull/6 where I produced a test bed of 160 runs, with 16 runs per commit split across 10 consecutive commits. All of them are green, and none of them failed (for a relevant reason at least), and no timeouts/hangs were noted – which is highly suggestive of the viability of this approach.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Claude Code 5 Fable was used extensively to debug the problem, back and forth, as mentioned in gh-25713. No AI tools were used to author this PR; the code is mine. It was able to partially diagnose the problem but did not come to a solution. It found relevant problems in the CPython interpreter and Emscripten's libffi, which may or may not prove to be direct causes of the issue at hand. The diff in this PR is a distilled and slightly modified version of the diff from my fork's PR, which Claude had authored. The idea to experiment with pytest-split was mine, and some of the earlier iterations prior to this came from the agent.