### PR TITLE
TST: spatial.transform: update float32 test tolerances

### DIFF
--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1099,7 +1099,7 @@ def test_mean_axis(xp, ndim: int):
     desired = xp.full(axes.shape[:-2], 0.0)
     if ndim == 1:
         desired = desired[()]
-    atol = 1e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
+    atol = 1.5e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
     xp_assert_close(tf.mean(axis=-1).rotation.magnitude(), desired, atol=atol)
 
     # Test tuple axes

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1363,7 +1363,7 @@ def test_mean_axis(xp, ndim: int):
     desired = xp.full(axes.shape[:-2], 0.0)
     if ndim == 1:
         desired = desired[()]
-    atol = 1e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
+    atol = 1.5e-6 if xpx.default_dtype(xp) is xp.float32 else 1e-10
     xp_assert_close(r.mean(axis=-1).magnitude(), desired, atol=atol)
 
     # Test tuple axes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
Some tests got flaky with the improved implementation according to @j-bowhay (see e.g. https://github.com/scipy/scipy/actions/runs/30793275799/job/91621280363?pr=25728). I can't reproduce this locally, but it might be prudent to raise the tolerances.

### Reference issue
Related to PR #25724

### What does this implement/fix?
Raise tolerances for `test_mean_along_axis` from `1e-6` to `1.5e-6`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
