### PR TITLE
TST: signal: unskip filtfilt/sosfiltfilt torch tests

### DIFF
--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -339,7 +339,6 @@ capabilities_overrides = {
                 "sosfiltfilt directly sets shape attributes on arrays"
                 " which dask doesn't like"
             ),
-            ("torch", "negative strides"),
         ],
     ),
     "sosfreqz": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2839,14 +2839,12 @@ class _TestFiltFilt:
             sos = xp.asarray(sos)
             return sosfiltfilt(sos, x, axis, padtype, padlen)
 
-    @skip_xp_backends('torch', reason='negative strides')
     def test_basic(self, xp):
         zpk = tf2zpk(xp.asarray([1., 2, 3]), xp.asarray([1., 2, 3]))
         out = self.filtfilt(zpk, xp.arange(12), xp=xp)
         atol= 4e-9 if is_cupy(xp) else 5.28e-11
         xp_assert_close(out, xp.arange(12, dtype=xp.float64), atol=atol)
 
-    @skip_xp_backends('torch', reason='negative strides')
     def test_sine(self, xp):
         rate = 2000
         t = xp.linspace(0, 1.0, rate + 1)
@@ -2857,7 +2855,7 @@ class _TestFiltFilt:
 
         zpk = butter(8, xp.asarray(0.125), output='zpk')
         # r is the magnitude of the largest pole.
-        r = np.abs(zpk[1]).max()
+        r = float(xp.max(xp.abs(zpk[1])))
         eps = 1e-5
         # n estimates the number of steps for the
         # transient to decay by a factor of eps.
@@ -2866,14 +2864,14 @@ class _TestFiltFilt:
         # High order lowpass filter...
         y = self.filtfilt(zpk, x, padlen=n, xp=xp)
         # Result should be just xlow.
-        err = np.abs(y - xlow).max()
+        err = float(xp.max(xp.abs(y - xlow)))
         assert err < 1e-4
 
         # A 2D case.
-        x2d = xp.asarray(np.vstack([xlow, xlow + xhigh]))
+        x2d = xp.stack((xlow, xlow + xhigh))
         y2d = self.filtfilt(zpk, x2d, padlen=n, axis=1, xp=xp)
         assert y2d.shape == x2d.shape
-        err = np.abs(y2d - xlow).max()
+        err = float(xp.max(xp.abs(y2d - xlow)))
         assert err < 1e-4
 
         # Use the previous result to check the use of the axis keyword.
@@ -2881,7 +2879,6 @@ class _TestFiltFilt:
         y2dt = self.filtfilt(zpk, x2d.T, padlen=n, axis=0, xp=xp)
         xp_assert_equal(y2d, y2dt.T)
 
-    @skip_xp_backends('torch', reason='negative strides')
     def test_axis(self, xp):
         # Test the 'axis' keyword on a 3D array.
         x = np.arange(10.0 * 11.0 * 12.0).reshape(10, 11, 12)
@@ -2939,7 +2936,6 @@ class TestFiltFilt(_TestFiltFilt):
 class TestSOSFiltFilt(_TestFiltFilt):
     filtfilt_kind = 'sos'
 
-    @skip_xp_backends('torch', reason='negative strides')
     def test_equivalence(self, xp):
         """Test equivalence between sosfiltfilt and filtfilt"""
         x_np = np.random.RandomState(0).randn(1000)
@@ -2949,7 +2945,9 @@ class TestSOSFiltFilt(_TestFiltFilt):
             b, a = zpk2tf(*zpk)
             sos = zpk2sos(*zpk)
 
-            y = filtfilt(b, a, x_np)
+            # copy: NumPy filtfilt output has negative strides, which torch
+            # cannot convert (pytorch/pytorch#59786)
+            y = filtfilt(b, a, x_np).copy()
             b, a, sos, y = map(xp.asarray, (b, a, sos, y))
             y_sos = sosfiltfilt(sos, x)
             xp_assert_close(y, y_sos, atol=1e-12, err_msg=f'order={order}')


### PR DESCRIPTION
The stride copies in `filtfilt`'s gust/no-edge paths and in `sosfiltfilt` (see PR gh-25746, search for `is_torch(xp)` in its diff) fixed `test_basic` and `test_axis` on `torch` for both the tf and sos variants, and made the capabilities-table skip for `sosfiltfilt` inaccurate; remove those skips.

The two remaining torch skips were test-code artifacts, not library bugs: `test_sine` applied NumPy ufuncs to backend arrays and `test_equivalence` converted the negative-stride NumPy `filtfilt` output to torch.

Note: this is technically not default-device related, more an opportunity to clean up some skips that fell out of it, that's why this is a separate PR.

#### AI Generation Disclosure

I worked on the complete branch of fixes and development of a linter and testing with the PyTorch 'meta' device (see https://github.com/scipy/scipy/pull/25578) with heavy use of Claude Fable 5. This PR is derived from that one, re-reviewed and polished by hand.
