### PR TITLE
ENH/BUG: linalg.eig: deal with `b` upcasting `a` for empty arrays

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -225,7 +225,31 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
 
-    # accommodate empty arrays
+    if b is not None:
+        b1 = _asarray_validated(b, check_finite=check_finite)
+        _deprecate_dtypes("eig", b1)
+
+        a1, b1 = _ensure_dtype_cdsz(a1, b1)  # NB: makes a1.dtype == b1.dtype, if needed
+        b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
+
+        if len(b1.shape) < 2 or b1.shape[-1] != b1.shape[-2]:
+            raise ValueError('expected square matrix')
+
+        if a1.shape[-1] != b1.shape[-1]:
+            raise ValueError('a and b must have the same shape')
+
+        # broadcast batch dimensions of b1 and a1
+        batch_shape = np.broadcast_shapes(a1.shape[:-2], b1.shape[:-2])
+        a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
+        b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
+
+        # check if we can work in-place (a1 might have been broadcast by b1)
+        overwrite_a = overwrite_a and (a1.ndim == 2)
+
+        overwrite_b = overwrite_b or (_datacopied(b1, b))
+        overwrite_b = overwrite_b and (b1.ndim == 2) and (b1.flags["F_CONTIGUOUS"])
+
+    # accommodate empty arrays, do so after potential upcasting of `a` due to `b`
     if a1.shape[-1] == 0 or a1.shape[-2] == 0:
         batch_shape = a1.shape[:-2]
         w_n, vr_n = eig(np.eye(2, dtype=a1.dtype))
@@ -252,30 +276,6 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     else:
         # b is not None: generalized eigenvalue problem
-
-        b1 = _asarray_validated(b, check_finite=check_finite)
-        _deprecate_dtypes("eig", b1)
-
-        a1, b1 = _ensure_dtype_cdsz(a1, b1)  # NB: makes a1.dtype == b1.dtype, if needed
-        b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
-
-        if len(b1.shape) < 2 or b1.shape[-1] != b1.shape[-2]:
-            raise ValueError('expected square matrix')
-
-        if a1.shape[-1] != b1.shape[-1]:
-            raise ValueError('a and b must have the same shape')
-
-        # broadcast batch dimensions of b1 and a1
-        batch_shape = np.broadcast_shapes(a1.shape[:-2], b1.shape[:-2])
-        a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
-        b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
-
-        # check if we can work in-place (a1 might have been broadcast by b1)
-        overwrite_a = overwrite_a and (a1.ndim == 2)
-
-        overwrite_b = overwrite_b or (_datacopied(b1, b))
-        overwrite_b = overwrite_b and (b1.ndim == 2) and (b1.flags["F_CONTIGUOUS"])
-
         w, beta, vl, vr, err_lst = _batched_linalg._eig(
             a1, left, right, overwrite_a, overwrite_b, b1
         )

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -415,12 +415,14 @@ class TestEig:
             assert np.isclose(D, 4.0, atol=1e-14).any()
             assert np.isclose(D, 8.0, atol=1e-14).any()
 
-    @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])
-    def test_empty(self, dt):
-        a = np.empty((0, 0), dtype=dt)
-        w, vr = eig(a)
+    @pytest.mark.parametrize('dt_a', [int, float, np.float32, complex, np.complex64])
+    @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
+    def test_empty(self, dt_a, dt_b):
+        a = np.empty((0, 0), dtype=dt_a)
+        b = np.empty((0, 0), dtype=dt_b)
+        w, vr = eig(a, b)
 
-        w_n, vr_n = eig(np.eye(2, dtype=dt))
+        w_n, vr_n = eig(np.eye(2, dtype=dt_a), np.eye(2, dtype=dt_b))
 
         assert w.shape == (0,)
         assert w.dtype == w_n.dtype  #eigvals(np.eye(2, dtype=dt)).dtype
@@ -429,7 +431,7 @@ class TestEig:
         assert vr.shape == (0, 0)
         assert vr.dtype == vr_n.dtype
 
-        w, vr = eig(a, homogeneous_eigvals=True)
+        w, vr = eig(a, b, homogeneous_eigvals=True)
         assert w.shape == (2, 0)
         assert w.dtype == w_n.dtype
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -378,13 +378,24 @@ class TestEig:
         A = np.arange(6).reshape(3, 2)
         assert_raises(ValueError, eig, A)
 
-    def test_shape_mismatch(self):
+    @pytest.mark.parametrize("n_a", [0, 2, 3])
+    @pytest.mark.parametrize("n_b", [0, 2, 3])
+    def test_shape_mismatch(self, n_a, n_b):
         """Check that passing arrays of with different shapes
         raises a ValueError."""
-        A = eye(2)
-        B = np.arange(9.0).reshape(3, 3)
-        assert_raises(ValueError, eig, A, B)
-        assert_raises(ValueError, eig, B, A)
+        A = np.arange(n_a * n_a).reshape(n_a, n_a)
+        B = np.eye(n_b)
+
+        if n_a != n_b:
+            with pytest.raises(ValueError, match="a and b must have"):
+                eig(A, B)
+            with pytest.raises(ValueError, match="a and b must have"):
+                eig(B, A)
+
+        else: # Verify correctness of solution
+            w, v = eig(A, B)
+            assert_allclose(A @ v, B @ v @ np.diag(w), atol=1e-14)
+
 
     def test_gh_11577(self):
         # https://github.com/scipy/scipy/issues/11577


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/25319#discussion_r3681116388

#### What does this implement/fix?
During work on `eigh` it was discovered that the early return that was used for empty arrays did not cover the case where `b` would upcast `a`; the decision on which dtype to use was made before that upcasting could have happened. A similar problem occurs in `eig`, which this PR attempts to fix.

#### Additional information
N/A

#### AI Generation Disclosure
No AI
