### PR TITLE
DOC: mention XSF in special roadmap

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -417,6 +417,11 @@ math implement by a few of the metrics.
 
 special
 ```````
+Development of many special-function implementations now takes place in the
+`XSF project <https://github.com/scipy/xsf>`__, which provides C++ kernels used
+by SciPy. See the `XSF roadmap <https://github.com/scipy/xsf/issues/220>`__ for
+current plans for this work.
+
 Though there are still a lot of functions that need improvements in precision,
 probably the only show-stoppers are hypergeometric functions, parabolic cylinder
 functions, and spheroidal wave functions. Three possible ways to handle this:


### PR DESCRIPTION
#### Reference issue

Closes gh-25820.

#### What does this implement/fix?

Links the XSF project and its roadmap from the `scipy.special` roadmap so readers can find the current plans for special-function implementation work.

#### Additional information

Validation: `rstcheck --report-level warning doc/source/dev/roadmap-detailed.rst` and `git diff --check` both pass.

#### AI Generation Disclosure

OpenAI Codex was used to draft the documentation text and run validation commands. The final text and links were reviewed for accuracy.
