### PR TITLE
BUG: optimize.curve_fit handle 1x1 covariance in single-point fix

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -538,7 +538,7 @@ def _wrap_func(func, xdata, ydata, transform):
     if transform is None:
         def func_wrapped(params):
             return func(xdata, *params) - ydata
-    elif transform.size == 1 or transform.ndim == 1:
+    elif transform.ndim == 0 or transform.ndim == 1:
         def func_wrapped(params):
             return transform * (func(xdata, *params) - ydata)
     else:
@@ -559,6 +559,9 @@ def _wrap_jac(jac, xdata, transform):
     if transform is None:
         def jac_wrapped(params):
             return jac(xdata, *params)
+    elif transform.ndim == 0:
+        def jac_wrapped(params):
+            return transform * np.asarray(jac(xdata, *params))
     elif transform.ndim == 1:
         def jac_wrapped(params):
             return transform[:, np.newaxis] * np.asarray(jac(xdata, *params))
@@ -992,12 +995,15 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
             transform = 1.0 / sigma
         # if 2-D, sigma is the covariance matrix,
         # define transform = L such that L L^T = C
-        elif sigma.shape == (ydata.size, ydata.size):
+        if sigma.shape == (ydata.size, ydata.size):
             try:
                 # scipy.linalg.cholesky requires lower=True to return L L^T = A
                 transform = cholesky(sigma, lower=True)
             except LinAlgError as e:
                 raise ValueError("`sigma` must be positive definite.") from e
+        # if 1-D or a scalar, sigma are errors, define transform = 1/sigma
+        elif sigma.size == 1 or sigma.shape == (ydata.size,):
+            transform = 1.0 / sigma
         else:
             raise ValueError("`sigma` has incorrect shape.")
     else:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -962,6 +962,52 @@ class TestCurveFit:
         )
         assert np.all(pcov1 == pcov2)
 
+    def test_curvefit_two_points_matrix_covariance(self):
+        def fit_f(x, par, off):
+            return par*x**2 + off
+
+        ys = np.array([144.0, 300.0])
+        ys_cov = np.array([[4.0, 1.0], [1.0, 10.0]])
+        xs = np.array([3.0, 6.0])
+        p0 = (3.0, 0.0)
+
+        popt, pcov = curve_fit(fit_f, xs, ys, p0=p0, sigma=ys_cov,
+                               absolute_sigma=True)
+
+        assert_(popt.shape == (2,))
+        assert_(pcov.shape == (2, 2))
+
+    def test_curvefit_single_point_matrix_covariance(self):
+        def fit_f(x, par):
+            return par*x**2
+
+        ys = np.array([144.0])
+        ys_cov = np.array([[4.0]])
+        xs = np.array([3.0])
+        p0 = (3.0,)
+
+        popt, pcov = curve_fit(fit_f, xs, ys, p0=p0, sigma=ys_cov,
+                               absolute_sigma=True)
+
+        assert_allclose(popt, [16.0])
+        assert_allclose(pcov[0, 0], 0.04938272)
+
+    def test_curvefit_single_point_vector_covariance(self):
+        def fit_f(x, par):
+            return par*x**2
+
+        ys = np.array([144.0])
+        ys_cov = np.array([[4.0]])
+        xs = np.array([3.0])
+        p0 = (3.0,)
+
+        popt, pcov = curve_fit(fit_f, xs, ys, p0=p0,
+                               sigma=np.sqrt(ys_cov[0]),
+                               absolute_sigma=True)
+
+        assert_allclose(popt, [16.0])
+        assert_allclose(pcov[0, 0], 0.04938272)
+
     def test_dtypes(self):
         # regression test for gh-9581: curve_fit fails if x and y dtypes differ
         x = np.arange(-3, 5)


### PR DESCRIPTION
#### Reference issue
Closes gh-22377. 

#### What does this implement/fix?
Fixes a regression in `optimize.curve_fit` for the edge case of one free parameter, one data point, and a 1x1 covariance matrix. 
This change makes sure that a 1x1 matrix follows the covariance path instead of being treated like scalar weights(meaning that single-point fits now follow the same behavior as other covariance-based fits). 

#### Additional information
Added tests that cover two-point fit with 2x2 covariance, single-point fit with 1x1 covariance, single-point fit with equivalent 1D sigma, and equivalence check between matrix and vector sigma forms. 

#### AI Generation Disclosure
I used Github Copilot for helping me find relevant files and understanding context. Everything else was done and verified manually by me.
