### PR TITLE
DOC: signal: Improve API-Reference page and User Guide

### DIFF
--- a/doc/source/tutorial/examples/signal_StateSpace_FreqSplitter.py
+++ b/doc/source/tutorial/examples/signal_StateSpace_FreqSplitter.py
@@ -1,0 +1,40 @@
+import numpy as np
+from scipy import signal
+import matplotlib.pyplot as plt
+
+ABCD = (np.array([[-10*np.sqrt(2), -100], [1,   0]]), np.array([[1], [0]]),
+        np.array([[-10*np.sqrt(2), -100], [0, 100]]), np.array([[1], [0]]))
+
+t_i, yy_i = signal.impulse(ABCD)  # simulate impulse response
+t_s, yy_s = signal.step(ABCD)    # simulate step response
+
+(b0, b1), a = signal.ss2tf(*ABCD)  # convert to transfer functions
+f = np.geomspace(1e-1, 1e2, 100)  # log-spaced frequencies
+
+_, (ax0, ax1) = plt.subplots(2, 1, sharex='all', constrained_layout=True)
+ax0.set(title="Impulse response", ylabel="Amplitude", xlim=(t_i[0], t_i[-1]))
+ax1.set(title="Step response", ylabel="Amplitude", xlabel="Time in seconds")
+for c_ in range(2):
+    ax0.plot(t_i, yy_i[:, c_], f'C{c_}-', label=f"Output {c_}")
+    ax1.plot(t_s, yy_s[:, c_], f'C{c_}-', label=f"Output {c_}")
+
+_, (ax10, ax11) = plt.subplots(2, 1, sharex='all', constrained_layout=True)
+ax10.set_title("Frequency response")
+ax10.set(ylabel="Magnitude in dB", xscale='log', xlim=(f[0], f[-1]),
+         yticks=np.arange(-80, 20, 20))
+ax11.set(ylabel="Phase in radians", xlabel="Frequency in hertz",
+         yticks = np.pi*np.array([-1, -0.5, 0, 0.5, 1]),
+         yticklabels=['-π', '-π/2', '0', 'π/2', 'π'])
+for c_, b_ in enumerate((b0, b1)):
+    _, H = signal.freqs(b_, a, worN=f)  # calculate frequency response
+    H_dB, H_ang = 20*np.log10(np.abs(H)), np.unwrap(np.angle(H))
+    ax10.plot(f, H_dB, f'C{c_}-', label=f"Output {c_}")
+    ax11.plot(f, H_ang, f'C{c_}-', label=f"Output {c_}")
+
+for ax_ in (ax0, ax1, ax10, ax11):
+    ax_.grid(True)
+    ax_.legend()
+plt.show()
+
+
+

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -315,7 +315,7 @@ as the periodic continuation in :math:`f` of the Fourier transform of the
 continuous-time periodic signal.
 
 A brief introduction about analyzing the spectral properties of sampled signals can be
-found in the :ref:`tutorial_SpectralAnalysis` section.
+found in the :ref:`tutorial_signal-SpectralAnalysis` section.
 
 .. _tutorial_FFT_Caveats:
 
@@ -360,7 +360,7 @@ Note that detrending a signal does not necessarily improve its spectrum. I.e., p
 components whose frequencies are not integer multiples of the frequency resolution
 :math:`\Delta f` produce a trend that should not be removed. More information on
 calculating and interpreting spectra can be found in the
-:ref:`tutorial_SpectralAnalysis` section.
+:ref:`tutorial_signal-SpectralAnalysis` section.
 
 
 Periodicity in the Frequency Domain

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1,5 +1,6 @@
+**********************************
 Signal Processing (`scipy.signal`)
-==================================
+**********************************
 
 .. sectionauthor:: Travis E. Oliphant
 
@@ -7,20 +8,38 @@ Signal Processing (`scipy.signal`)
 
 .. currentmodule:: scipy.signal
 
-The signal processing toolbox currently contains some filtering
-functions, a limited set of filter design tools, and a few B-spline
-interpolation algorithms for 1- and 2-D data. While the
-B-spline algorithms could technically be placed under the
-interpolation category, they are included here because they only work
-with equally-spaced data and make heavy use of filter-theory and
-transfer-function formalism to provide a fast B-spline transform. To
-understand this section, you will need to understand that a signal in
-SciPy is an array of real or complex numbers.
+The signal module provides essential tools for signal processing. It includes tools for
+filtering, filter design, analyzing digital signals and simulating state-space systems.
+Consult the `~scipy.signal` page for details. Here, the following topics are covered:
 
-.. _tutorial-signal-bsplines:
+.. contents:: Table of contents
+    :local:
+    :depth: 1
+
+.. math::
+    % LaTeX Macros to make the LaTeX formulas more readable:
+    \newcommand{\IC}{{\mathbb{C}}}  % set of complex numbers
+    \newcommand{\IN}{{\mathbb{N}}}  % set of natural numbers
+    \newcommand{\IR}{{\mathbb{R}}}  % set of real numbers
+    \newcommand{\IZ}{{\mathbb{Z}}}  % set of integers
+    \newcommand{\jj}{{\mathbb{j}}}  % imaginary unit
+    \newcommand{\e}{\operatorname{e}}  % Euler's number
+    \newcommand{\dd}{\operatorname{d}} % infinitesimal operator
+    \newcommand{\abs}[1]{\left|#1\right|} % absolute value
+    \newcommand{\conj}[1]{\overline{#1}} % complex conjugate
+    \newcommand{\conjT}[1]{\overline{#1^T}} % transposed complex conjugate
+    \newcommand{\inv}[1]{\left(#1\right)^{\!-1}} % inverse
+    % Since the physics package is not loaded, we define the macros ourselves:
+    \newcommand{\vb}[1]{\mathbf{#1}} % vectors and matrices are bold
+    % new macros:
+    \newcommand{\rect}{\operatorname{rect}}  % rect or boxcar function
+    \newcommand{\sinc}{\operatorname{sinc}}  % sinc(t) := sin(pi*t) / (pi*t)
+
+
+.. _tutorial_signal-BSplines:
 
 B-splines
----------
+=========
 
 A B-spline is an approximation of a continuous function over a finite-
 domain in terms of B-spline coefficients and knot points. If the knot-
@@ -120,35 +139,272 @@ conditions.
    >>> import numpy as np
    >>> from scipy import signal, datasets
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> image = datasets.face(gray=True).astype(np.float32)
    >>> derfilt = np.array([1.0, -2, 1.0], dtype=np.float32)
    >>> ck = signal.cspline2d(image, 8.0)
    >>> deriv = (signal.sepfir2d(ck, derfilt, [1]) +
    ...          signal.sepfir2d(ck, [1], derfilt))
-
-   Alternatively, we could have done::
-
-       laplacian = np.array([[0,1,0], [1,-4,1], [0,1,0]], dtype=np.float32)
-       deriv2 = signal.convolve2d(ck,laplacian,mode='same',boundary='symm')
-
-   >>> plt.figure()
-   >>> plt.imshow(image)
-   >>> plt.gray()
-   >>> plt.title('Original image')
+   ...
+   >>> _, (ax0, ax1) = plt.subplots(1, 2, figsize=(7, 3), constrained_layout=True)
+   >>> ax0.set_title('Original image')
+   >>> ax0.imshow(image, cmap='gray')
+   >>> ax1.set_title('Output of spline edge filter')
+   >>> ax1.imshow(deriv, cmap='gray')
    >>> plt.show()
 
-   >>> plt.figure()
-   >>> plt.imshow(deriv)
-   >>> plt.gray()
-   >>> plt.title('Output of spline edge filter')
-   >>> plt.show()
+An alternative to using `sepfir2d` is::
+
+    laplacian = np.array([[0,1,0], [1,-4,1], [0,1,0]], dtype=np.float32)
+    deriv2 = signal.convolve2d(ck,laplacian,mode='same',boundary='symm')
+
 
 ..   :caption: Example of using smoothing splines to filter images.
 
+.. _tutorial_signal-LTI-Systems:
+
+LTI Systems
+===========
+Linear time invariant (LTI) systems are used extensively in this module: For
+single-input single-output (SISO) systems, they are used in the form of transfer
+functions to model :ref:`filters <tutorial_signal-Filtering>`. The state-space system
+representation allows to model systems with multiple inputs and outputs (MIMO). LTI
+systems can be either discrete-time (often called "digital") or continuous-time (called
+"analog"). In the following, the notations of the various utilized LTI representations
+are presented. Consult the :ref:`scipy-api-LTI_Conversions` section in the
+:ref:`scipy-api` for conversion functions.
+
+
+.. _tutorial_signal-TransferFunctionRepresentation:
+
+Transfer function representation
+--------------------------------
+
+The ``ba`` or ``tf`` format is a 2-tuple ``(b, a)`` representing a transfer
+function, where `b` is a length ``M+1`` array of coefficients of the `M`-order
+numerator polynomial, and `a` is a length ``N+1`` array of coefficients of the
+`N`-order denominator, as positive, descending powers of the transfer function
+variable. So the tuple of :math:`b = [b_0, b_1, ..., b_M]` and
+:math:`a =[a_0, a_1, ..., a_N]` can represent an analog filter of the form:
+
+.. math::
+
+    H(s) = \frac
+    {b_0 s^M + b_1 s^{(M-1)} + \cdots + b_M}
+    {a_0 s^N + a_1 s^{(N-1)} + \cdots + a_N}
+    = \frac
+    {\sum_{i=0}^M b_i s^{(M-i)}}
+    {\sum_{i=0}^N a_i s^{(N-i)}}
+
+or a discrete-time filter of the form:
+
+.. math::
+
+    H(z) = \frac
+    {b_0 z^M + b_1 z^{(M-1)} + \cdots + b_M}
+    {a_0 z^N + a_1 z^{(N-1)} + \cdots + a_N}
+    = \frac
+    {\sum_{i=0}^M b_i z^{(M-i)}}
+    {\sum_{i=0}^N a_i z^{(N-i)}}.
+
+This "positive powers" form is found more commonly in controls
+engineering.  If `M` and `N` are equal (which is true for all filters
+generated by the bilinear transform), then this happens to be equivalent
+to the "negative powers" discrete-time form preferred in DSP:
+
+.. math::
+
+    H(z) = \frac
+    {b_0 + b_1 z^{-1} + \cdots + b_M z^{-M}}
+    {a_0 + a_1 z^{-1} + \cdots + a_N z^{-N}}
+    = \frac
+    {\sum_{i=0}^M b_i z^{-i}}
+    {\sum_{i=0}^N a_i z^{-i}}.
+
+Although this is true for common filters, remember that this is not true
+in the general case. If `M` and `N` are not equal, the discrete-time
+transfer function coefficients must first be converted to the "positive
+powers" form before finding the poles and zeros.
+
+This representation suffers from numerical error at higher orders, so other
+formats are preferred when possible.
+
+
+Zeros and poles representation
+------------------------------
+
+The ``zpk`` format is a 3-tuple ``(z, p, k)``, where `z` is an `M`-length
+array of the complex zeros of the transfer function
+:math:`z = [z_0, z_1, ..., z_{M-1}]`, `p` is an `N`-length array of the
+complex poles of the transfer function :math:`p = [p_0, p_1, ..., p_{N-1}]`,
+and `k` is a scalar gain.  These represent the digital transfer function:
+
+.. math::
+    H(z) = k \cdot \frac
+    {(z - z_0) (z - z_1) \cdots (z - z_{(M-1)})}
+    {(z - p_0) (z - p_1) \cdots (z - p_{(N-1)})}
+    = k \frac
+    {\prod_{i=0}^{M-1} (z - z_i)}
+    {\prod_{i=0}^{N-1} (z - p_i)}
+
+or the analog transfer function:
+
+.. math::
+    H(s) = k \cdot \frac
+    {(s - z_0) (s - z_1) \cdots (s - z_{(M-1)})}
+    {(s - p_0) (s - p_1) \cdots (s - p_{(N-1)})}
+    = k \frac
+    {\prod_{i=0}^{M-1} (s - z_i)}
+    {\prod_{i=0}^{N-1} (s - p_i)}.
+
+Although the sets of roots are stored as ordered NumPy arrays, their ordering
+does not matter: ``([-1, -2], [-3, -4], 1)`` is the same filter as
+``([-2, -1], [-4, -3], 1)``.
+
+Second-order sections representation
+------------------------------------
+
+The ``sos`` format is a single 2-D array of shape ``(S, 6)``,
+representing a sequence of :math:`S` second-order transfer functions which, when
+cascaded in series, realize a higher-order filter with minimal numerical
+error. It can be expressed as
+
+.. math::
+
+    H(z) = \prod_{s=0}^{S-1} \frac{b_{s,0} + b_{s,1} z^{-1} + b_{s,2} z^{-2}}{
+                               a_{s,0} + a_{s,1} z^{-1} + a_{s,2} z^{-2}}
+
+where :math:`[b_{s,0}, b_{s,1}, b_{s,2}, a_{s,0}, a_{s,1}, a_{s,2}]` represents the
+:math:`s`-th row of the array.
+
+The coefficients are typically normalized, such that :math:`a_{s,0}` is always 1.
+The section order is usually not important with floating-point computation;
+the filter output will be the same, regardless of the order.
+
+
+.. _tutorial_signal-StateSpaceRepresentation:
+
+State-space system representation
+---------------------------------
+
+The ``ss`` format is a 4-tuple of arrays ``(A, B, C, D)`` representing the
+state-space of an `n`-order digital/discrete-time system of the form
+
+.. math::
+    :label: eq_StateSpaceDiscr
+
+    \vb{x}[k+1] = \vb{A}\, \vb{x}[k] + \vb{B}\, \vb{u}[k] \,,\\
+    \vb{y}[k]   = \vb{C}\, \vb{x}[k] + \vb{D}\, \vb{u}[k]
+
+or a continuous/analog system of the form
+
+.. math::
+    :label: eq_StateSpaceCont
+
+    \dot{\vb{x}}(t) = \vb{A}\, \vb{x}(t) + \vb{B}\, \vb{u}(t) \,,\\
+         \vb{y}(t)  = \vb{C}\, \vb{x}(t) + \vb{D}\, \vb{u}(t),
+
+with :math:`p` inputs, :math:`q` outputs and :math:`n` state variables, where:
+
+- :math:`\vb{x}` is the state vector of length :math:`n`
+- :math:`\vb{y}` is the output vector of length :math:`q`
+- :math:`\vb{u}` is the input vector of length :math:`p`
+- :math:`\vb{A}` is the state matrix, with shape :math:`(n, n)`
+- :math:`\vb{B}` is the input matrix with shape :math:`(n, p)`
+- :math:`\vb{C}` is the output matrix with shape :math:`(q, n)`
+- :math:`\vb{D}` is the feedthrough or feedforward matrix with shape :math:`(q, p)`. (In
+  cases where the system does not have a direct feedthrough, all values in
+  :math:`\vb{D}` are zero.)
+
+The function `abcd_normalize` can be utilized to check the matrices' compatibility and
+ensure that they are 2d arrays.
+
+State-space is the most general representation and the only one that allows
+for multiple-input, multiple-output (MIMO) systems. There are multiple
+state-space representations for a given transfer function. Specifically, the
+"controllable canonical form" and "observable canonical form" have the same
+coefficients as the ``tf`` representation, and, therefore, suffer from the same
+numerical errors.
+
+.. _tutorial_signal-UsingStateSpaceSystems:
+
+Using State-space Systems
+=========================
+State-space systems model linear time invariant (LTI) systems with multiple inputs and
+outputs. Discrete-time systems, as defined in Eq. :math:numref:`eq_StateSpaceDiscr`,
+can be simulated by iterating over their governing equations. The evolution
+from step :math:`k=0` to the :math:`k`-th step (:math:`k>0`) can be expressed as
+
+.. math::
+
+       x[k] = \vb{A}^{k}\, \vb{x}[0] +
+                             \sum_{i=0}^{k-1}\vb{A}^{k-i-1}\vb{B}\, \vb{u}[i]  \,,\qquad
+       \vb{y}[k]   = \vb{C}\, \vb{x}[k] + \vb{D}\, \vb{u}[k] \,.
+
+The `dlsim` function can be used for such simulations. For the special inputs of an
+impulse and a step function, the wrappers `dimpulse` and `dstep` are provided. Note
+that single-input single-output state-space systems can alternatively be
+:ref:`converted <scipy-api-LTI_Conversions>` into a transfer function (aka a
+:ref:`filter <tutorial_signal-Filtering>`) to use the `lfilter` or `sosfilt`
+functions instead.
+
+For a continuous-time system, as defined in Eq. :math:numref:`eq_StateSpaceCont`, the
+general solution for :math:`t > t_0` can be expressed as
+
+.. math::
+    :label: eq_StateSpaceContSolution
+    
+    \vb{x}(t) = \vb{e}^{\vb{A}(t-t_0)} \vb{x}(t_0) + \int_{t_0}^t
+                        \vb{e}^{\vb{A}(t-\tau)} \vb{B}\, \vb{u}(\tau) \dd\tau  \,,\qquad
+    \vb{y}(t) =  \vb{C}\, \vb{x}(t) + \vb{D}\, \vb{u}(t) \,,
+
+by utilizing the matrix exponential (i.e., the `~scipy.linalg.expm` function)
+
+.. math::
+
+    \vb{e}^{\vb{A} t} := \sum_{i=0}^\infty \frac{(\vb{A}\, t)^i}{(i!)}
+                       = \vb{I} + \vb{A}\,t + \frac{1}{2}(\vb{A}\,t)^2 + \ldots \ .
+
+The function `lsim` calculates a solution by approximating the integral of Eq.
+:math:numref:`eq_StateSpaceContSolution` by a sum. For the special inputs of an impulse
+and a step function, the wrappers `impulse` and `step` are provided. Alternatively, the
+continuous-time system can be converted into a discrete-time system by using
+`cont2discrete` and be simulated it with `dlsim`.
+
+As a simple example, consider the following 2\ :sup:`nd` order state-space system with
+one input and two outputs:
+
+.. math::
+
+    \begin{bmatrix} \dot{x}_0(t)\\ \dot{x}_1(t) \end{bmatrix} &=
+    \begin{bmatrix} -10\sqrt{2} & -100\\ 1 & 0 \end{bmatrix}
+    \begin{bmatrix} x_0(t)\\ x_1(t) \end{bmatrix} +
+    \begin{bmatrix} 1\\ 0 \end{bmatrix} u(t) \,,\\
+    \begin{bmatrix} y_0(t)\\ y_1(t) \end{bmatrix} &=
+    \begin{bmatrix} -10\sqrt{2} & -100\\ 0 & \phantom{-}100 \end{bmatrix}
+    \begin{bmatrix} x_0(t)\\ x_1(t) \end{bmatrix} +
+    \begin{bmatrix} 1\\ 0 \end{bmatrix} u(t) \,.
+
+The following code snippet simulates the impulse and step response for each output
+channel. Also the frequency response of each output channel is calculated converting
+the state-space matrices into transfer functions with `ss2tf`:
+
+.. plot:: tutorial/examples/signal_StateSpace_FreqSplitter.py
+    :alt: Example of simulating a basic 10 Hz frequency splitter.
+
+Currently, the only control algorithm in this module is `place_poles`, which provides
+pole assignment by state feedback. Consider using the `Python Control Systems Library`_
+or `harold`_, if you need more functionality.
+
+.. _`Python Control Systems Library`: https://python-control.readthedocs.io
+.. _harold: https://harold.readthedocs.io
+
+
+
+.. _tutorial_signal-Filtering:
 
 Filtering
----------
+=========
 
 Filtering is a generic name for any system that modifies an input
 signal in some way. In SciPy, a signal can be thought of as a NumPy
@@ -169,7 +425,7 @@ for computing the output of the filter is employed.
 
 
 Convolution/Correlation
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 Many linear filters also have the property of shift-invariance. This
 means that the filtering operation is the same at different locations
@@ -312,23 +568,18 @@ enhancing, and edge-detection for an image.
    >>> import numpy as np
    >>> from scipy import signal, datasets
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> image = datasets.face(gray=True)
    >>> w = np.zeros((50, 50))
-   >>> w[0][0] = 1.0
-   >>> w[49][25] = 1.0
+   >>> w[0, 0] = 1.0
+   >>> w[49, 25] = 1.0
    >>> image_new = signal.fftconvolve(image, w)
-
-   >>> plt.figure()
-   >>> plt.imshow(image)
-   >>> plt.gray()
-   >>> plt.title('Original image')
-   >>> plt.show()
-
-   >>> plt.figure()
-   >>> plt.imshow(image_new)
-   >>> plt.gray()
-   >>> plt.title('Filtered image')
+   ...
+   >>> _, (ax0, ax1) = plt.subplots(1, 2, figsize=(7, 3), constrained_layout=True)
+   >>> ax0.set_title('Original image')
+   >>> ax0.imshow(image, cmap='gray')
+   >>> ax1.set_title('Filtered image')
+   >>> ax1.imshow(image_new, cmap='gray')
    >>> plt.show()
 
 
@@ -359,27 +610,22 @@ which is often used for blurring.
    >>> import numpy as np
    >>> from scipy import signal, datasets
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> image = np.asarray(datasets.ascent(), np.float64)
    >>> w = signal.windows.gaussian(51, 10.0)
    >>> image_new = signal.sepfir2d(image, w, w)
-
-   >>> plt.figure()
-   >>> plt.imshow(image)
-   >>> plt.gray()
-   >>> plt.title('Original image')
-   >>> plt.show()
-
-   >>> plt.figure()
-   >>> plt.imshow(image_new)
-   >>> plt.gray()
-   >>> plt.title('Filtered image')
+   ...
+   >>> _, (ax0, ax1) = plt.subplots(1, 2, figsize=(7, 3), constrained_layout=True)
+   >>> ax0.set_title('Original image')
+   >>> ax0.imshow(image, cmap='gray')
+   >>> ax1.set_title('Filtered image')
+   >>> ax1.imshow(image_new, cmap='gray')
    >>> plt.show()
 
 
 
 Difference-equation filtering
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 
 A general class of linear 1-D filters (that includes convolution
 filters) are filters described by the difference equation
@@ -464,7 +710,7 @@ first for initial conditions :math:`y[-1] = 0` (default case), then for
 
 >>> import numpy as np
 >>> from scipy import signal
-
+...
 >>> x = np.array([1., 0., 0., 0.])
 >>> b = np.array([1.0/2, 1.0/4])
 >>> a = np.array([1.0, -1.0/3])
@@ -479,7 +725,7 @@ the input signal :math:`x[n]`.
 
 
 Analysis of Linear Systems
-""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Linear system described a linear-difference equation can be fully described by
 the coefficient vectors :math:`a` and :math:`b` as was done above; an alternative
@@ -508,8 +754,10 @@ of a system described by the coefficients :math:`a_k` and :math:`b_k`. See the
 help of the :func:`freqz` function for a comprehensive example.
 
 
+.. _tutorial_signal-FilterDesign:
+
 Filter Design
-^^^^^^^^^^^^^
+=============
 
 Time-discrete filters can be classified into finite response (FIR) filters and
 infinite response (IIR) filters. FIR filters can provide a linear phase
@@ -517,7 +765,7 @@ response, whereas IIR filters cannot. SciPy provides functions
 for designing both types of filters.
 
 FIR Filter
-""""""""""
+----------
 
 The function :func:`firwin` designs filters according to the window method. Depending
 on the provided arguments, the function returns different filter types (e.g., low-pass,
@@ -532,8 +780,8 @@ Nyquist frequency of 1 Hz is plotted.
 
 The function :func:`firwin2` allows design of almost arbitrary frequency responses by
 specifying an array of corner frequencies and corresponding gains, respectively. The
-example below designs a filter with such an arbitrary amplitude response and plots the
-its frequency response on a linear magnitude scale. The four specified gains corner are
+example below designs a filter with such an arbitrary amplitude response and plots
+its frequency response on a linear magnitude scale. The four specified corner gains are
 denoted by gray dots connected by a dashed line, whereas the response of the filter is
 depicted by a continuous blue line.
 
@@ -548,7 +796,7 @@ default sampling frequencies.
 
 
 IIR Filter
-""""""""""
+----------
 
 SciPy provides two functions to directly design IIR :func:`iirdesign` and
 :func:`iirfilter`, where the filter type (e.g., elliptic) is passed as an
@@ -572,7 +820,6 @@ stop-band attenuation of :math:`\approx 60` dB.
    ...
    >>> plt.title('Digital filter frequency response')
    >>> plt.plot(w, 20*np.log10(np.abs(h)))
-   >>> plt.title('Digital filter frequency response')
    >>> plt.ylabel('Amplitude Response [dB]')
    >>> plt.xlabel('Frequency (rad/sample)')
    >>> plt.grid()
@@ -608,159 +855,10 @@ stop-band attenuation of :math:`\approx 60` dB.
         >>> ax.set(xlabel="Frequency (Hz)", ylabel="Amplitude Response [dB]")
         >>> ax.legend()
 
-Filter Coefficients
-"""""""""""""""""""
 
-Filter coefficients can be stored in several different formats:
-
-* 'ba' or 'tf' = transfer function coefficients
-* 'zpk' = zeros, poles, and overall gain
-* 'ss' = state-space system representation
-* 'sos' = transfer function coefficients of second-order sections
-
-Functions, such as :func:`tf2zpk` and :func:`zpk2ss`, can convert between them.
-
-.. _tutorial_signal_TransferFunctionRepresentation:
-
-Transfer function representation
-********************************
-
-The ``ba`` or ``tf`` format is a 2-tuple ``(b, a)`` representing a transfer
-function, where `b` is a length ``M+1`` array of coefficients of the `M`-order
-numerator polynomial, and `a` is a length ``N+1`` array of coefficients of the
-`N`-order denominator, as positive, descending powers of the transfer function
-variable. So the tuple of :math:`b = [b_0, b_1, ..., b_M]` and
-:math:`a =[a_0, a_1, ..., a_N]` can represent an analog filter of the form:
-
-.. math::
-
-    H(s) = \frac
-    {b_0 s^M + b_1 s^{(M-1)} + \cdots + b_M}
-    {a_0 s^N + a_1 s^{(N-1)} + \cdots + a_N}
-    = \frac
-    {\sum_{i=0}^M b_i s^{(M-i)}}
-    {\sum_{i=0}^N a_i s^{(N-i)}}
-
-or a discrete-time filter of the form:
-
-.. math::
-
-    H(z) = \frac
-    {b_0 z^M + b_1 z^{(M-1)} + \cdots + b_M}
-    {a_0 z^N + a_1 z^{(N-1)} + \cdots + a_N}
-    = \frac
-    {\sum_{i=0}^M b_i z^{(M-i)}}
-    {\sum_{i=0}^N a_i z^{(N-i)}}.
-
-This "positive powers" form is found more commonly in controls
-engineering.  If `M` and `N` are equal (which is true for all filters
-generated by the bilinear transform), then this happens to be equivalent
-to the "negative powers" discrete-time form preferred in DSP:
-
-.. math::
-
-    H(z) = \frac
-    {b_0 + b_1 z^{-1} + \cdots + b_M z^{-M}}
-    {a_0 + a_1 z^{-1} + \cdots + a_N z^{-N}}
-    = \frac
-    {\sum_{i=0}^M b_i z^{-i}}
-    {\sum_{i=0}^N a_i z^{-i}}.
-
-Although this is true for common filters, remember that this is not true
-in the general case. If `M` and `N` are not equal, the discrete-time
-transfer function coefficients must first be converted to the "positive
-powers" form before finding the poles and zeros.
-
-This representation suffers from numerical error at higher orders, so other
-formats are preferred when possible.
-
-Zeros and poles representation
-******************************
-
-The ``zpk`` format is a 3-tuple ``(z, p, k)``, where `z` is an `M`-length
-array of the complex zeros of the transfer function
-:math:`z = [z_0, z_1, ..., z_{M-1}]`, `p` is an `N`-length array of the
-complex poles of the transfer function :math:`p = [p_0, p_1, ..., p_{N-1}]`,
-and `k` is a scalar gain.  These represent the digital transfer function:
-
-.. math::
-    H(z) = k \cdot \frac
-    {(z - z_0) (z - z_1) \cdots (z - z_{(M-1)})}
-    {(z - p_0) (z - p_1) \cdots (z - p_{(N-1)})}
-    = k \frac
-    {\prod_{i=0}^{M-1} (z - z_i)}
-    {\prod_{i=0}^{N-1} (z - p_i)}
-
-or the analog transfer function:
-
-.. math::
-    H(s) = k \cdot \frac
-    {(s - z_0) (s - z_1) \cdots (s - z_{(M-1)})}
-    {(s - p_0) (s - p_1) \cdots (s - p_{(N-1)})}
-    = k \frac
-    {\prod_{i=0}^{M-1} (s - z_i)}
-    {\prod_{i=0}^{N-1} (s - p_i)}.
-
-Although the sets of roots are stored as ordered NumPy arrays, their ordering
-does not matter: ``([-1, -2], [-3, -4], 1)`` is the same filter as
-``([-2, -1], [-4, -3], 1)``.
-
-.. _tutorial_signal_state_space_representation:
-
-State-space system representation
-*********************************
-
-The ``ss`` format is a 4-tuple of arrays ``(A, B, C, D)`` representing the
-state-space of an `N`-order digital/discrete-time system of the form:
-
-.. math::
-    \mathbf{x}[k+1] = A \mathbf{x}[k] + B \mathbf{u}[k]\\
-    \mathbf{y}[k] = C \mathbf{x}[k] + D \mathbf{u}[k]
-
-or a continuous/analog system of the form:
-
-.. math::
-    \dot{\mathbf{x}}(t) = A \mathbf{x}(t) + B \mathbf{u}(t)\\
-    \mathbf{y}(t) = C \mathbf{x}(t) + D \mathbf{u}(t),
-
-with `P` inputs, `Q` outputs and `N` state variables, where:
-
-- `x` is the state vector
-- `y` is the output vector of length `Q`
-- `u` is the input vector of length `P`
-- `A` is the state matrix, with shape ``(N, N)``
-- `B` is the input matrix with shape ``(N, P)``
-- `C` is the output matrix with shape ``(Q, N)``
-- `D` is the feedthrough or feedforward matrix with shape ``(Q, P)``.  (In
-  cases where the system does not have a direct feedthrough, all values in
-  `D` are zero.)
-
-State-space is the most general representation and the only one that allows
-for multiple-input, multiple-output (MIMO) systems. There are multiple
-state-space representations for a given transfer function. Specifically, the
-"controllable canonical form" and "observable canonical form" have the same
-coefficients as the ``tf`` representation, and, therefore, suffer from the same
-numerical errors.
-
-Second-order sections representation
-************************************
-
-The ``sos`` format is a single 2-D array of shape ``(n_sections, 6)``,
-representing a sequence of second-order transfer functions which, when
-cascaded in series, realize a higher-order filter with minimal numerical
-error. Each row corresponds to a second-order ``tf`` representation, with
-the first three columns providing the numerator coefficients and the last
-three providing the denominator coefficients:
-
-.. math::
-    [b_0, b_1, b_2, a_0, a_1, a_2]
-
-The coefficients are typically normalized, such that :math:`a_0` is always 1.
-The section order is usually not important with floating-point computation;
-the filter output will be the same, regardless of the order.
 
 Filter transformations
-""""""""""""""""""""""
+----------------------
 
 The IIR filter design functions first generate a prototype analog low-pass filter
 with a normalized cutoff frequency of 1 rad/sec. This is then transformed into
@@ -788,13 +886,13 @@ To convert the transformed analog filter into a digital filter, the
 where T is the sampling time (the inverse of the sampling frequency).
 
 Other filters
-^^^^^^^^^^^^^
+-------------
 
 The signal processing package provides many more filters as well.
 
 
 Median Filter
-"""""""""""""
+^^^^^^^^^^^^^
 
 A median filter is commonly applied when noise is markedly non-Gaussian or
 when it is desired to preserve edges. The median filter works by sorting all
@@ -809,7 +907,7 @@ only for 2-D arrays is available as :func:`medfilt2d`.
 
 
 Order Filter
-""""""""""""
+^^^^^^^^^^^^
 
 A median filter is a specific example of a more general class of filters
 called order filters. To compute the output at a particular pixel, all order
@@ -826,7 +924,7 @@ used as the output. The command to perform an order filter is
 
 
 Wiener filter
-"""""""""""""
+^^^^^^^^^^^^^
 
 The Wiener filter is a simple deblurring filter for denoising images. This is
 not the Wiener filter commonly described in image-reconstruction problems but,
@@ -846,7 +944,7 @@ variances.
 
 
 Hilbert filter
-""""""""""""""
+^^^^^^^^^^^^^^
 
 The Hilbert transform constructs the complex-valued analytic signal
 from a real signal. For example, if :math:`x=\cos\omega n`, then
@@ -863,7 +961,7 @@ frequencies, and :math:`1` for zero-frequencies.
 
 
 Analog Filter Design
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 The functions :func:`iirdesign`, :func:`iirfilter`, and the filter design
 functions for specific filter types (e.g., :func:`ellip`) all have a flag
@@ -881,10 +979,10 @@ in the amplitude response.
    >>> import numpy as np
    >>> import scipy.signal as signal
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> b, a = signal.iirdesign(wp=100, ws=200, gpass=2.0, gstop=40., analog=True)
    >>> w, h = signal.freqs(b, a)
-
+   ...
    >>> plt.title('Analog filter frequency response')
    >>> plt.plot(w, 20*np.log10(np.abs(h)))
    >>> plt.ylabel('Amplitude Response [dB]')
@@ -894,11 +992,11 @@ in the amplitude response.
 
 
    >>> z, p, k = signal.tf2zpk(b, a)
-
+   ...
    >>> plt.plot(np.real(z), np.imag(z), 'ob', markerfacecolor='none')
    >>> plt.plot(np.real(p), np.imag(p), 'xr')
    >>> plt.legend(['Zeros', 'Poles'], loc=2)
-
+   ...
    >>> plt.title('Pole / Zero Plot')
    >>> plt.xlabel('Real')
    >>> plt.ylabel('Imaginary')
@@ -906,31 +1004,10 @@ in the amplitude response.
    >>> plt.show()
 
 
-
-.. math::
-    % LaTeX Macros to make the LaTeX formulas more readable:
-    \newcommand{\IC}{{\mathbb{C}}}  % set of complex numbers
-    \newcommand{\IN}{{\mathbb{N}}}  % set of natural numbers
-    \newcommand{\IR}{{\mathbb{R}}}  % set of real numbers
-    \newcommand{\IZ}{{\mathbb{Z}}}  % set of integers
-    \newcommand{\jj}{{\mathbb{j}}}  % imaginary unit
-    \newcommand{\e}{\operatorname{e}}  % Euler's number
-    \newcommand{\dd}{\operatorname{d}} % infinitesimal operator
-    \newcommand{\abs}[1]{\left|#1\right|} % absolute value
-    \newcommand{\conj}[1]{\overline{#1}} % complex conjugate
-    \newcommand{\conjT}[1]{\overline{#1^T}} % transposed complex conjugate
-    \newcommand{\inv}[1]{\left(#1\right)^{\!-1}} % inverse
-    % Since the physics package is not loaded, we define the macros ourselves:
-    \newcommand{\vb}[1]{\mathbf{#1}} % vectors and matrices are bold
-    % new macros:
-    \newcommand{\rect}{\operatorname{rect}}  % rect or boxcar function
-    \newcommand{\sinc}{\operatorname{sinc}}  % sinc(t) := sin(pi*t) / (pi*t)
-
-
-.. _tutorial_SpectralAnalysis:
+.. _tutorial_signal-SpectralAnalysis:
 
 Spectral Analysis
-------------------
+=================
 Spectral analysis refers to investigating the Fourier transform [#Wiki_FT]_ of a
 signal. Depending on the context, various names, like spectrum, spectral density or
 periodogram exist for the various spectral representations of the Fourier transform.
@@ -949,7 +1026,7 @@ this section the spectra are continuous in frequency.
 
 
 Continuous-time Sine Signal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 Consider a sine signal with amplitude :math:`a`, frequency :math:`f_x` and duration
 :math:`\tau`, i.e.,
 
@@ -1104,7 +1181,7 @@ information about the signal's amplitude.
 
 
 Sampled Sine Signal
-^^^^^^^^^^^^^^^^^^^
+-------------------
 In practice sampled signals are widely used. I.e., the signal is represented by :math:`n`
 samples :math:`x_k := x(kT)`, :math:`k=0, \ldots, n-1`, where :math:`T` is the sampling
 interval, :math:`\tau:=nT` the signal's duration and :math:`f_S := 1/T` the sampling
@@ -1290,7 +1367,7 @@ used in filter design than in spectral analysis.
 
 
 Phase of Spectrum
-^^^^^^^^^^^^^^^^^
+-----------------
 The phase (i.e., :func:`~numpy.angle()`) of the Fourier transform is typically utilized
 for investigating the time delay of the spectral components of a signal passing through
 a system like a filter. In the following example the standard test signal, an impulse
@@ -1320,7 +1397,7 @@ response of a filter directly.
 
 
 Spectra with Averaging
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 The :func:`~scipy.signal.periodogram` function calculates a power spectral density
 (``scaling='density'``) or a squared magnitude spectrum (``scaling='spectrum'``). To
 obtain a smoothed periodogram, the :func:`~scipy.signal.welch` function can be used. It
@@ -1351,7 +1428,7 @@ reducing the number of segments by increasing the segment length (setting parame
 
 
 Lomb-Scargle Periodograms (:func:`lombscargle`)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------
 
 Least-squares spectral analysis (LSSA) [#Lomb1976]_ [#Scargle1982]_ is a method of
 estimating a frequency spectrum, based on a least-squares fit of sinusoids to data
@@ -1396,10 +1473,10 @@ allows for the weighting of individual samples and calculating an unknown offset
 .. |old_istft| replace:: `istft <scipy.signal.istft>`
 .. |old_spectrogram| replace:: `spectrogram <scipy.signal.spectrogram>`
 
-.. _tutorial_stft:
+.. _tutorial_signal-STFT:
 
 Short-Time Fourier Transform
-----------------------------
+============================
 This section gives some background information on using the |ShortTimeFFT|
 class: The short-time Fourier transform (STFT) can be utilized to analyze the
 spectral properties of signals over time. It divides a signal into overlapping
@@ -1452,7 +1529,7 @@ reformulate Eq. :math:numref:`eq_dSTFT` as a two-step process:
    where the integer :math:`\lfloor M/2\rfloor` represents ``M//2``, i.e., it is
    the mid point of the window (`m_num_mid`). For notational convenience,
    :math:`x[k]:=0` for :math:`k\not\in\{0, 1, \ldots, N-1\}` is assumed. In the
-   subsection :ref:`tutorial_stft_sliding_win` the indexing of the slices is
+   subsection :ref:`tutorial_signal-STFT_sliding_win` the indexing of the slices is
    discussed in more detail.
 #. Then perform a discrete Fourier transform (i.e., an
    :ref:`FFT <tutorial_FFT>`) of :math:`x_p[m]`.
@@ -1480,7 +1557,7 @@ these two steps:
 
    .. math::
 
-      x_p[m] = \frac{1}{M}\sum_{q=0}^M S[q, p]\, \exp\!\big\{
+      x_p[m] = \frac{1}{M}\sum_{q=0}^{M-1} S[q, p]\, \exp\!\big\{
                                           2\jj\pi (q + \phi_m)\, m / M\big\}\ .
 
 #. Sum the shifted slices weighted by :math:`w_d[m]` to reconstruct the
@@ -1499,12 +1576,12 @@ a given window :math:`w[m]` the hop size :math:`h` must be small enough to ensur
 every sample of :math:`x[k]` is touched by a non-zero value of at least one
 window slice. This is sometimes referred as the "non-zero overlap condition"
 (see :func:`~scipy.signal.check_NOLA`). Some more details are
-given in the subsection :ref:`tutorial_stft_dual_win`.
+given in the subsection :ref:`tutorial_signal-STFT_dual_win`.
 
-.. _tutorial_stft_sliding_win:
+.. _tutorial_signal-STFT_sliding_win:
 
 Sliding Windows
-^^^^^^^^^^^^^^^
+---------------
 This subsection discusses how the sliding window is indexed in the
 |ShortTimeFFT| by means of an example: Consider a window of length 6 with a
 `hop` interval of two and a sampling interval `T` of one, e.g., ``ShortTimeFFT
@@ -1552,10 +1629,10 @@ first slice not touching the signal. The corresponding sample index is
    that the shown indexes are correct.
 
 
-.. _tutorial_stft_dual_win:
+.. _tutorial_signal-STFT_dual_win:
 
 Inverse STFT and Dual Windows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 The term dual window stems from frame theory [#Christensen2016]_ where a frame is a
 series expansion which can represent any function in a given Hilbert space. There the
 expansions :math:`\{g_k\}` and :math:`\{h_k\}` are dual frames if for all
@@ -1876,15 +1953,15 @@ mapping, which is implemented in `~scipy.signal.ShortTimeFFT.from_win_equals_dua
 
 
 
-.. _tutorial_stft_legacy_stft:
+.. _tutorial_signal-STFT_legacy_stft:
 
 Comparison with Legacy Implementation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------
 The functions |old_stft|, |old_istft|, and the |old_spectrogram| predate the
 |ShortTimeFFT| implementation. This section discusses the key differences
 between the older "legacy" and the newer |ShortTimeFFT| implementations. The
 main motivation for a rewrite was the insight that integrating :ref:`dual
-windows <tutorial_stft_dual_win>` could not be done in a sane way without
+windows <tutorial_signal-STFT_dual_win>` could not be done in a sane way without
 breaking compatibility. This opened the opportunity for rethinking the code
 structure and the parametrization, thus making some implicit behavior more
 explicit.
@@ -1943,7 +2020,7 @@ with a negative slope:
 
 
 That the |ShortTimeFFT| produces 3 more time slices than the legacy version is
-the main difference. As laid out in the :ref:`tutorial_stft_sliding_win`
+the main difference. As laid out in the :ref:`tutorial_signal-STFT_sliding_win`
 section, all slices which touch the signal are incorporated in the new version.
 This has the advantage that the STFT can be sliced and reassembled as shown in
 the |ShortTimeFFT| code example. Furthermore, using all touching slices makes
@@ -2082,9 +2159,9 @@ table shows those correspondences:
 When using ``onesided`` output on complex-valued input signals, the old
 |old_spectrogram| switches to ``two-sided`` mode. The |ShortTimeFFT| raises
 a :exc:`TypeError`, since the utilized `~scipy.fft.rfft` function only accepts
-real-valued inputs. Consult the :ref:`tutorial_SpectralAnalysis` section above for a
-discussion on the various spectral representations which are induced by the various
-parameterizations.
+real-valued inputs. Consult the :ref:`tutorial_signal-SpectralAnalysis` section above
+for a discussion on the various spectral representations which are induced by the
+various parameterizations.
 
 
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -3,6 +3,9 @@
 Signal processing (:mod:`scipy.signal`)
 =======================================
 
+.. Note that in the `autosummary` blocks, the text after the command is ignored. The
+   first line of the function's docstring is used instead.
+
 .. toctree::
    :hidden:
 
@@ -26,6 +29,8 @@ Convolution
 
 B-splines
 =========
+Consult the :ref:`tutorial_signal-BSplines` section of the :ref:`user_guide` for
+additional information.
 
 .. autosummary::
    :toctree: generated/
@@ -42,6 +47,45 @@ B-splines
 
 Filtering
 =========
+Consult the :ref:`tutorial_signal-Filtering` section of the :ref:`user_guide` for
+additional information. Note that :mod:`~scipy.ndimage`, the "multidimensional image
+processing" module, also provides filtering functions.
+
+Digital filtering using transfer functions
+------------------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   lfilter       -- 1-D FIR and IIR digital linear filtering.
+   lfiltic       -- Construct initial conditions for `lfilter`.
+   lfilter_zi    -- Compute an initial state zi for the lfilter function that
+                 -- corresponds to the steady state of the step response.
+   filtfilt      -- A forward-backward filter.
+   sosfilt       -- 1-D IIR digital linear filtering using
+                 -- a second-order sections filter representation.
+   sosfilt_zi    -- Compute an initial state zi for the sosfilt function that
+                 -- corresponds to the steady state of the step response.
+   sosfiltfilt   -- A forward-backward filter for second-order sections.
+
+
+Resampling and Hilbert transforms
+---------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   hilbert       -- Compute 1-D analytic signal, using the Hilbert transform.
+   hilbert2      -- Compute 2-D analytic signal, using the Hilbert transform.
+   envelope      -- Compute the envelope of a real- or complex-valued signal.
+   decimate      -- Downsample a signal.
+   resample      -- Resample using Fourier method.
+   resample_poly -- Resample using polyphase filtering method.
+   upfirdn       -- Upsample, apply FIR filter, downsample.
+
+
+Miscellaneous filtering
+-----------------------
 
 .. autosummary::
    :toctree: generated/
@@ -50,86 +94,55 @@ Filtering
    medfilt       -- N-D median filter.
    medfilt2d     -- 2-D median filter (faster).
    wiener        -- N-D Wiener filter.
-
    symiirorder1  -- 2nd-order IIR filter (cascade of first-order systems).
    symiirorder2  -- 4th-order IIR filter (cascade of second-order systems).
-   lfilter       -- 1-D FIR and IIR digital linear filtering.
-   lfiltic       -- Construct initial conditions for `lfilter`.
-   lfilter_zi    -- Compute an initial state zi for the lfilter function that
-                 -- corresponds to the steady state of the step response.
-   filtfilt      -- A forward-backward filter.
    savgol_filter -- Filter a signal using the Savitzky-Golay filter.
-
    deconvolve    -- 1-D deconvolution using lfilter.
-
-   sosfilt       -- 1-D IIR digital linear filtering using
-                 -- a second-order sections filter representation.
-   sosfilt_zi    -- Compute an initial state zi for the sosfilt function that
-                 -- corresponds to the steady state of the step response.
-   sosfiltfilt   -- A forward-backward filter for second-order sections.
-   hilbert       -- Compute 1-D analytic signal, using the Hilbert transform.
-   hilbert2      -- Compute 2-D analytic signal, using the Hilbert transform.
-   envelope      -- Compute the envelope of a real- or complex-valued signal.
-
-   decimate      -- Downsample a signal.
    detrend       -- Remove linear and/or constant trends from data.
-   resample      -- Resample using Fourier method.
-   resample_poly -- Resample using polyphase filtering method.
-   upfirdn       -- Upsample, apply FIR filter, downsample.
+
 
 Filter design
 =============
+Consult the :ref:`tutorial_signal-FilterDesign` section of the :ref:`user_guide` for
+additional information.
+
+Filter Analysis
+---------------
 
 .. autosummary::
    :toctree: generated/
 
-   bilinear      -- Digital filter from an analog filter using
-                    -- the bilinear transform.
-   bilinear_zpk  -- Digital filter from an analog filter using
-                    -- the bilinear transform.
    findfreqs     -- Find array of frequencies for computing filter response.
-   firls         -- FIR filter design using least-squares error minimization.
-   firwin        -- Windowed FIR filter design, with frequency response
-                    -- defined as pass and stop bands.
-   firwin2       -- Windowed FIR filter design, with arbitrary frequency
-                    -- response.
-   firwin_2d        -- Windowed FIR filter design, with frequency response for
-                    -- 2D using 1D design.
    freqs         -- Analog filter frequency response from TF coefficients.
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
    freqz         -- Digital filter frequency response from TF coefficients.
    sosfreqz      -- Digital filter frequency response for SOS format filter (legacy).
    freqz_sos     -- Digital filter frequency response for SOS format filter.
    freqz_zpk     -- Digital filter frequency response from ZPK coefficients.
-   gammatone     -- FIR and IIR gammatone filter design.
    group_delay   -- Digital filter group delay.
-   iirdesign     -- IIR filter design given bands and gains.
-   iirfilter     -- IIR filter design given order and critical frequencies.
-   kaiser_atten  -- Compute the attenuation of a Kaiser FIR filter, given
-                    -- the number of taps and the transition width at
-                    -- discontinuities in the frequency response.
-   kaiser_beta   -- Compute the Kaiser parameter beta, given the desired
-                    -- FIR filter attenuation.
-   kaiserord     -- Design a Kaiser window to limit ripple and width of
-                    -- transition region.
-   minimum_phase -- Convert a linear phase FIR filter to minimum phase.
-   savgol_coeffs -- Compute the FIR filter coefficients for a Savitzky-Golay
-                    -- filter.
-   remez         -- Optimal FIR filter design.
+
+
+Utility functions
+-----------------
+
+.. autosummary::
+   :toctree: generated/
 
    unique_roots  -- Unique roots and their multiplicities.
    residue       -- Partial fraction expansion of b(s) / a(s).
    residuez      -- Partial fraction expansion of b(z) / a(z).
    invres        -- Inverse partial fraction expansion for analog filter.
    invresz       -- Inverse partial fraction expansion for digital filter.
+   normalize      -- Normalize polynomial representation of a transfer function.
    BadCoefficients  -- Warning on badly conditioned filter coefficients.
 
-Lower-level filter design functions:
+
+Continuous-time (analog) filter design
+--------------------------------------
 
 .. autosummary::
    :toctree: generated/
 
-   abcd_normalize -- Check state-space matrices compatibility and ensure they are 2d.
    band_stop_obj  -- Band Stop Objective Function for order minimization.
    besselap       -- Return (z,p,k) for analog prototype of Bessel filter.
    buttap         -- Return (z,p,k) for analog prototype of Butterworth filter.
@@ -144,12 +157,10 @@ Lower-level filter design functions:
    lp2hp_zpk      -- Transform a lowpass filter prototype to a highpass filter.
    lp2lp          -- Transform a lowpass filter prototype to a lowpass filter.
    lp2lp_zpk      -- Transform a lowpass filter prototype to a lowpass filter.
-   normalize      -- Normalize polynomial representation of a transfer function.
 
 
-
-Matlab-style IIR filter design
-==============================
+Continuous-time (analog) / discrete-time (digital) IIR filter design
+--------------------------------------------------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -162,15 +173,86 @@ Matlab-style IIR filter design
    cheb2ord
    ellip -- Elliptic (Cauer)
    ellipord
-   bessel -- Bessel (no order selection available -- try butterod)
+   bessel -- Bessel (no order selection available -- try `butterord`)
+
+
+Discrete-time (digital) IIR / FIR filter design
+-----------------------------------------------
+Finite impulse response (FIR) filter design:
+
+.. autosummary::
+   :toctree: generated/
+
+   firls         -- FIR filter design using least-squares error minimization.
+   firwin        -- Windowed FIR filter design defined by pass and stop bands.
+   firwin2       -- Windowed FIR filter design, with arbitrary frequency response.
+   firwin_2d     -- 2D Windowed FIR filter design using 1D design.
+   kaiser_atten  -- Compute the attenuation of a Kaiser FIR filter
+   kaiser_beta   -- Compute the Kaiser parameter beta
+   kaiserord     -- Design a Kaiser window to limit ripple & width of transition region.
+   minimum_phase -- Convert a linear phase FIR filter to minimum phase.
+   savgol_coeffs -- Compute the FIR filter coefficients for a Savitzky-Golay filter.
+   remez         -- Optimal FIR filter design.
+
+Infinite impulse response (IIR) filter design:
+
+.. autosummary::
+   :toctree: generated/
+
+   bilinear      -- Digital filter from an analog filter using the bilinear transform.
+   bilinear_zpk  -- Digital filter from an analog filter using the bilinear transform.
+   iirdesign     -- IIR filter design given bands and gains.
+   iirfilter     -- IIR filter design given order and critical frequencies.
    iirnotch      -- Design second-order IIR notch digital filter.
    iirpeak       -- Design second-order IIR peak (resonant) digital filter.
    iircomb       -- Design IIR comb filter.
 
+FIR / IIR filter design:
+
+.. autosummary::
+   :toctree: generated/
+
+   gammatone     -- FIR and IIR gammatone filter design.
+
+
+.. _scipy-api-LTI_Conversions:
+
+LTI Conversions
+===============
+The `signal` module employs the following representations of linear time invariant
+(LTI) systems:
+
+* *Transfer function* ('tf' or 'ba'): Parametrized by the numerator coefficients array
+  `b` and the denominator coefficients array `a`.
+* *Zeros, poles, gain* ('zpk'): Parametrized by the zeros array `z`, the poles array
+  `p` and scalar overall gain `k`.
+* *Second order sections* ('sos'): Parametrized by a (n, 6) array where each row is made
+  up of three numerator and three denominator coefficients.
+* *State-space* ('ss'): Parametrized by four 2d arrays `A, B, C, D`.
+
+Consult the :ref:`tutorial_signal-LTI-Systems` section in the
+:ref:`user_guide` for the representations' definitions. The following functions
+allow to convert between those representations:
+
+.. autosummary::
+   :toctree: generated/
+
+   tf2zpk        -- Transfer function to zero-pole-gain.
+   tf2sos        -- Transfer function to second-order sections.
+   tf2ss         -- Transfer function to state-space.
+   zpk2tf        -- Zero-pole-gain to transfer function.
+   zpk2sos       -- Zero-pole-gain to second-order sections.
+   zpk2ss        -- Zero-pole-gain to state-space.
+   ss2tf         -- State-space to transfer function.
+   ss2zpk        -- State-space to pole-zero-gain.
+   sos2zpk       -- Second-order sections to zero-pole-gain.
+   sos2tf        -- Second-order sections to transfer function.
 
 
 Linear Systems
 ==============
+Consult the :ref:`tutorial_signal-UsingStateSpaceSystems` section of the
+:ref:`user_guide` for additional information.
 
 Continuous-time or discrete-time:
 
@@ -180,6 +262,10 @@ Continuous-time or discrete-time:
    StateSpace       -- Linear time invariant system in state space form.
    TransferFunction -- Linear time invariant system in transfer function form.
    ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
+   place_poles   -- Pole placement.
+   cont2discrete -- Continuous-time to discrete-time LTI conversion.
+   abcd_normalize -- Check state-space matrices compatibility and ensure they are 2d.
+
 
 
 Continuous-time:
@@ -208,25 +294,6 @@ Discrete-time:
    dbode            -- Bode magnitude and phase data (discrete-time LTI).
 
 
-LTI representations
-===================
-
-.. autosummary::
-   :toctree: generated/
-
-   tf2zpk        -- Transfer function to zero-pole-gain.
-   tf2sos        -- Transfer function to second-order sections.
-   tf2ss         -- Transfer function to state-space.
-   zpk2tf        -- Zero-pole-gain to transfer function.
-   zpk2sos       -- Zero-pole-gain to second-order sections.
-   zpk2ss        -- Zero-pole-gain to state-space.
-   ss2tf         -- State-pace to transfer function.
-   ss2zpk        -- State-space to pole-zero-gain.
-   sos2zpk       -- Second-order sections to zero-pole-gain.
-   sos2tf        -- Second-order sections to transfer function.
-   cont2discrete -- Continuous-time to discrete-time LTI conversion.
-   place_poles   -- Pole placement.
-
 Waveforms
 =========
 
@@ -244,10 +311,9 @@ Waveforms
 Window functions
 ================
 
-For window functions, see the `scipy.signal.windows` namespace.
-
-In the `scipy.signal` namespace, there is a convenience function to
-obtain these windows by name:
+For window functions, consult the `scipy.signal.windows` namespace. For convenience,
+the following function is duplicated from the `scipy.signal.windows` namespace into the
+`scipy.signal` namespace:
 
 .. autosummary::
    :toctree: generated/
@@ -270,6 +336,8 @@ Peak finding
 
 Spectral analysis
 =================
+Consult the :ref:`tutorial_signal-SpectralAnalysis` and :ref:`tutorial_signal-STFT`
+sections of the :ref:`user_guide` for additional information.
 
 .. autosummary::
    :toctree: generated/
@@ -278,18 +346,23 @@ Spectral analysis
    welch          -- Compute a periodogram using Welch's method.
    csd            -- Compute the cross spectral density, using Welch's method.
    coherence      -- Compute the magnitude squared coherence, using Welch's method.
-   spectrogram    -- Compute the spectrogram (legacy).
    lombscargle    -- Computes the Lomb-Scargle periodogram.
    vectorstrength -- Computes the vector strength.
-   ShortTimeFFT   -- Interface for calculating the \
-                     :ref:`Short Time Fourier Transform <tutorial_stft>` and \
-                     its inverse.
-   closest_STFT_dual_window -- Calculate the STFT dual window of a given window \
-                               closest to a desired dual window.
+   ShortTimeFFT   -- Provide the short-time Fourier transform (STFT) and its inverse.
+   closest_STFT_dual_window -- Calculate the closest STFT dual window of a given window.
+   check_NOLA     -- Check the NOLA constraint for iSTFT reconstruction.
+
+The following functions are considered legacy and will no longer receive updates.
+Their functionality is superseded by `ShortTimeFFT` and `closest_STFT_dual_window`.
+
+.. autosummary::
+   :toctree: generated/
+
+   spectrogram    -- Compute the spectrogram (legacy).
    stft           -- Compute the Short Time Fourier Transform (legacy).
    istft          -- Compute the Inverse Short Time Fourier Transform (legacy).
    check_COLA     -- Check the COLA constraint for iSTFT reconstruction (legacy).
-   check_NOLA     -- Check the NOLA constraint for iSTFT reconstruction.
+
 
 Chirp Z-transform and Zoom FFT
 ============================================
@@ -297,11 +370,11 @@ Chirp Z-transform and Zoom FFT
 .. autosummary::
    :toctree: generated/
 
-   czt - Chirp z-transform convenience function
-   zoom_fft - Zoom FFT convenience function
-   CZT - Chirp z-transform function generator
-   ZoomFFT - Zoom FFT function generator
-   czt_points - Output the z-plane points sampled by a chirp z-transform
+   czt -- Chirp z-transform convenience function
+   zoom_fft -- Zoom FFT convenience function
+   CZT -- Chirp z-transform function generator
+   ZoomFFT -- Zoom FFT function generator
+   czt_points -- Output the z-plane points sampled by a chirp z-transform
 
 The functions are simpler to use than the classes, but are less efficient when
 using the same transform on many arrays of the same length, since they

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -155,7 +155,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     -----
     If a matrix is not modified, the original matrix (not a copy) is returned.
 
-    The :ref:`tutorial_signal_state_space_representation` section of the
+    The :ref:`tutorial_signal-StateSpaceRepresentation` section of the
     :ref:`user_guide` presents the corresponding definitions of continuous-time and
     disrcete time state space systems.
 
@@ -270,7 +270,7 @@ def ss2tf(A, B, C, D, input=0):
     except in the case where each of `A`, `B`, `C`, and `D` has integer dtype, in which
     case the resulting dtype will be the default floating point dtype of ``float64``.
 
-    The :ref:`tutorial_signal_state_space_representation` section of the
+    The :ref:`tutorial_signal-StateSpaceRepresentation` section of the
     :ref:`user_guide` presents the corresponding definitions of continuous-time and
     disrcete time state space systems.
 

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1537,7 +1537,7 @@ class StateSpace(LinearTimeInvariant):
     convert to the specific system representation first. For example, call
     ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
 
-    The :ref:`tutorial_signal_state_space_representation` section of the
+    The :ref:`tutorial_signal-StateSpaceRepresentation` section of the
     :ref:`user_guide` presents the corresponding definitions of continuous-time and
     disrcete time state space systems.
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -112,9 +112,10 @@ def closest_STFT_dual_window(win: np.ndarray, hop: int,
         -----
         For a given window and `hop` interval, all possible dual windows are expressed
         by the `hop` linear conditions of Eq. :math:numref:`eq_STFT_AllDualWinsCond` in
-        the :ref:`tutorial_stft` section of the :ref:`user_guide`. Hence, decreasing
-        `hop`, increases the number of degrees of freedom of the set of all possible
-        dual windows, improving the ability to better approximate a `desired_dual`.
+        the :ref:`tutorial_signal-STFT` section of the :ref:`user_guide`. Hence,
+        decreasing `hop`, increases the number of degrees of freedom of the set of all
+        possible dual windows, improving the ability to better approximate a
+        `desired_dual`.
 
         This function can also be used to determine windows which fulfill the
         so-called "Constant OverLap Add" (COLA) condition [1]_. It states that summing
@@ -257,7 +258,7 @@ class ShortTimeFFT:
     backwards from an array's end like in standard Python indexing but being
     left of t = 0.
 
-    More detailed information can be found in the :ref:`tutorial_stft`
+    More detailed information can be found in the :ref:`tutorial_signal-STFT`
     section of the :ref:`user_guide`.
 
     Note that all parameters of the initializer, except `scale_to` (which uses
@@ -470,7 +471,7 @@ class ShortTimeFFT:
         from a given dual window `dual_win`. All other parameters have the
         same meaning as in the initializer of `ShortTimeFFT`.
 
-        As explained in the :ref:`tutorial_stft` section of the
+        As explained in the :ref:`tutorial_signal-STFT` section of the
         :ref:`user_guide`, an invertible STFT can be interpreted as series
         expansion of time-shifted and frequency modulated dual windows. E.g.,
         the series coefficient S[q,p] belongs to the term, which shifted
@@ -671,7 +672,7 @@ class ShortTimeFFT:
         -----
         The set of all possible windows with identical dual is defined by the set of
         linear constraints of Eq. :math:numref:`eq_STFT_AllDualWinsCond` in the
-        :ref:`tutorial_stft` section of the :ref:`user_guide`. There it is also
+        :ref:`tutorial_signal-STFT` section of the :ref:`user_guide`. There it is also
         derived that ``ShortTimeFFT.dual_win == ShortTimeFFT.m_pts * ShortTimeFFT.win``
         needs to hold for an STFT to be a unitary mapping.
 
@@ -1500,7 +1501,7 @@ class ShortTimeFFT:
             q_max = S.shape[t_range] + self.p_min
             k_max = (q_max - 1) * self.hop + self.m_num - self.m_num_mid
 
-        The :ref:`tutorial_stft` section of the :ref:`user_guide` discussed the
+        The :ref:`tutorial_signal-STFT` section of the :ref:`user_guide` discussed the
         slicing behavior by means of an example.
         """
         if f_axis == t_axis:
@@ -1652,7 +1653,7 @@ class ShortTimeFFT:
         `k_min` is the index of the left-most non-zero value of the lowest
         slice `p_min`. Since the zeroth slice is centered over the zeroth
         sample of the input signal, `k_min` is never positive.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         See Also
@@ -1679,7 +1680,7 @@ class ShortTimeFFT:
 
         Since, per convention the zeroth slice is centered at t=0,
         `p_min` <= 0 always holds.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         See Also
@@ -1730,7 +1731,7 @@ class ShortTimeFFT:
 
         `k_max` - 1 is the largest sample index of the slice `p_max` - 1 for a
         given input signal of `n` samples.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         Parameters
@@ -1763,7 +1764,7 @@ class ShortTimeFFT:
         of samples indexes covered by the window slices is given by `k_max`.
         Furthermore, `p_max` does not denote the number of slices `p_num` since
         `p_min` is typically less than zero.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         Parameters
@@ -1792,7 +1793,7 @@ class ShortTimeFFT:
 
         It is given by `p_num` = `p_max` - `p_min` with `p_min` typically
         being negative.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         Parameters
@@ -1824,7 +1825,7 @@ class ShortTimeFFT:
 
         Describes the point where the window does not stick out to the left
         of the signal domain.
-        A detailed example is provided in the :ref:`tutorial_stft_sliding_win`
+        A detailed example is provided in the :ref:`tutorial_signal-STFT_sliding_win`
         section of the :ref:`user_guide`.
 
         See Also
@@ -1859,7 +1860,7 @@ class ShortTimeFFT:
 
         Describes the point where the window does begin stick out to the right
         of the signal domain.
-        A detailed example is given :ref:`tutorial_stft_sliding_win` section
+        A detailed example is given :ref:`tutorial_signal-STFT_sliding_win` section
         of the :ref:`user_guide`.
 
         Parameters

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4464,7 +4464,7 @@ def lfilter_zi(b, a):
     Notes
     -----
     The parameters `b` and `a` represent a transfer function :math:`H(z) = Y(z)/X(z)`
-    which is defined in the :ref:`tutorial_signal_TransferFunctionRepresentation`
+    which is defined in the :ref:`tutorial_signal-TransferFunctionRepresentation`
     section of the :ref:`user_guide`. As discussed in [1]_, the final value of
     filtering a step response :math:`X(z) = z / (z-1)`, i.e., steady state, is given by
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -403,7 +403,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     If `return_onesided` is ``True``, the values of the negative frequencies are added
     to values of the corresponding positive ones.
 
-    Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
+    Consult the :ref:`tutorial_signal-SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of the power spectral density and
     the magnitude (squared) spectrum.
 
@@ -577,7 +577,7 @@ def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=N
     If `return_onesided` is ``True``, the values of the negative frequencies are added
     to values of the corresponding positive ones.
 
-    Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
+    Consult the :ref:`tutorial_signal-SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of the power spectral density and
     the (squared) magnitude spectrum.
 
@@ -767,7 +767,7 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
     If `return_onesided` is ``True``, the values of the negative frequencies are added
     to values of the corresponding positive ones.
 
-    Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
+    Consult the :ref:`tutorial_signal-SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of a spectral density and an (amplitude) spectrum.
 
     Welch's method may be interpreted as taking the average over the time slices of a
@@ -970,8 +970,8 @@ def spectrogram(x, fs=1.0, window=('tukey_periodic', .25), nperseg=None, noverla
 
         :class:`ShortTimeFFT` is a newer STFT / ISTFT implementation with more
         features also including a :meth:`~ShortTimeFFT.spectrogram` method.
-        A :ref:`comparison <tutorial_stft_legacy_stft>` between the
-        implementations can be found in the :ref:`tutorial_stft` section of
+        A :ref:`comparison <tutorial_signal-STFT_legacy_stft>` between the
+        implementations can be found in the :ref:`tutorial_signal-STFT` section of
         the :ref:`user_guide`.
 
     Parameters
@@ -1425,8 +1425,8 @@ def stft(x, fs=1.0, window='hann_periodic', nperseg=256, noverlap=None, nfft=Non
     .. legacy:: function
 
         `ShortTimeFFT` is a newer STFT / ISTFT implementation with more
-        features. A :ref:`comparison <tutorial_stft_legacy_stft>` between the
-        implementations can be found in the :ref:`tutorial_stft` section of the
+        features. A :ref:`comparison <tutorial_signal-STFT_legacy_stft>` between the
+        implementations can be found in the :ref:`tutorial_signal-STFT` section of the
         :ref:`user_guide`.
 
     Parameters
@@ -1613,8 +1613,8 @@ def istft(Zxx, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft
     .. legacy:: function
 
         `ShortTimeFFT` is a newer STFT / ISTFT implementation with more
-        features. A :ref:`comparison <tutorial_stft_legacy_stft>` between the
-        implementations can be found in the :ref:`tutorial_stft` section of the
+        features. A :ref:`comparison <tutorial_signal-STFT_legacy_stft>` between the
+        implementations can be found in the :ref:`tutorial_signal-STFT` section of the
         :ref:`user_guide`.
 
     Parameters

--- a/scipy/signal/_splinemodule.cc
+++ b/scipy/signal/_splinemodule.cc
@@ -50,7 +50,7 @@ static char doc_FIRsepsym2d[] = "sepfir2d(input, hrow, hcol)\n"
 "\n"
 "    Examples\n"
 "    --------\n"
-"    Examples are given :ref:`in the tutorial <tutorial-signal-bsplines>`.\n"
+"    Examples are given :ref:`in the tutorial <tutorial_signal-BSplines>`.\n"
 "\n";
 
 static PyObject *FIRsepsym2d(PyObject *NPY_UNUSED(dummy), PyObject *args) {

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -743,7 +743,7 @@ def test_compare_stft_detrend():
 def test_tutorial_stft_sliding_win():
     """Verify example in "Sliding Windows" subsection from the "User Guide".
 
-    In :ref:`tutorial_stft_sliding_win` (file ``signal.rst``) of the
+    In :ref:`tutorial_signal-STFT_sliding_win` (file ``signal.rst``) of the
     :ref:`user_guide` the behavior the border behavior of
     ``ShortTimeFFT(np.ones(6), 2, fs=1)`` with a 50 sample signal is discussed.
     This test verifies the presented indexes.
@@ -770,7 +770,7 @@ def test_tutorial_stft_legacy_stft():
     """Verify STFT example in "Comparison with Legacy Implementation" from the
     "User Guide".
 
-    In :ref:`tutorial_stft_legacy_stft` (file ``signal.rst``) of the
+    In :ref:`tutorial_signal-STFT_legacy_stft` (file ``signal.rst``) of the
     :ref:`user_guide` the legacy and the new implementation are compared.
     """
     fs, N = 200, 1001  # # 200 Hz sampling rate for 5 s signal
@@ -811,7 +811,7 @@ def test_tutorial_stft_legacy_spectrogram():
     """Verify spectrogram example in "Comparison with Legacy Implementation"
     from the "User Guide".
 
-    In :ref:`tutorial_stft_legacy_stft` (file ``signal.rst``) of the
+    In :ref:`tutorial_signal-STFT_legacy_stft` (file ``signal.rst``) of the
     :ref:`user_guide` the legacy and the new implementation are compared.
     """
     fs, N = 200, 1001  # 200 Hz sampling rate for almost 5 s signal

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1999,7 +1999,7 @@ class TestSampledSpectralRepresentations:
     """Check energy/power relations from `Spectral Analysis` section in the user guide.
 
     A 32 sample cosine signal is used to compare the numerical to the expected results
-    stated in :ref:`tutorial_SpectralAnalysis` in
+    stated in :ref:`tutorial_signal-SpectralAnalysis` in
     file ``doc/source/tutorial/signal.rst``
     """
     n: int = 32  #: number of samples

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -196,8 +196,8 @@ def boxcar(M, sym=True, *, xp=None, device=None):
     decrease on the order of :math:`O(|l|^{-1})`.
 
     For many applications, like calculating a magnitude spectrum in the example below,
-    a normalized window is needed. Consult the :ref:`tutorial_SpectralAnalysis` section
-    of the :ref:`user_guide` for details.
+    a normalized window is needed. Consult the :ref:`tutorial_signal-SpectralAnalysis`
+    section of the :ref:`user_guide` for details.
 
     References
     ----------
@@ -959,8 +959,8 @@ def hann(M, sym=True, *, xp=None, device=None):
     The height of the sidelobes decreases on the order of :math:`O(|l|^{-3})`.
 
     For many applications, like calculating a magnitude spectrum in the example below,
-    a normalized window is needed. Consult the :ref:`tutorial_SpectralAnalysis` section
-    of the :ref:`user_guide` for details.
+    a normalized window is needed. Consult the :ref:`tutorial_signal-SpectralAnalysis`
+    section of the :ref:`user_guide` for details.
 
     References
     ----------


### PR DESCRIPTION
On the signal API-Reference page (`scipy/signal/__init__.py`):
 
* The "Filtering", "Filter design", "Matlab-style IIR design" and "LTI-representation" sections of the "API Reference page" are reorganized into more application-focused groupings.
* Added references to the user guide sections  and fix typos


In file `signal.rst` (tutorial):

* The sections in the "Filtering" chapter are reorganized to be more coherent.
* "Using State-space Systems" section (including the example `signal_StateSpace_FreqSplitter.py`) is added to give an overview of the state-space functionality.
* Fixed section levels and rename sections link names for better coherence. 
* Fixed typos. 

All the changes in the other files only contain updated links to the signal tutorial sections.

The initial motivation for this PR was the [Deprecation discussion] about LTI classes ([lti], [dlti], [StateSpace], [TransferFunction], [ZerosPolesGain]):  Improving the documentation about the control systems capabilities (mainly the added "Using State-Space Systems" section) could benefit the discussion about which functions can be deprecated, since they are only wrappers. For that reason the "Using State-Space Systems" section deliberately omits the functions [freqresp], [bode] and [dbode] as well as the classes.

[docs only]

[Deprecation discussion]: https://discuss.scientific-python.org/t/dep-depcrecate-lti-classes-in-signal-module/2432
[lti]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.lti.html
[dlti]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.dlti.html
[StateSpace]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.StateSpace.html
[TransferFunction]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.TransferFunction.html
[ZerosPolesGain]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.ZerosPolesGain.html
[freqresp]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.freqresp.html
[dfreqresp]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.dfreqresp.html
[bode]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.bode.html
[dbode]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.dbode.html


#### AI Generation Disclosure
AI helped a little bit with the proof reading.