### PR TITLE
TST: special: fix mpmath branch selection in test_legenq

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1642,16 +1642,19 @@ class TestSystematic:
             [IntArg(), FixedArg(np.logspace(-30, -4, 20))],
         )
 
-    @pytest.mark.xfail(run=False, reason="apparently picks wrong function at |z| > 1")
     def test_legenq(self):
         def lqnm(n, m, z):
             return sc.lqmn(m, n, z)[0][-1,-1]
 
         def legenq(n, m, z):
-            if abs(z) < 1e-15:
+            if abs(z) < 1e-15 or abs(abs(z) - 1.0) < 1e-6:
                 # mpmath has bad performance here
                 return np.nan
-            return exception_to_nan(mpmath.legenq)(n, m, z, type=2)
+            tp = 2 if abs(z) < 1 else 3
+            val = exception_to_nan(mpmath.legenq)(n, m, z, type=tp)
+            if tp == 3 and np.isreal(z) and z < -1:
+                val = (-1)**m * val
+            return val
 
         assert_mpmath_equal(
             lqnm,
@@ -1659,16 +1662,19 @@ class TestSystematic:
             [IntArg(0, 100), IntArg(0, 100), Arg()],
         )
 
-    @nonfunctional_tooslow
     def test_legenq_complex(self):
         def lqnm(n, m, z):
             return sc.lqmn(int(m.real), int(n.real), z)[0][-1,-1]
 
         def legenq(n, m, z):
-            if abs(z) < 1e-15:
+            if abs(z) < 1e-15 or abs(abs(z) - 1.0) < 1e-6:
                 # mpmath has bad performance here
                 return np.nan
-            return exception_to_nan(mpmath.legenq)(int(n.real), int(m.real), z, type=2)
+            tp = 2 if abs(z) < 1 else 3
+            val = exception_to_nan(mpmath.legenq)(int(n.real), int(m.real), z, type=tp)
+            if tp == 3 and z.real < -1:
+                val = (-1)**int(m.real) * val
+            return val
 
         assert_mpmath_equal(
             lqnm,


### PR DESCRIPTION
#### Reference issue
Closes gh-25815

#### What does this implement/fix?
`test_legenq` was permanently skipped via `@pytest.mark.xfail(run=False)` and
`test_legenq_complex` was skipped via `@nonfunctional_tooslow`. Both used
`mpmath.legenq(..., type=2)` for all `z`, which is only correct for `|z| < 1`
(Legendre Q on the real cut `(-1, 1)`). For `|z| > 1`, `type=3` is required.

Select the correct mpmath branch based on `|z|`:
- `type=2` for `|z| < 1` — Legendre Q on the cut
- `type=3` for `|z| > 1` — Legendre Q off the cut (C minus [-1, 1])

For real `z < -1`, `mpmath` `type=3` differs from `scipy.special.lqmn` by a
sign factor `(-1)^m`, which is applied explicitly. Points near `|z| = 1`
(within `1e-6`) are excluded due to mpmath's poor convergence near the
branch-point singularity.

**Tests changed**

- `test_legenq`: removed `@pytest.mark.xfail(run=False)`, updated reference to use correct mpmath type
- `test_legenq_complex`: removed `@nonfunctional_tooslow`, updated reference similarly

**Validation**

- **Real** — 500 random `(n, m, z)` triples, `n,m in [0,100]`, `z in R`: PASSED
- **Complex** — 50 triples, `n,m in [0,10]`, `z in C`: PASSED

Direct spot-checks confirmed `lqmn` values are correct; the test was comparing against the wrong mpmath branch, not computing wrong values.

#### Additional information
Highest-risk line:
```python
if tp == 3 and np.isreal(z) and z < -1:
    val = (-1)**m * val
```
Parity factor `(-1)^m` verified empirically for `n,m in [0,9]^2` across `z in {+/-1.0001, +/-2.5, +/-10}` — all matched `scipy.special.lqmn` to < 1e-9 absolute error.

#### AI Generation Disclosure
AI tools (Google Deepmind's internal coding assistant, Antigravity) were used to assist in debugging the `test_legenq` test failures and discovering the correct `mpmath` branch cuts and sign parity (`(-1)^m`) necessary for `|z| > 1`. The AI assistant wrote the initial fix for the test helper function and drafted this PR description under human guidance and review. All changes were subsequently reviewed and verified by a human developer.
