### PR TITLE
DOC: stats: fix typo for Chi-squared distribution tutorial documentation

### DIFF
--- a/doc/source/tutorial/stats/continuous_chi2.rst
+++ b/doc/source/tutorial/stats/continuous_chi2.rst
@@ -6,7 +6,7 @@ Chi-squared Distribution
 
 This is the gamma distribution with :math:`L=0.0` and :math:`S=2.0` and :math:`\alpha=\nu/2` where :math:`\nu` is called the degrees of freedom. If :math:`Z_{1}, \ldots, Z_{\nu}` are all standard normal distributions, then :math:`W=\sum_{k}Z_{k}^{2}` has (standard) chi-square distribution with :math:`\nu` degrees of freedom.
 
-The standard form (most often used in standard form only) has support :math:`x\geq0`.
+The standard form has support :math:`x\geq0`.
 
 .. math::
    :nowrap:
@@ -15,7 +15,11 @@ The standard form (most often used in standard form only) has support :math:`x\g
     F\left(x;\alpha\right) & = & \frac{\gamma\left(\frac{\nu}{2},\frac{x}{2}\right)}{\Gamma(\frac{\nu}{2})}\\
     G\left(q;\alpha\right) & = & 2\gamma^{-1}\left(\frac{\nu}{2},q{\Gamma(\frac{\nu}{2})}\right)\end{eqnarray*}
 
-where :math:`\gamma` is the lower incomplete gamma function, :math:`\gamma\left(s, x\right) = \int_0^x t^{s-1} e^{-t} dt`.
+where :math:`\gamma` is the lower incomplete gamma function,
+:math:`\gamma\left(s, x\right) = \int_0^x t^{s-1} e^{-t} dt`. For fixed
+:math:`s`, :math:`\gamma^{-1}\left(s, y\right)` denotes the inverse with
+respect to :math:`x`; that is,
+:math:`\gamma\left(s, \gamma^{-1}\left(s, y\right)\right) = y`.
 
 .. math::
 
@@ -28,6 +32,6 @@ where :math:`\gamma` is the lower incomplete gamma function, :math:`\gamma\left(
     \mu_{2} & = & 2\nu\\
     \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\
     \gamma_{2} & = & \frac{12}{\nu}\\
-    m_{d} & = & \frac{\nu}{2}-1\end{eqnarray*}
+    m_{d} & = & \max\left(\nu - 2, 0\right)\end{eqnarray*}
 
 Implementation: `scipy.stats.chi2`


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
While reviewing https://github.com/scipy/scipy/pull/25819, I found a typo for the mode of the chi2 distribution. See the [Wikipedia](https://en.wikipedia.org/wiki/Chi-squared_distribution) reference for the formula.

This PR also clarifies the notation $\gamma^{-1}$.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to review what I did.