### PR TITLE
DOC: clarify ndimage convolve/correlate weights are the kernel

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1331,7 +1331,7 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
     ----------
     %(input)s
     weights : ndarray
-        array of weights, same number of dimensions as input
+        The correlation kernel; same number of dimensions as input
     %(output)s
     %(mode_reflect)s
     %(cval)s
@@ -1401,7 +1401,7 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
     ----------
     %(input)s
     weights : array_like
-        Array of weights, same number of dimensions as input
+        The convolution kernel; same number of dimensions as input
     %(output)s
     %(mode_reflect)s
     cval : scalar, optional


### PR DESCRIPTION
Replaces confusing notation for median (m_n) and mode (m_d) with clearer x_median/x_mode notation in the continuous distributions tutorial.

Closes #25831
