### PR TITLE
DOC: special: add examples to `eval_*` functions

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -1598,6 +1598,35 @@ add_newdoc("eval_jacobi",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E7
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_jacobi
+    >>> import matplotlib.pyplot as plt
+
+    These are the parameter values that we'll use in this example.
+
+    >>> alpha = 1.0
+    >>> beta = 0.5
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_jacobi(3, alpha, beta, [0, 0.25, 0.5])
+    array([-0.2109375 , -0.67687988, -0.47949219])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-1, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_jacobi(n, alpha, beta, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Jacobi Polynomials")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel(r'$P_n^{(\alpha, \beta)}(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_sh_jacobi",
@@ -1650,6 +1679,35 @@ add_newdoc("eval_sh_jacobi",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.1.E2
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_sh_jacobi
+    >>> import matplotlib.pyplot as plt
+
+    These are the parameter values that we'll use in this example.
+
+    >>> p1 = 0.5
+    >>> q1 = 0.125
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_sh_jacobi(3, p1, q1, [0, 0.25, 0.5])
+    array([-0.00344968,  0.01217532, -0.02333604])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_sh_jacobi(n, p1, q1, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Shifted Jacobi Polynomials")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$G_n^{(p, q)}(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_gegenbauer",
@@ -1703,6 +1761,34 @@ add_newdoc("eval_gegenbauer",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E9
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_gegenbauer
+    >>> import matplotlib.pyplot as plt
+
+    This is the parameter value that we'll use in this example.
+
+    >>> alpha = 1.25
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_gegenbauer(3, alpha, [0, 0.25, 0.5])
+    array([ 0.        , -1.21582031, -1.2890625 ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-1, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_gegenbauer(n, alpha, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Gegenbauer Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel(r'$C_n^{(\alpha)}(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_chebyt",
@@ -1759,6 +1845,30 @@ add_newdoc("eval_chebyt",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E11_2
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_chebyt
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_chebyt(3, [0, 0.25, 0.5])
+    array([-0.    , -0.6875, -1.    ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-1, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_chebyt(n, x)
+    ...     ax.plot(x, y, label=f'{n = }')
+    >>> ax.grid()
+    >>> ax.set_title("Chebyshev Polynomials of the First Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$T_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_chebyu",
@@ -1809,6 +1919,30 @@ add_newdoc("eval_chebyu",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E11_4
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_chebyu
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_chebyu(3, [0, 0.25, 0.5])
+    array([-0.   , -0.875, -1.   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-1, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_chebyu(n, x)
+    ...     ax.plot(x, y, label=f'{n = }')
+    >>> ax.grid()
+    >>> ax.set_title("Chebyshev Polynomials of the Second Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$U_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_chebys",
@@ -1860,15 +1994,35 @@ add_newdoc("eval_chebys",
     Examples
     --------
     >>> import numpy as np
-    >>> import scipy.special as sc
+    >>> from scipy.special import eval_chebys, eval_chebyu
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_chebys(3, [0, 0.25, 0.5])
+    array([-0.      , -0.484375, -0.875   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-2, 2, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_chebys(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Chebyshev Polynomials of the Second Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$S_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
 
     They are a scaled version of the Chebyshev polynomials of the
     second kind.
 
     >>> x = np.linspace(-2, 2, 6)
-    >>> sc.eval_chebys(3, x)
+    >>> eval_chebys(3, x)
     array([-4.   ,  0.672,  0.736, -0.736, -0.672,  4.   ])
-    >>> sc.eval_chebyu(3, x / 2)
+    >>> eval_chebyu(3, x / 2)
     array([-4.   ,  0.672,  0.736, -0.736, -0.672,  4.   ])
 
     """)
@@ -1923,15 +2077,35 @@ add_newdoc("eval_chebyc",
     Examples
     --------
     >>> import numpy as np
-    >>> import scipy.special as sc
+    >>> from scipy.special import eval_chebyc, eval_chebyt
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_chebyc(3, [0, 0.25, 0.5])
+    array([-0.      , -0.734375, -1.375   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-2, 2, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_chebyc(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Chebyshev Polynomials of the First Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$C_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
 
     They are a scaled version of the Chebyshev polynomials of the
     first kind.
 
     >>> x = np.linspace(-2, 2, 6)
-    >>> sc.eval_chebyc(3, x)
+    >>> eval_chebyc(3, x)
     array([-2.   ,  1.872,  1.136, -1.136, -1.872,  2.   ])
-    >>> 2 * sc.eval_chebyt(3, x / 2)
+    >>> 2 * eval_chebyt(3, x / 2)
     array([-2.   ,  1.872,  1.136, -1.136, -1.872,  2.   ])
 
     """)
@@ -1983,6 +2157,30 @@ add_newdoc("eval_sh_chebyt",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E7
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_sh_chebyt
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_sh_chebyt(3, [0, 0.125, 0.25, 0.375, 0.5])
+    array([-1.    ,  0.5625,  1.    ,  0.6875, -0.    ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_sh_chebyt(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Shifted Chebyshev Polynomials of the First Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$T_n^*(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_sh_chebyu",
@@ -2031,6 +2229,30 @@ add_newdoc("eval_sh_chebyu",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E8
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_sh_chebyu
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_sh_chebyu(3, [0, 0.125, 0.25, 0.375, 0.5])
+    array([-4.   , -0.375,  1.   ,  0.875, -0.   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_sh_chebyu(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Shifted Chebyshev Polynomials of the Second Kind")
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('$U_n^*(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_legendre",
@@ -2085,6 +2307,7 @@ add_newdoc("eval_legendre",
     --------
     >>> import numpy as np
     >>> from scipy.special import eval_legendre
+    >>> import matplotlib.pyplot as plt
 
     Evaluate the zero-order Legendre polynomial at x = 0
 
@@ -2093,29 +2316,28 @@ add_newdoc("eval_legendre",
 
     Evaluate the first-order Legendre polynomial between -1 and 1
 
-    >>> X = np.linspace(-1, 1, 5)  # Domain of Legendre polynomials
-    >>> eval_legendre(1, X)
+    >>> x = np.linspace(-1, 1, 5)  # Domain of Legendre polynomials
+    >>> eval_legendre(1, x)
     array([-1. , -0.5,  0. ,  0.5,  1. ])
 
     Evaluate Legendre polynomials of order 0 through 4 at x = 0
 
-    >>> N = range(0, 5)
-    >>> eval_legendre(N, 0)
+    >>> n = range(0, 5)
+    >>> eval_legendre(n, 0)
     array([ 1.   ,  0.   , -0.5  ,  0.   ,  0.375])
 
     Plot Legendre polynomials of order 0 through 4
 
-    >>> X = np.linspace(-1, 1)
-
-    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> x = np.linspace(-1, 1)
     >>> for n in range(0, 5):
-    ...     y = eval_legendre(n, X)
-    ...     plt.plot(X, y, label=r'$P_{}(x)$'.format(n))
-
-    >>> plt.title("Legendre Polynomials")
-    >>> plt.xlabel("x")
-    >>> plt.ylabel(r'$P_n(x)$')
-    >>> plt.legend(loc='lower right')
+    ...     y = eval_legendre(n, x)
+    ...     ax.plot(x, y, label=r'$P_{}(x)$'.format(n))
+    >>> ax.set_title("Legendre Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel(r'$P_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> ax.grid()
     >>> plt.show()
 
     """)
@@ -2166,6 +2388,31 @@ add_newdoc("eval_sh_legendre",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E10
 
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from scipy.special import eval_sh_legendre
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_sh_legendre(3, [0, 0.25, 0.5])
+    array([-1.    ,  0.4375,  0.    ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0, 1, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_sh_legendre(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Shifted Legendre Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel('$P_n^*(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_genlaguerre",
@@ -2221,6 +2468,34 @@ add_newdoc("eval_genlaguerre",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E12
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_genlaguerre
+    >>> import matplotlib.pyplot as plt
+
+    This is the parameter value that we'll use in this example.
+
+    >>> alpha = 1.25
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_genlaguerre(3, alpha, [0, 0.25, 0.5])
+    array([5.1796875 , 3.58333333, 2.23697917])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0.0, 9.0, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_genlaguerre(n, alpha, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Generalized Laguerre Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel(r'$L_n^{(\alpha)}(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_laguerre",
@@ -2274,7 +2549,31 @@ add_newdoc("eval_laguerre",
     .. [DLMF2] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E12
 
-     """)
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_laguerre
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_laguerre(3, [0, 0.25, 0.5])
+    array([ 1.        ,  0.34114583, -0.14583333])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(0.0, 8.0, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_laguerre(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Laguerre Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel('$L_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
+    """)
 
 add_newdoc("eval_hermite",
     r"""
@@ -2321,6 +2620,30 @@ add_newdoc("eval_hermite",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.T1
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_hermite
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_hermite(3, [0, 0.25, 0.5])
+    array([-0.   , -2.875, -5.   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-1.6, 1.6, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_hermite(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Physicist's Hermite Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel('$H_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("eval_hermitenorm",
@@ -2369,6 +2692,30 @@ add_newdoc("eval_hermitenorm",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.T1
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import eval_hermitenorm
+    >>> import matplotlib.pyplot as plt
+
+    Evaluate the order 3 polynomial at a few values of x.
+
+    >>> eval_hermitenorm(3, [0, 0.25, 0.5])
+    array([-0.      , -0.734375, -1.375   ])
+
+    Plot the polynomials of order 0 through 4.
+
+    >>> x = np.linspace(-2.3, 2.3, 800)
+    >>> fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    >>> for n in range(5):
+    ...     y = eval_hermitenorm(n, x)
+    ...     ax.plot(x, y, label=f'{n =}')
+    >>> ax.grid()
+    >>> ax.set_title("Probabilist's Hermite Polynomials")
+    >>> ax.set_xlabel("x")
+    >>> ax.set_ylabel('$He_n(x)$')
+    >>> ax.legend(loc='upper left', bbox_to_anchor=(1, 1), shadow=True)
+    >>> plt.show()
     """)
 
 add_newdoc("expn",


### PR DESCRIPTION


#### Reference issue

gh-7168

#### What does this implement/fix?
Add (or in the case of `eval_chebys`, `eval_chebyt` and `eval_legendre`, modify) the *Examples* section in the docstrings of:

```
eval_chebyc
eval_chebys
eval_chebyt
eval_chebyu
eval_gegenbauer
eval_genlaguerre
eval_hermite
eval_hermitenorm
eval_jacobi
eval_laguerre
eval_legendre
eval_sh_chebyt
eval_sh_chebyu
eval_sh_legendre
eval_sh_jacobi
```

The examples are not very interesting, but I think getting the plots in the documentation is valuable.  If anyone wants to spice them up, feel free to use the "suggest code changes" feature to propose improvements, or if the changes are not small, create a follow-up PR once this is merged.


#### AI Generation Disclosure
No AI tools used.