### PR TITLE
MAINT: signal.normalize: fix typo in error message

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1935,7 +1935,7 @@ def normalize(b, a):
         raise ValueError("Numerator polynomial must be rank-1 or"
                          " rank-2 array.")
     if xp.all(den == 0):
-        raise ValueError("Denominator must have at least on nonzero element.")
+        raise ValueError("Denominator must have at least one nonzero element.")
 
     # Trim leading zeros in denominator, leave at least one.
     den = _pu._trim_zeros(den, 'f')


### PR DESCRIPTION
#### Reference issue

Closes gh-25799.

#### What does this implement/fix?

Fixes a typo in the `ValueError` message raised by `scipy.signal.normalize`
in `scipy/signal/_filter_design.py`. When the denominator contains no nonzero
elements the message read:

> Denominator must have at least on nonzero element.

The word "on" is corrected to "one":

> Denominator must have at least one nonzero element.

#### Additional information

Documentation-only string change. No behavior change, no tests reference the
message string, so no test or release-note updates are needed.

#### AI Generation Disclosure

This PR was prepared with Claude Code. The tool identified the typo from the
linked issue, made the one-character source change, and drafted this PR
description. All changes were reviewed by me before submission.
