### PR TITLE
TST: signal: convert test to array api and clean-up array-like test

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2334,8 +2334,7 @@ class TestLinearFilterComplexExtended(_TestLinearFilter):
     dtype = np.dtype('G')
 
 
-@make_xp_test_case(lfilter)
-def test_lfilter_bad_object(xp):
+def test_lfilter_bad_object():  # array-like is np-only
     # lfilter: object arrays with non-numeric objects raise TypeError.
     # Regression test for ticket #1452.
     if hasattr(sys, 'abiflags') and 'd' in sys.abiflags:
@@ -2345,22 +2344,22 @@ def test_lfilter_bad_object(xp):
     assert_raises(TypeError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
 
 
-@make_xp_test_case(lfilter)
-def test_lfilter_notimplemented_input(xp):
+def test_lfilter_notimplemented_input():  # array-like input is np-only
     # Should not crash, gh-7991
     assert_raises(NotImplementedError, lfilter, [2,3], [4,5], [1,2,3,4,5])
 
 
-def test_lfilter_empty_input():
+@make_xp_test_case(lfilter)
+def test_lfilter_empty_input(xp):
     """Verify that unchanged `zi` is returned for an empty input `x`
 
     This test ensures correct special handling for empty inputs,
     to prevent leaking internal state as reported in gh-22571.
     """
-    b = np.array([1.0, 0.5])
-    a = np.array([1.0, -0.5])
-    x = np.array([])
-    zi = np.array([0.25])
+    b = xp.asarray([1.0, 0.5])
+    a = xp.asarray([1.0, -0.5])
+    x = xp.asarray([])
+    zi = xp.asarray([0.25])
 
     y, zf = lfilter(b, a, x, zi=zi)
     assert y.shape == (0,)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Converts test from #25334 to array api. Removes `xp` fixture from test which uses an array-like (thus np only) input.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI