### PR TITLE
DOC: clarify median and mode notation in continuous stats tutorial

### DIFF
--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -83,19 +83,19 @@ so that a normal distribution has a kurtosis of zero.
 Median and mode
 ---------------
 
-The median, :math:`m_{n}` is defined as the point at which half of the density is on one side
-and half on the other. In other words, :math:`F\left(m_{n}\right)=\frac{1}{2}` so that
+The median, :math:`x_{\mathrm{median}}` is defined as the point at which half of the density is on one side
+and half on the other. In other words, :math:`F\left(x_{\mathrm{median}}\right)=\frac{1}{2}` so that
 
 .. math::
 
-     m_{n}=G\left(\frac{1}{2}\right).
+     x_{\mathrm{median}}=G\left(\frac{1}{2}\right).
 
-In addition, the mode, :math:`m_{d}`, is defined as the value for which the probability density function
+In addition, the mode, :math:`x_{\mathrm{mode}}`, is defined as the value for which the probability density function
 reaches its peak
 
 .. math::
 
-     m_{d}=\arg\max_{x}f\left(x\right).
+     x_{\mathrm{mode}}=\arg\max_{x}f\left(x\right).
 
 
 Fitting data


### PR DESCRIPTION
Replaces confusing notation for median (m_n) and mode (m_d) with clearer x_median/x_mode notation in the continuous distributions tutorial.

Closes #25831
