### PR TITLE
MAINT: reduce redundant computation in `differential_evolution`

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1208,11 +1208,12 @@ class DifferentialEvolutionSolver:
         status_message = _status_message['success']
 
         # The population may have just been initialized (all entries are
-        # np.inf). If it has you have to calculate the initial energies.
+        # np.inf and self._init_energized is False).
+        # If it has you have to calculate the initial energies.
         # Although this is also done in the evolve generator it's possible
         # that someone can set maxiter=0, at which point we still want the
         # initial energies to be calculated (the following loop isn't run).
-        if np.all(np.isinf(self.population_energies)):
+        if not self._init_energized:
             self.feasible, self.constraint_violation = (
                 self._calculate_population_feasibilities(self.population))
 
@@ -1616,8 +1617,9 @@ class DifferentialEvolutionSolver:
             Value of objective function obtained from the best solution.
         """
         # the population may have just been initialized (all entries are
-        # np.inf). If it has you have to calculate the initial energies
-        if not self._init_energized and np.all(np.isinf(self.population_energies)):
+        # np.inf and self._init_energized is False).
+        # If it has you have to calculate the initial energies
+        if not self._init_energized:
             self.feasible, self.constraint_violation = (
                 self._calculate_population_feasibilities(self.population))
 
@@ -1628,6 +1630,7 @@ class DifferentialEvolutionSolver:
                     self.population[self.feasible]))
 
             self._promote_lowest_energy()
+            self._init_energized = True
 
         if self.dither is not None:
             self.scale = self.random_number_generator.uniform(self.dither[0],

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1020,6 +1020,8 @@ class DifferentialEvolutionSolver:
         self.constraint_violation = np.zeros((self.num_population_members, 1))
         self.feasible = np.ones(self.num_population_members, bool)
 
+        self._init_energized = False
+
         # an array to shuffle when selecting candidates. Create it here
         # rather than repeatedly creating it in _select_samples.
         self._random_population_index = np.arange(self.num_population_members)
@@ -1220,6 +1222,10 @@ class DifferentialEvolutionSolver:
                     self.population[self.feasible]))
 
             self._promote_lowest_energy()
+
+            # this attribute is used to prevent the codeblock above
+            # from being run again in __next__.
+            self._init_energized = True
 
         # do the optimization.
         for nit in range(1, self.maxiter + 1):
@@ -1611,7 +1617,7 @@ class DifferentialEvolutionSolver:
         """
         # the population may have just been initialized (all entries are
         # np.inf). If it has you have to calculate the initial energies
-        if np.all(np.isinf(self.population_energies)):
+        if not self._init_energized and np.all(np.isinf(self.population_energies)):
             self.feasible, self.constraint_violation = (
                 self._calculate_population_feasibilities(self.population))
 


### PR DESCRIPTION
Instead of #25754. That PR states that there are duplicate function/constraint evaluations if the initial population energies are all `np.inf`, or if none of the initial population satisfy constraints.

I verified with the following test:

```
from scipy.optimize import rosen, differential_evolution, Bounds, NonlinearConstraint
import numpy as np

rng = np.random.default_rng(1220)

class Con:
    def __init__(self):
        self.nfev = 0
    
    def __call__(self, x):
        self.nfev += 1
        if np.all(x < 1):
            return np.inf
        return 0

c = Con()
nlc = NonlinearConstraint(c, -1, 1)

init_pop = rng.uniform(size=(60, 3), low=0.0, high=0.5)
res = differential_evolution(rosen, [(0, 5)]*3, rng=rng, init=init_pop, constraints=(nlc,), polish=False)
print(res.nfev, c.nfev)
```

With main we get `(14158, 16803)`, with this branch we get `(14158, 16743)`, showing that the number of constraint evaluations dropped.
I expect the extra evaluations on main to be an edge use.
