### PR TITLE
BUG: Check `mdtype` index in MATLAB Parser

### DIFF
--- a/scipy/io/matlab/_mio5_utils.pyx
+++ b/scipy/io/matlab/_mio5_utils.pyx
@@ -167,6 +167,15 @@ cdef class VarReader5:
         int squeeze_me
         int chars_as_strings
 
+    cdef inline cnp.dtype _dtype_from_mdtype(self, cnp.uint32_t mdtype) except *:
+        cdef PyObject* dt_obj
+        if mdtype >= _N_MIS:
+            raise ValueError("Invalid MATLAB data type code %d" % mdtype)
+        dt_obj = self.dtypes[mdtype]
+        if dt_obj == NULL:
+            raise ValueError("Unsupported MATLAB data type code %d" % mdtype)
+        return <cnp.dtype><object>dt_obj
+
     def __cinit__(self, preader):
         byte_order = preader.byte_order
         self.is_swapped = byte_order == swapped_code
@@ -445,7 +454,7 @@ cdef class VarReader5:
         cdef cnp.ndarray el
         cdef object data = self.read_element(
             &mdtype, &byte_count, <void **>&data_ptr, copy)
-        cdef cnp.dtype dt = <cnp.dtype>self.dtypes[mdtype]
+        cdef cnp.dtype dt = self._dtype_from_mdtype(mdtype)
         if dt.itemsize != 1 and nnz != -1 and byte_count == nnz:
             el_count = <cnp.npy_intp> nnz
             dt = BOOL_DTYPE

--- a/scipy/io/matlab/tests/test_mio5_utils.py
+++ b/scipy/io/matlab/tests/test_mio5_utils.py
@@ -149,6 +149,21 @@ def test_read_numeric_writeable():
     assert_(el.flags.writeable is True)
 
 
+def test_read_numeric_invalid_mdtype():
+    # gh-25829: invalid mdtype in tag should raise ValueError, not crash
+    str_io = BytesIO()
+    r = _make_readerlike(str_io, '<')
+    c_reader = m5u.VarReader5(r)
+    tag_dt = np.dtype([('mdtype', '<u4'), ('byte_count', '<u4'),
+                       ('val', '<u2'), ('padding', 'u1', 6)])
+    tag = np.zeros((1,), dtype=tag_dt)
+    tag['mdtype'] = 99
+    tag['byte_count'] = 2
+    tag['val'] = 1
+    _write_stream(str_io, tag.tobytes())
+    assert_raises(ValueError, c_reader.read_numeric)
+
+
 def test_zero_byte_string():
     # Tests hack to allow chars of non-zero length, but 0 bytes
     # make reader-like thing


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Fix a crash that is reproducible through:

```
from io import BytesIO
import numpy as np
import scipy.io.matlab._mio5_utils as m5u
class R: pass
r = R()
r.mat_stream = BytesIO()
r.byte_order = '<'
r.struct_as_record = True
r.uint16_codec = 'utf-8'
r.chars_as_strings = False
r.mat_dtype = False
r.squeeze_me = False
vr = m5u.VarReader5(r)
byte_count=1
tag = np.array([(8, 1)], dtype=[('mdtype','<u4'),
('byte_count','<u4')]).tobytes()
payload = b'\x00' + b'\x00'*7
r.mat_stream = BytesIO(tag + payload)
vr.set_stream(r.mat_stream)

vr.read_numeric()
```

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
Found by AISLE in partnership with Red Hat
Co-Authored-By: Claude <noreply@anthropic.com>