### PR TITLE
DOC: optimize: clarify SHGO `iters` behavior

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -76,7 +76,9 @@ def shgo(
         another specified number of sampling points are generated.
     iters : int, optional
         Number of iterations used in the construction of the simplicial
-        complex. Default is 1.
+        complex. Default is 1. This value is ignored if any of ``maxiter``,
+        ``maxfev``, ``maxev``, ``minhgrd``, or ``f_min`` in ``options`` is set
+        to a value other than ``None``.
     callback : callable, optional
         Called after each iteration, as ``callback(xk)``, where ``xk`` is the
         current parameter vector.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-25843.

#### What does this implement/fix?
<!--Please explain your changes.-->
- Previous `iters` documentation didn't explain that the parameter is ignored when `maxiter`, `maxfev`, `maxev`, `minhgrd`, or `f_min` is not `None`.
- Documents this behavior

#### Additional information
<!--Any additional information you think is important.-->
None
#### AI Generation Disclosure
OpenAI Codex used to help inspect SHGO and run checks.