### PR TITLE
DOC: add example svd docstring in interpolative module

### DIFF
--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -825,13 +825,13 @@ def svd(A, eps_or_k, rand=True, rng=None):
         1D array of singular values.
     V : :class:`numpy.ndarray`
         2D array right singular vectors.
-    
+
     Examples
     --------
     >>> import numpy as np
     >>> from scipy.linalg.interpolative import svd
     >>> rng = np.random.default_rng()
-    >>> # Create a wide matrix with rank 5
+    >>> # Create a rank-5 matrix
     >>> A = rng.standard_normal((20, 5)) @ rng.standard_normal((5, 10))
     >>> U, S, V = svd(A, 5)
     >>> U.shape

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -825,21 +825,22 @@ def svd(A, eps_or_k, rand=True, rng=None):
         1D array of singular values.
     V : :class:`numpy.ndarray`
         2D array right singular vectors.
-        
     Examples
     --------
     >>> import numpy as np
     >>> from scipy.linalg.interpolative import svd
-    >>> rng = np.random.default_rng(0)
-    >>> A = rng.standard_normal((20, 10))
+    >>> rng = np.random.default_rng()
+    >>> # Create a matrix with rank 5.
+    >>> A = rng.standard_normal((20, 5))
     >>> U, S, V = svd(A, 5)
     >>> U.shape
     (20, 5)
     >>> S.shape
     (5,)
     >>> V.shape
-    (10, 5)
-    
+    (5, 5)
+    >>> np.allclose(A, U @ np.diag(S) @ V.T)
+    True
     """
     from scipy.sparse.linalg import LinearOperator
     rng = np.random.default_rng(rng)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -825,6 +825,21 @@ def svd(A, eps_or_k, rand=True, rng=None):
         1D array of singular values.
     V : :class:`numpy.ndarray`
         2D array right singular vectors.
+        
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.linalg.interpolative import svd
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((20, 10))
+    >>> U, S, V = svd(A, 5)
+    >>> U.shape
+    (20, 5)
+    >>> S.shape
+    (5,)
+    >>> V.shape
+    (10, 5)
+    
     """
     from scipy.sparse.linalg import LinearOperator
     rng = np.random.default_rng(rng)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -825,6 +825,7 @@ def svd(A, eps_or_k, rand=True, rng=None):
         1D array of singular values.
     V : :class:`numpy.ndarray`
         2D array right singular vectors.
+    
     Examples
     --------
     >>> import numpy as np
@@ -841,6 +842,7 @@ def svd(A, eps_or_k, rand=True, rng=None):
     (5, 5)
     >>> np.allclose(A, U @ np.diag(S) @ V.T)
     True
+
     """
     from scipy.sparse.linalg import LinearOperator
     rng = np.random.default_rng(rng)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -831,15 +831,15 @@ def svd(A, eps_or_k, rand=True, rng=None):
     >>> import numpy as np
     >>> from scipy.linalg.interpolative import svd
     >>> rng = np.random.default_rng()
-    >>> # Create a matrix with rank 5.
-    >>> A = rng.standard_normal((20, 5))
+    >>> # Create a wide matrix with rank 5
+    >>> A = rng.standard_normal((20, 5)) @ rng.standard_normal((5, 10))
     >>> U, S, V = svd(A, 5)
     >>> U.shape
     (20, 5)
     >>> S.shape
     (5,)
     >>> V.shape
-    (5, 5)
+    (10, 5)
     >>> np.allclose(A, U @ np.diag(S) @ V.T)
     True
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-7168

#### What does this implement/fix?
<!--Please explain your changes.-->
Added an example to the `svd` docstring demonstrating basic usage of the function, including creating a random matrix, computing its SVD, and checking the output shapes.

#### Additional information
<!--Any additional information you think is important.-->
This change only modifies documentation.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
N/A