### PR TITLE
meson: skip GNU version script when using NAG Fortran compiler

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,7 +140,7 @@ add_global_arguments(_intel_cflags, language: ['c', 'cpp'])
 # Meson using `-fvisibility=hidden` for C and `-fvisibility-inlines-hidden` for
 # C++ code. See gh-15996 for details.
 version_link_args = []
-if cc.get_id() != 'clang-cl'
+if cc.get_id() != 'clang-cl' and ff.get_id() != 'nagfor'
   _linker_script = meson.project_source_root() / 'tools/building/link-version-pyinit.map'
   vscript_link_args = ['-Wl,--version-script=' + _linker_script]
   # Note that FreeBSD only accepts version scripts when -shared is passed,


### PR DESCRIPTION
NAG's linker driver forwards linker flags to GCC without the -Wl, prefix, so the raw --version-script= flag reaches the linker directly and causes the build to fail.

Extend the existing clang-cl exclusion to also skip the version-script block when the Fortran compiler is nagfor.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #25803 

#### What does this implement/fix?

NAG's Fortran compiler (`nagfor`) uses a linker driver that forwards flags to GCC without wrapping them in `-Wl,`. This means the `--version-script=` flag constructed on line 145 is passed directly to the linker rather than through the compiler driver, causing the link step to fail with an unrecognized flag error.

The fix mirrors the existing `clang-cl` exclusion introduced in #23313 — both are compiler toolchains whose linker drivers cannot handle this GNU-style flag. With this change, `version_link_args` remains empty when building with `nagfor`, consistent with the `clang-cl` behavior.

#### Additional information

I'm making a PR to the spack-packages (https://github.com/spack/spack-packages) package for py-scipy to enable NAG compiler support there as well.


#### AI Generation Disclosure

This fix was identified and developed with AI assistance (OpenCode/GPT 5.6 Terra). The one-line change and PR description were reviewed and verified by the author.
