### PR TITLE
DOC: clarify SHGO stopping criteria

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -105,18 +105,20 @@ def shgo(
         criteria are met. However, the default algorithm does not require any
         to be specified:
 
-        maxfev : int (L)
+        maxfev : int
             Maximum number of function evaluations in the feasible domain.
-            (Note only methods that support this option will terminate
-            the routine at precisely exact specified value. Otherwise the
-            criterion will only terminate during a global iteration)
+            This limit applies only to global sampling and is not passed to the
+            local minimization routine. The specified value may be exceeded
+            before stopping because the criterion is checked between global
+            iterations.
         f_min : float
             Specify the minimum objective function value, if it is known.
+            Supplying this value enables the ``f_tol`` stopping criterion.
         f_tol : float
-            Precision goal for the value of f in the stopping
-            criterion. Note that the global routine will also
-            terminate if a sampling point in the global routine is
-            within this tolerance.
+            Precision goal used with ``f_min``. This option has no effect unless
+            ``f_min`` is also specified. When both are set, the global routine
+            terminates when a sampling point meets the tolerance around
+            ``f_min``.
         maxiter : int
             Maximum number of iterations to perform.
         maxev : int
@@ -130,9 +132,11 @@ def shgo(
             iteration. The rank of this group has a one-to-one correspondence
             with the number of locally convex subdomains in the objective
             function (after adequate sampling points each of these subdomains
-            contain a unique global minimum). If the difference in the hgr is 0
-            between iterations for ``maxhgrd`` specified iterations the
-            algorithm will terminate.
+            contain a unique global minimum). If the difference in the hgr
+            between iterations is less than or equal to ``minhgrd``, the
+            algorithm will terminate. This criterion is only effective when
+            ``minimize_every_iter`` is True, because the homology group rank is
+            updated from the local minimizer pool.
 
         Objective function knowledge:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-25839, gh-25840, gh-25841, and gh-25842.

#### What does this implement/fix?
<!--Please explain your changes.-->
Clarify four related SHGO option descriptions in one documentation update:

- Remove the incorrect ``(L)`` marker from ``maxfev`` and explain that it applies only to global sampling.
- Document that ``f_tol`` is enabled by, and has no effect without, ``f_min``.
- Correct the ``minhgrd`` stopping-condition wording and document its dependency on ``minimize_every_iter=True``.

#### Additional information
<!--Any additional information you think is important.-->
Validated with:

- ``spin test --no-build scipy/optimize/tests/test__shgo.py`` — 69 passed, 3 skipped, 4 deselected
- ``spin refguide-check --submodule optimize`` — passed
- ``spin lint --diff-against HEAD^ --no-cython`` — passed

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
OpenAI Codex was used to inspect the SHGO implementation, draft the documentation wording, and run the validation commands above. Each statement was verified directly against the corresponding stopping-criterion and iteration code paths.
