### PR TITLE
DOC/DEV: update special ufunc contributor guide for XSF machinery

### DIFF
--- a/doc/source/dev/api-dev/special_ufuncs.rst
+++ b/doc/source/dev/api-dev/special_ufuncs.rst
@@ -18,7 +18,7 @@ write a C wrapper around the code; for examples of such wrappers see
 ``specfun_wrappers.c``.
 
 After implementing the scalar function, register the new function by
-adding an entry to ``functions.json``. The docstring in
+adding an entry to ``XSF ufunc machinery in special_ufuncs.cpp``. The docstring in
 ``generate_ufuncs.py`` explains the format. Also add documentation for
 the new function by adding an entry to ``add_newdocs.py``; look in the
 file for examples.


### PR DESCRIPTION
#### Reference issue

This PR fixes the documentation issue reported in #25792: corrects `functions.json` to `XSF ufunc machinery in special_ufuncs.cpp` in `doc/source/dev/api-dev/special_ufuncs.rst`.

Fixes #25792

#### What does this implement/fix?

#### Additional information

#### AI Generation Disclosure

Fixes #25792