### PR TITLE
DOC: signal: add examples for `buttap` and `cheb1ap`

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4730,6 +4730,12 @@ def buttap(N, *, xp=None, device=None):
     --------
     butter : Filter design function using this prototype
 
+
+    Examples
+    --------
+    Compute the zeros, poles, and gain of a 2nd-order Butterworth analog
+    lowpass prototype with a cutoff frequency of 1 rad/s:
+
     Examples
     --------
     Compute the zeros, poles, and gain of a 2nd-order Butterworth analog
@@ -4743,6 +4749,34 @@ def buttap(N, *, xp=None, device=None):
     array([-0.70710678+0.70710678j, -0.70710678-0.70710678j])
     >>> k
     1.0
+
+    Sweep the frequency response of a 3rd-order prototype:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.signal import freqs_zpk
+    >>> z, p, k = buttap(3)
+    >>> f = np.geomspace(1e-1, 1e1, 200)
+    >>> _, h = freqs_zpk(z, p, k, worN=f)
+    >>> h_db = 20 * np.log10(np.abs(h))
+    >>> fig, ax = plt.subplots()
+    >>> ax.semilogx(f, h_db)
+    >>> ax.set(title='3rd-order Butterworth prototype',
+    ...        xlabel='Frequency [rad/s]', ylabel='Magnitude [dB]')
+    >>> ax.axvline(1.0, color='C1', ls='--', label='Cutoff frequency')
+    >>> ax.grid(True, which='both')
+    >>> ax.legend()
+    >>> plt.show()
+    >>> from scipy.signal import buttap
+    >>> z, p, k = buttap(2)
+    >>> z
+    array([], dtype=float64)
+    >>> p
+    array([-0.70710678+0.70710678j, -0.70710678-0.70710678j])
+    >>> k
+    1.0
+
+
 
     Sweep the frequency response of a 3rd-order prototype:
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4707,7 +4707,7 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
 
 
 def buttap(N, *, xp=None, device=None):
-    """Return (z,p,k) for analog prototype of Nth-order Butterworth filter.
+    r"""Return (z, p, k) for analog prototype of Nth-order Butterworth filter.
 
     The filter will have an angular (e.g., rad/s) cutoff frequency of 1.
 
@@ -4722,20 +4722,35 @@ def buttap(N, *, xp=None, device=None):
     z : ndarray[float64]
         Zeros of the transfer function. Is always an empty array.
     p : ndarray[complex128]
-        Poles of the transfer function.
+        Poles of the transfer function as an `(N,)` array.
     k : float
-        Gain of the transfer function.
+        Gain of the transfer function, which is always one.
+
+    Notes
+    -----
+    Here, a cutoff frequency of :math:`\omega_c = 1\,`\ rad/s and and a gain of
+    :math:`k=1` is assumed. The transfer function can be expressed as [1]_
+
+    .. math::
+
+        H(s) = k \prod_{i=0}^{N-1} \frac{\omega_c}{s - s_l}
+                 \quad\text{with poles}\quad
+          s_l = -\omega_c\exp\!\left\{ j\pi\frac{2l+1-N}{2N} \right\} \,.
+
+    Hence, this function returns no zeros and `N` poles. Note that the poles are ordered
+    in a way so that the :math:`l`\-th pole is the conjugate complex of the
+    :math:`(N-1-l)`\-th pole. I.e., if :math:`N` is odd, then the :math:`(N//2)`-th pole
+    is always :math:`-1`.
+
+    References
+    ----------
+    .. [1] "Butterworth filter", Wikipedia,
+           https://en.wikipedia.org/wiki/Butterworth_filter
 
     See Also
     --------
     butter : Filter design function using this prototype
 
-
-    Examples
-    --------
-    Compute the zeros, poles, and gain of a 2nd-order Butterworth analog
-    lowpass prototype with a cutoff frequency of 1 rad/s:
-
     Examples
     --------
     Compute the zeros, poles, and gain of a 2nd-order Butterworth analog
@@ -4750,51 +4765,31 @@ def buttap(N, *, xp=None, device=None):
     >>> k
     1.0
 
-    Sweep the frequency response of a 3rd-order prototype:
+    Bode plot of the frequency response of a 3rd-order prototype:
 
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
-    >>> from scipy.signal import freqs_zpk
+    >>> from scipy.signal import freqs_zpk, buttap
+    ...
     >>> z, p, k = buttap(3)
     >>> f = np.geomspace(1e-1, 1e1, 200)
     >>> _, h = freqs_zpk(z, p, k, worN=f)
-    >>> h_db = 20 * np.log10(np.abs(h))
-    >>> fig, ax = plt.subplots()
-    >>> ax.semilogx(f, h_db)
-    >>> ax.set(title='3rd-order Butterworth prototype',
-    ...        xlabel='Frequency [rad/s]', ylabel='Magnitude [dB]')
-    >>> ax.axvline(1.0, color='C1', ls='--', label='Cutoff frequency')
-    >>> ax.grid(True, which='both')
-    >>> ax.legend()
+    >>> h_db, h_ph = 20 * np.log10(np.abs(h)), np.unwrap(np.angle(h))
+    ...
+    >>> _, (ax0, ax1) = plt.subplots(2, 1, sharex='all', constrained_layout=True)
+    >>> ax0.set(title='3rd-order Butterworth prototype', ylabel='Magnitude in dB',
+    ...         yticks=[-60, -40, -20, 0])
+    >>> ax0.semilogx(f, h_db, 'C0', label='Magnitude')
+    >>> ax1.set(ylabel="Phase in radians", xlabel="Frequency in rad/s",
+    ...         yticks=np.pi*np.arange(-1.5, 0.5, 0.5), ylim=(-1.5*np.pi, 0),
+    ...         yticklabels=['-3π/2', '-π', '-π/2', '0'], xlim=(f[0], f[-1]))
+    >>> ax1.semilogx(f, h_ph, 'C1', label='Phase')
+    >>> for ax_ in (ax0, ax1):
+    ...     ax_.axvline(1.0, color='C2', ls='--', alpha=.5, label='Cutoff frequency')
+    ...     ax_.grid(True, which='both')
+    ...     ax_.legend()
     >>> plt.show()
-    >>> from scipy.signal import buttap
-    >>> z, p, k = buttap(2)
-    >>> z
-    array([], dtype=float64)
-    >>> p
-    array([-0.70710678+0.70710678j, -0.70710678-0.70710678j])
-    >>> k
-    1.0
 
-
-
-    Sweep the frequency response of a 3rd-order prototype:
-
-    >>> import numpy as np
-    >>> import matplotlib.pyplot as plt
-    >>> from scipy.signal import freqs_zpk
-    >>> z, p, k = buttap(3)
-    >>> f = np.geomspace(1e-1, 1e1, 200)
-    >>> _, h = freqs_zpk(z, p, k, worN=f)
-    >>> h_db = 20 * np.log10(np.abs(h))
-    >>> fig, ax = plt.subplots()
-    >>> ax.semilogx(f, h_db)
-    >>> ax.set(title='3rd-order Butterworth prototype',
-    ...        xlabel='Frequency [rad/s]', ylabel='Magnitude [dB]')
-    >>> ax.axvline(1.0, color='C1', ls='--', label='Cutoff frequency')
-    >>> ax.grid(True, which='both')
-    >>> ax.legend()
-    >>> plt.show()
     """
     if xp is None:
         xp = np_compat
@@ -4809,8 +4804,7 @@ def buttap(N, *, xp=None, device=None):
 
 
 def cheb1ap(N, rp, *, xp=None, device=None):
-    """
-    Return (z,p,k) for Nth-order Chebyshev type I analog lowpass filter.
+    r"""Return (z, p, k) for Nth-order Chebyshev type I analog lowpass filter.
 
     The returned filter prototype has `rp` decibels of ripple in the passband.
 
@@ -4822,7 +4816,8 @@ def cheb1ap(N, rp, *, xp=None, device=None):
     N : int
         The order of the filter
     rp : float
-        The ripple intensity
+        The passband ripple in dB. It constrains the passband gain to the
+        interval [-rp, 0] dB.
     %(xp_device_snippet)s
 
     Returns
@@ -4852,6 +4847,34 @@ def cheb1ap(N, rp, *, xp=None, device=None):
            -0.2470853 -0.96599867j])
     >>> k
     0.49130668209006784
+
+    Plot of the frequency response of a 3rd-order prototype with a passband riple
+    of 5 dB:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.signal import freqs_zpk, cheb1ap
+    ...
+    >>> z, p, k = cheb1ap(3, rp=5)
+    >>> f = np.geomspace(1e-1, 1e1, 200)
+    >>> _, h = freqs_zpk(z, p, k, worN=f)
+    >>> h_db, h_ph = 20 * np.log10(np.abs(h)), np.unwrap(np.angle(h))
+    ...
+    >>> _, (ax0, ax1) = plt.subplots(2, 1, sharex='all', constrained_layout=True)
+    >>> ax0.set(title='3rd-order Chebyshev type I prototype', ylim=(-60, 3),
+    ...         ylabel='Magnitude in dB', yticks=[-60, -40, -20, 0])
+    >>> ax0.fill((0, 0, 1, 1), (0, -5, -5, 0), 'C2', alpha=.3, label="5 dB ripple band")
+    >>> ax0.semilogx(f, h_db, 'C0', label='Magnitude')
+    >>> ax1.set(ylabel="Phase in radians", xlabel="Frequency in rad/s",
+    ...         yticks=np.pi*np.arange(-1.5, 0.5, 0.5), ylim=(-1.5*np.pi, 0),
+    ...         yticklabels=['-3π/2', '-π', '-π/2', '0'], xlim=(f[0], f[-1]))
+    >>> ax1.semilogx(f, h_ph, 'C1', label='Phase')
+    >>> for ax_ in (ax0, ax1):
+    ...     ax_.axvline(1.0, color='C2', ls='--', alpha=.5, label='Cutoff frequency')
+    ...     ax_.grid(True, which='both')
+    ...     ax_.legend()
+    >>> plt.show()
+
     """
     if xp is None:
         xp = np_compat

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4730,6 +4730,37 @@ def buttap(N, *, xp=None, device=None):
     --------
     butter : Filter design function using this prototype
 
+    Examples
+    --------
+    Compute the zeros, poles, and gain of a 2nd-order Butterworth analog
+    lowpass prototype with a cutoff frequency of 1 rad/s:
+
+    >>> from scipy.signal import buttap
+    >>> z, p, k = buttap(2)
+    >>> z
+    array([], dtype=float64)
+    >>> p
+    array([-0.70710678+0.70710678j, -0.70710678-0.70710678j])
+    >>> k
+    1.0
+
+    Sweep the frequency response of a 3rd-order prototype:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.signal import freqs_zpk
+    >>> z, p, k = buttap(3)
+    >>> f = np.geomspace(1e-1, 1e1, 200)
+    >>> _, h = freqs_zpk(z, p, k, worN=f)
+    >>> h_db = 20 * np.log10(np.abs(h))
+    >>> fig, ax = plt.subplots()
+    >>> ax.semilogx(f, h_db)
+    >>> ax.set(title='3rd-order Butterworth prototype',
+    ...        xlabel='Frequency [rad/s]', ylabel='Magnitude [dB]')
+    >>> ax.axvline(1.0, color='C1', ls='--', label='Cutoff frequency')
+    >>> ax.grid(True, which='both')
+    >>> ax.legend()
+    >>> plt.show()
     """
     if xp is None:
         xp = np_compat
@@ -4773,6 +4804,20 @@ def cheb1ap(N, rp, *, xp=None, device=None):
     --------
     cheby1 : Filter design function using this prototype
 
+    Examples
+    --------
+    Compute the zeros, poles, and gain of a 3rd-order Chebyshev type I
+    analog lowpass prototype with 1 dB of passband ripple:
+
+    >>> from scipy.signal import cheb1ap
+    >>> z, p, k = cheb1ap(3, 1)
+    >>> z
+    array([], dtype=float64)
+    >>> p
+    array([-0.2470853 +0.96599867j, -0.4941706 +0.j        ,
+           -0.2470853 -0.96599867j])
+    >>> k
+    0.49130668209006784
     """
     if xp is None:
         xp = np_compat


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Refs gh-7168.
[docs only]

#### What does this implement/fix?
Adds an `Examples` section to the docstrings of `signal.buttap` and
`signal.cheb1ap`. Both functions were listed in gh-7168 as missing examples.

#### Additional information
Docstring-only edit to `scipy/signal/_filter_design.py`.

#### AI Generation Disclosure
No AI tool used in this section. 
