### PR TITLE
DOC: Fix np array alignment in Sparse user guide

### DIFF
--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -23,8 +23,8 @@ Sparse arrays are a special kind of array where only a few locations in the arra
    >>> sparse = sp.sparse.coo_array(dense)
    >>> dense
    array([[1, 0, 0, 2],
-       [0, 4, 1, 0],
-       [0, 0, 5, 0]])
+          [0, 4, 1, 0],
+          [0, 0, 5, 0]])
    >>> sparse
    <COOrdinate sparse array of dtype 'int64'
         with 5 stored elements and shape (3, 4)>
@@ -99,8 +99,8 @@ All formats of `scipy.sparse` arrays can be constructed directly from a `numpy.n
 
    >>> dense
    array([[1, 0, 0, 2],
-       [0, 4, 1, 0],
-       [0, 0, 5, 0]])
+          [0, 4, 1, 0],
+          [0, 0, 5, 0]])
 
 The ``row``, ``column``, and ``data`` arrays describe the rows, columns, and values where our sparse array has entries: 
 
@@ -139,12 +139,12 @@ The "extra" element is our *explicit zero*. The two are still identical when con
 
    >>> csr.todense()
    array([[1, 0, 0, 2],
-       [0, 4, 1, 0],
-       [0, 0, 5, 0]])
+          [0, 4, 1, 0],
+          [0, 0, 5, 0]])
    >>> dense
    array([[1, 0, 0, 2],
-       [0, 4, 1, 0],
-       [0, 0, 5, 0]])
+          [0, 4, 1, 0],
+          [0, 0, 5, 0]])
 
 But, for sparse arithmetic, linear algebra, and graph methods, the value at ``2,3`` will be considered an *explicit zero*. To remove this explicit zero, we can use the ``csr.eliminate_zeros()`` method. This operates on the sparse array *in place*, and removes any zero-value stored elements: 
 
@@ -175,8 +175,8 @@ Note that there are six stored elements in this sparse array, despite only havin
 
    >>> dupes.todense()
    array([[1, 0, 0, 2],
-         [0, 4, 1, 0],
-         [0, 0, 5, 0]])
+          [0, 4, 1, 0],
+          [0, 0, 5, 0]])
 
 To remove duplicate values within the sparse array itself and thus reduce the number of stored elements, we can use the ``.sum_duplicates()`` method:
 


### PR DESCRIPTION
Some NumPy arrays were misaligned

[docs only]

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
n/a <!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
see above <!--Please explain your changes.-->

#### Additional information
n/a <!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used <!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->