### PR TITLE
BUG: Adding shape zero case in `convolve` and `convolve_z`

### DIFF
--- a/scipy/fftpack/convolve.pyx
+++ b/scipy/fftpack/convolve.pyx
@@ -48,6 +48,8 @@ def convolve(inout, omega, swap_real_imag=False, overwrite_x=False):
     if X_arr.ndim != 1 or w.ndim != 1 or w.shape[0] != n:
         raise ValueError(
             "inout and omega must be 1-dimensional arrays of the same length")
+    if n == 0:
+        return X_arr
 
     r2r_fftpack(X_arr, None, True, True, out=X_arr)
 
@@ -107,6 +109,8 @@ def convolve_z(inout, omega_real, omega_imag, overwrite_x=False):
         or wi.ndim != 1 or wi.shape[0] != n):
         raise ValueError(
             "inout and omega must be 1-dimensional arrays of the same length")
+    if n == 0:
+        return X_arr
 
     r2r_fftpack(X_arr, None, True, True, out=X_arr)
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -5,6 +5,7 @@ from numpy.testing import (assert_, assert_equal, assert_array_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 from scipy.fftpack import ifft, fft, fftn, ifftn, rfft, irfft, fft2
+from scipy.fftpack import convolve
 
 from numpy import (arange, array, asarray, zeros, dot, exp, pi,
                    swapaxes, double, cdouble)
@@ -875,3 +876,11 @@ def test_shape_axes_ndarray(func):
     expect = func(a, shape=(4, 7), axes=(1, 0))
     actual = func(a, shape=np.array([4, 7]), axes=np.array([1, 0]))
     assert_equal(expect, actual)
+
+
+def test_gh_25849():
+    actual = convolve.convolve_z(np.zeros(0), np.zeros(0), np.zeros(0))
+    assert_equal(actual, np.asarray([]))
+
+    actual = convolve.convolve(np.zeros(0), np.zeros(0), swap_real_imag=True)
+    assert_equal(actual, np.asarray([]))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Fixes: #25849 

#### What does this implement/fix?
<!--Please explain your changes.-->

Return early if n == 0

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Fixes were made by Claude code (model: Sonnet 5)
