### PR TITLE
MAINT: spatial.transform: update float32 test tolerances

### DIFF
--- a/scipy/spatial/_distance_xp.py
+++ b/scipy/spatial/_distance_xp.py
@@ -1,20 +1,18 @@
 """Array-API backend for scipy.spatial.distance."""
 
-from __future__ import annotations
-
-from typing import Any
 from types import ModuleType
+from typing import Any
 
 import numpy as np
 
 from scipy._lib._array_api import (
+    Array,
+    ArrayLike,
     _asarray,
     array_namespace,
     is_lazy_array,
     is_numpy,
     xp_promote,
-    Array,
-    ArrayLike,
 )
 
 # Functions in the backend should be batched by default, operating over the last axis
@@ -23,13 +21,12 @@ from scipy._lib._array_api import (
 
 
 def _validate_vector(u: ArrayLike, dtype: Any | None = None) -> Array:
-    # XXX Is order='c' really necessary?
     try:
-        u = _asarray(u, dtype=dtype, order="c")
+        u = _asarray(u, dtype=dtype)
     except TypeError:
         # String/object arrays (e.g. hamming on byte strings) have no array-API
         # namespace. Fall back to NumPy, which handles them.
-        u = np.asarray(u, dtype=dtype, order="c")
+        u = np.asarray(u, dtype=dtype)
     if u.ndim == 1:
         return u
     raise ValueError("Input vector should be 1-D.")
@@ -66,9 +63,7 @@ def _promote(x: ArrayLike, xp: ModuleType) -> Array:
     return xp_promote(x, force_floating=True, xp=xp)
 
 
-def minkowski(
-    u: ArrayLike, v: ArrayLike, p: float | int = 2, w: ArrayLike | None = None
-):
+def minkowski(u: ArrayLike, v: ArrayLike, p: float = 2, w: ArrayLike | None = None):
     xp = array_namespace(u, v)
     u = _promote(u, xp=xp)
     v = _promote(v, xp=xp)

--- a/scipy/spatial/_distance_xp.py
+++ b/scipy/spatial/_distance_xp.py
@@ -1,0 +1,89 @@
+"""Array-API backend for scipy.spatial.distance."""
+
+from __future__ import annotations
+
+from typing import Any
+from types import ModuleType
+
+import numpy as np
+
+from scipy._lib._array_api import (
+    _asarray,
+    array_namespace,
+    is_lazy_array,
+    is_numpy,
+    xp_promote,
+    Array,
+    ArrayLike,
+)
+
+# Functions in the backend should be batched by default, operating over the last axis
+# and broadcasting over arbitrary leading dimensions. This allows us to keep one
+# implementation for the single-pair and pdist/cdist cases
+
+
+def _validate_vector(u: ArrayLike, dtype: Any | None = None) -> Array:
+    # XXX Is order='c' really necessary?
+    try:
+        u = _asarray(u, dtype=dtype, order="c")
+    except TypeError:
+        # String/object arrays (e.g. hamming on byte strings) have no array-API
+        # namespace. Fall back to NumPy, which handles them.
+        u = np.asarray(u, dtype=dtype, order="c")
+    if u.ndim == 1:
+        return u
+    raise ValueError("Input vector should be 1-D.")
+
+
+def _validate_weights(w: ArrayLike, xp: ModuleType | None = None) -> Array:
+    """Reject negatives along the last axis.
+
+    Note:
+        If w is a numpy array, we also cast to float64. If w is lazy, we fill the
+        weights with NaN.
+    """
+    xp = array_namespace(w) if xp is None else xp
+    w = _promote(w, xp=xp)
+    invalid = w < 0
+    if is_lazy_array(w):
+        any_invalid = xp.any(invalid, axis=-1, keepdims=True)
+        return xp.where(any_invalid, xp.nan, w)
+    if xp.any(invalid):
+        raise ValueError("Input weights should be all non-negative")
+    return w
+
+
+def _promote(x: ArrayLike, xp: ModuleType) -> Array:
+    """Promote array to float64 for numpy, else according to the Array API spec.
+
+    The return array dtype follows the following rules:
+    - If x is an ArrayLike or NumPy array, we always promote to float64
+    - If x is an Array from frameworks other than NumPy, we preserve the precision
+      of the input array dtype.
+    """
+    if is_numpy(xp):
+        return _asarray(x, order="C", xp=xp, dtype=xp.float64)
+    return xp_promote(x, force_floating=True, xp=xp)
+
+
+def minkowski(
+    u: ArrayLike, v: ArrayLike, p: float | int = 2, w: ArrayLike | None = None
+):
+    xp = array_namespace(u, v)
+    u = _promote(u, xp=xp)
+    v = _promote(v, xp=xp)
+    if p <= 0:
+        raise ValueError("p must be greater than 0")
+    u_v = u - v
+    if w is not None:
+        w = _validate_weights(w, xp=xp)
+        if p == 1:
+            root_w = w
+        elif p == 2:
+            root_w = xp.sqrt(w)  # better precision and speed
+        elif p == np.inf:
+            root_w = xp.astype(w != 0, w.dtype)
+        else:
+            root_w = w ** (1 / p)
+        u_v = root_w * u_v
+    return xp.linalg.vector_norm(u_v, ord=p, axis=-1)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -120,7 +120,7 @@ from . import _hausdorff, _distance_pybind, _distance_wrap
 # Backends that take priority over the array API one, keyed by function name and array
 # namespace. Registering per function lets a namespace keep a specialized kernel for
 # some distances and the generic implementation for the rest.
-backend_registry = {}
+_backend_registry = {}
 
 
 def _select_backend(name, xp, generic=False):
@@ -136,7 +136,7 @@ def _select_backend(name, xp, generic=False):
     """
     if generic:
         return _distance_xp
-    return backend_registry.get((name, xp), _distance_xp)
+    return _backend_registry.get((name, xp), _distance_xp)
 
 
 def _copy_array_if_base_present(a):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -123,7 +123,7 @@ from . import _hausdorff, _distance_pybind, _distance_wrap
 backend_registry = {}
 
 
-def select_backend(name, xp, generic=False):
+def _select_backend(name, xp, generic=False):
     """Select the backend implementing the distance function.
 
     Args:
@@ -490,7 +490,7 @@ def minkowski(u, v, p=2, w=None):
     1.0
 
     """
-    backend = select_backend('minkowski', array_namespace(u, v))
+    backend = _select_backend('minkowski', array_namespace(u, v))
     return backend.minkowski(u, v, p, w)
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -109,12 +109,34 @@ from functools import partial
 
 import numpy as np
 
-from scipy._lib._array_api import _asarray
+from scipy._lib._array_api import _asarray, array_namespace, xp_capabilities
 from scipy._lib._util import _asarray_validated, _transition_to_rng
 from scipy._external import array_api_extra as xpx
-from scipy.linalg import norm
 from scipy.special import rel_entr
+from scipy.spatial import _distance_xp
+from scipy.spatial._distance_xp import _validate_weights, _validate_vector
 from . import _hausdorff, _distance_pybind, _distance_wrap
+
+# Backends that take priority over the array API one, keyed by function name and array
+# namespace. Registering per function lets a namespace keep a specialized kernel for
+# some distances and the generic implementation for the rest.
+backend_registry = {}
+
+
+def select_backend(name, xp, generic=False):
+    """Select the backend implementing the distance function.
+
+    Args:
+        name: Public function name, such as "euclidean".
+        xp: Array namespace of the inputs.
+        generic: Skip the registry and take the array API backend.
+
+    Returns:
+        The module implementing `name`.
+    """
+    if generic:
+        return _distance_xp
+    return backend_registry.get((name, xp), _distance_xp)
 
 
 def _copy_array_if_base_present(a):
@@ -286,19 +308,6 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
     return kwargs
 
 
-def _validate_vector(u, dtype=None):
-    # XXX Is order='c' really necessary?
-    u = np.asarray(u, dtype=dtype, order='c')
-    if u.ndim == 1:
-        return u
-    raise ValueError("Input vector should be 1-D.")
-
-
-def _validate_weights(w, dtype=np.float64):
-    w = _validate_vector(w, dtype=dtype)
-    if np.any(w < 0):
-        raise ValueError("Input weights should be all non-negative")
-    return w
 
 
 @_transition_to_rng('seed', position_num=2, replace_doc=False)
@@ -430,6 +439,7 @@ def directed_hausdorff(u, v, rng=0):
     return result
 
 
+@xp_capabilities()
 def minkowski(u, v, p=2, w=None):
     """
     Compute the Minkowski distance between two arrays.
@@ -480,25 +490,8 @@ def minkowski(u, v, p=2, w=None):
     1.0
 
     """
-    u = _asarray(u, order='C')
-    v = _asarray(v, order='C')
-    if p <= 0:
-        raise ValueError("p must be greater than 0")
-    u_v = u - v
-    if w is not None:
-        w = _validate_weights(w)
-        if p == 1:
-            root_w = w
-        elif p == 2:
-            # better precision and speed
-            root_w = np.sqrt(w)
-        elif p == np.inf:
-            root_w = (w != 0)
-        else:
-            root_w = np.power(w, 1/p)
-        u_v = root_w * u_v
-    dist = norm(u_v, ord=p, axis=-1)
-    return dist
+    backend = select_backend('minkowski', array_namespace(u, v))
+    return backend.minkowski(u, v, p, w)
 
 
 def euclidean(u, v, w=None):

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -105,6 +105,7 @@ py3.install_sources([
 
 py3.install_sources([
     '__init__.py',
+    '_distance_xp.py',
     '_geometric_slerp.py',
     '_kdtree.py',
     '_plotutils.py',

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1446,16 +1446,17 @@ class TestSomeDistanceFunctions:
 
     @make_xp_test_case(minkowski)
     def test_minkowski(self, xp):
+        atol = 1.5e-7
         for x, y in self.cases:
             x, y = xp.asarray(x), xp.asarray(y)
             dist1 = minkowski(x, y, p=1)
-            xp_assert_close(dist1, xp.asarray(3.0), atol=1.5e-7)
+            xp_assert_close(dist1, xp.asarray(3.0), atol=atol)
             dist1p5 = minkowski(x, y, p=1.5)
-            xp_assert_close(dist1p5, xp.asarray((1.0 + 2.0**1.5)**(2. / 3)), atol=1.5e-7)
+            xp_assert_close(dist1p5, xp.asarray((1.0 + 2.0**1.5)**(2. / 3)), atol=atol)
             dist2 = minkowski(x, y, p=2)
-            xp_assert_close(dist2, xp.asarray(5.0 ** 0.5), atol=1.5e-7)
+            xp_assert_close(dist2, xp.asarray(5.0 ** 0.5), atol=atol)
             dist0p25 = minkowski(x, y, p=0.25)
-            xp_assert_close(dist0p25, xp.asarray((1.0 + 2.0 ** 0.25) ** 4), atol=1.5e-7)
+            xp_assert_close(dist0p25, xp.asarray((1.0 + 2.0 ** 0.25) ** 4), atol=atol)
 
         # Check that casting input to minimum scalar type doesn't affect result
         # (issue #10262). This could be extended to more test inputs with

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -49,7 +49,7 @@ import scipy.spatial.distance
 
 from scipy.spatial.distance import (
     squareform, pdist, cdist, num_obs_y, num_obs_dm, is_valid_dm, is_valid_y,
-    _validate_vector, _METRICS_NAMES)
+    _validate_vector, _validate_weights, _METRICS_NAMES)
 
 # these were missing: chebyshev cityblock
 # jensenshannon  and seuclidean are referenced by string name.
@@ -61,7 +61,8 @@ from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     sokalsneath, sqeuclidean, yule)
 from scipy._lib._util import _apply_over_batch
 from scipy.conftest import skip_xp_invalid_arg
-from scipy._lib._array_api import xp_assert_close, xp_assert_equal
+from scipy._lib._array_api import make_xp_test_case, is_lazy_array, array_namespace
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 @pytest.fixture(params=_METRICS_NAMES, scope="session")
 def metric(request):
@@ -1443,24 +1444,26 @@ class TestSomeDistanceFunctions:
 
         self.cases = [(x, y)]
 
-    def test_minkowski(self):
+    @make_xp_test_case(minkowski)
+    def test_minkowski(self, xp):
         for x, y in self.cases:
+            x, y = xp.asarray(x), xp.asarray(y)
             dist1 = minkowski(x, y, p=1)
-            assert math.isclose(dist1, 3.0, abs_tol=1.5e-7)
+            xp_assert_close(dist1, xp.asarray(3.0), atol=1.5e-7)
             dist1p5 = minkowski(x, y, p=1.5)
-            assert math.isclose(dist1p5, (1.0 + 2.0**1.5)**(2. / 3), abs_tol=1.5e-7)
+            xp_assert_close(dist1p5, xp.asarray((1.0 + 2.0**1.5)**(2. / 3)), atol=1.5e-7)
             dist2 = minkowski(x, y, p=2)
-            assert math.isclose(dist2, 5.0 ** 0.5, abs_tol=1.5e-7)
+            xp_assert_close(dist2, xp.asarray(5.0 ** 0.5), atol=1.5e-7)
             dist0p25 = minkowski(x, y, p=0.25)
-            assert math.isclose(dist0p25, (1.0 + 2.0 ** 0.25) ** 4, abs_tol=1.5e-7)
+            xp_assert_close(dist0p25, xp.asarray((1.0 + 2.0 ** 0.25) ** 4), atol=1.5e-7)
 
         # Check that casting input to minimum scalar type doesn't affect result
         # (issue #10262). This could be extended to more test inputs with
         # np.min_scalar_type(np.max(input_matrix)).
-        a = np.array([352, 916])
-        b = np.array([350, 660])
+        a = xp.asarray([352, 916])
+        b = xp.asarray([350, 660])
         xp_assert_equal(minkowski(a, b),
-                     minkowski(a.astype('uint16'), b.astype('uint16')))
+                        minkowski(xp.astype(a, xp.uint16), xp.astype(b, xp.uint16)))
 
     def test_euclidean(self):
         for x, y in self.cases:
@@ -1815,13 +1818,14 @@ class TestIsValidY:
         return y
 
 
+@make_xp_test_case(minkowski)
 @pytest.mark.parametrize("p", [-10.0, -0.5, 0.0])
-def test_bad_p(p):
+def test_bad_p(xp, p):
     # Raise ValueError if p <=0.
     with pytest.raises(ValueError):
-        minkowski([1, 2], [3, 4], p)
+        minkowski(xp.asarray([1, 2]), xp.asarray([3, 4]), p)
     with pytest.raises(ValueError):
-        minkowski([1, 2], [3, 4], p, [1, 1])
+        minkowski(xp.asarray([1, 2]), xp.asarray([3, 4]), p, xp.asarray([1, 1]))
 
 
 def test_sokalsneath_all_false():
@@ -1996,16 +2000,21 @@ def test_Xdist_non_negative_weights(metric):
             cdist(X, X, m, w=w)
 
 
-def test__validate_vector():
-    x = [1, 2, 3]
+@pytest.mark.uses_xp_capabilities(False)
+def test_validate_vector(xp):
+    x = [1, 2, 3]  # Check list inputs are converted to arrays
+    y = _validate_vector(x)
+    xp_assert_equal(y, np.asarray(x), xp=array_namespace(np.empty(0)))
+
+    x = xp.asarray([1, 2, 3])
     y = _validate_vector(x)
     xp_assert_equal(y, x)
 
-    y = _validate_vector(x, dtype=np.float64)
-    xp_assert_equal(y, np.asarray(x, dtype=np.float64))
-    assert y.dtype == np.float64
+    y = _validate_vector(x, dtype=xp.float64)
+    xp_assert_equal(y, xp.asarray([1, 2, 3], dtype=xp.float64))
+    assert y.dtype == xp.float64
 
-    x = [1]
+    x = xp.asarray([1])
     y = _validate_vector(x)
     assert y.ndim == 1
     xp_assert_equal(y, x)
@@ -2014,13 +2023,26 @@ def test__validate_vector():
     with pytest.raises(ValueError, match="Input vector should be 1-D"):
         _validate_vector(x)
 
-    x = np.arange(5).reshape(1, -1, 1)
+    x = xp.reshape(xp.arange(5), (1, -1, 1))
     with pytest.raises(ValueError, match="Input vector should be 1-D"):
         _validate_vector(x)
 
     x = [[1, 2], [3, 4]]
     with pytest.raises(ValueError, match="Input vector should be 1-D"):
         _validate_vector(x)
+
+@pytest.mark.uses_xp_capabilities(False)
+def test_validate_weights(xp):
+    w = xp.asarray([1.0, -1.0, 2.0])
+    if is_lazy_array(w):  # Lazy backends return NaN for a negative weight
+        assert xp.all(xp.isnan(_validate_weights(w)))
+    else:  # Eager backends raise on a negative weight
+        with pytest.raises(ValueError, match="non-negative"):
+            _validate_weights(w)
+    # valid weights pass through unchanged on every backend
+    xp_assert_close(_validate_weights(xp.asarray([1.0, 2.0, 3.0])),
+                    xp.asarray([1.0, 2.0, 3.0]))
+
 
 def test_yule_all_same():
     # Test yule avoids a divide by zero when exactly equal

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -61,6 +61,7 @@ from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     sokalsneath, sqeuclidean, yule)
 from scipy._lib._util import _apply_over_batch
 from scipy.conftest import skip_xp_invalid_arg
+from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import make_xp_test_case, is_lazy_array, array_namespace
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
@@ -1446,9 +1447,10 @@ class TestSomeDistanceFunctions:
 
     @make_xp_test_case(minkowski)
     def test_minkowski(self, xp):
+        dtype = xpx.default_dtype(xp)
         atol = 1.5e-7
         for x, y in self.cases:
-            x, y = xp.asarray(x), xp.asarray(y)
+            x, y = xp.asarray(x, dtype=dtype), xp.asarray(y, dtype=dtype)
             dist1 = minkowski(x, y, p=1)
             xp_assert_close(dist1, xp.asarray(3.0), atol=atol)
             dist1p5 = minkowski(x, y, p=1.5)

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1099,7 +1099,7 @@ def test_mean_axis(xp, ndim: int):
     desired = xp.full(axes.shape[:-2], 0.0)
     if ndim == 1:
         desired = desired[()]
-    atol = 1e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
+    atol = 1.5e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
     xp_assert_close(tf.mean(axis=-1).rotation.magnitude(), desired, atol=atol)
 
     # Test tuple axes

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1363,7 +1363,7 @@ def test_mean_axis(xp, ndim: int):
     desired = xp.full(axes.shape[:-2], 0.0)
     if ndim == 1:
         desired = desired[()]
-    atol = 1e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
+    atol = 1.5e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
     xp_assert_close(r.mean(axis=-1).magnitude(), desired, atol=atol)
 
     # Test tuple axes

--- a/tach.toml
+++ b/tach.toml
@@ -128,7 +128,7 @@ depends_on = ["scipy", "scipy._lib", "scipy.linalg", "scipy.spatial.distance", "
 
 [[modules]]
 path = "scipy.spatial.distance"
-depends_on = ["scipy._lib", "scipy.linalg", "scipy.spatial", "scipy.special", "scipy._external"]
+depends_on = ["scipy._lib", "scipy.spatial", "scipy.special", "scipy._external"]
 
 [[modules]]
 path = "scipy.spatial.transform"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
Some tests got flaky with the improved implementation according to @j-bowhay (see e.g. https://github.com/scipy/scipy/actions/runs/30793275799/job/91621280363?pr=25728). I can't reproduce this locally, but it might be prudent to raise the tolerances.

### Reference issue
Related to PR #25724

### What does this implement/fix?
Raise tolerances for `test_mean_along_axis` from `1e-6` to `1.5e-6`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
