### PR TITLE
CI: Skip redirector icon on no-artifact

### DIFF
--- a/.github/circle-artifacts.yml
+++ b/.github/circle-artifacts.yml
@@ -1,3 +1,4 @@
 artifact-path: 0/html/index.html
 circleci-jobs: build_docs
 job-title: Check the rendered docs here!
+no-artifact-state: skip


### PR DESCRIPTION
@lucascolley as requested... will only take effect once merged into `main`.