### PR TITLE
Fix flaky minimize test

### DIFF
--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -15,6 +15,12 @@ from scipy.optimize import (NonlinearConstraint,
                             rosen)
 
 
+def _constr_hess(constr_hess):
+    # HessianUpdateStrategy is stateful, so build a fresh one per `constr` access
+    # rather than sharing one across parametrizations (and threads).
+    return constr_hess() if isinstance(constr_hess, type) else constr_hess
+
+
 class Maratos:
     """Problem 15.4 from Nocedal and Wright
 
@@ -55,7 +61,7 @@ class Maratos:
             def hess(x, v):
                 return 2*v[0]*np.eye(2)
         else:
-            hess = self.constr_hess
+            hess = _constr_hess(self.constr_hess)
 
         return NonlinearConstraint(fun, 1, 1, jac, hess)
 
@@ -109,7 +115,7 @@ class MaratosTestArgs:
             def hess(x, v):
                 return 2*v[0]*np.eye(2)
         else:
-            hess = self.constr_hess
+            hess = _constr_hess(self.constr_hess)
 
         return NonlinearConstraint(fun, 1, 1, jac, hess)
 
@@ -156,7 +162,7 @@ class MaratosGradInFunc:
             def hess(x, v):
                 return 2*v[0]*np.eye(2)
         else:
-            hess = self.constr_hess
+            hess = _constr_hess(self.constr_hess)
 
         return NonlinearConstraint(fun, 1, 1, jac, hess)
 
@@ -202,7 +208,7 @@ class HyperbolicIneq:
                 return 2*v[0]*np.array([[1/(x[0] + 1)**3, 0],
                                         [0, 0]])
         else:
-            hess = self.constr_hess
+            hess = _constr_hess(self.constr_hess)
 
         return NonlinearConstraint(fun, 0.25, np.inf, jac, hess)
 
@@ -440,7 +446,7 @@ class Elec:
                 D = 2 * np.diag(v)
                 return block_diag(D, D, D)
         else:
-            hess = self.constr_hess
+            hess = _constr_hess(self.constr_hess)
 
         return NonlinearConstraint(fun, -np.inf, 0, jac, hess)
 
@@ -448,23 +454,23 @@ class Elec:
 class TestTrustRegionConstr:
     list_of_problems = [Maratos(),
                         Maratos(constr_hess='2-point'),
-                        Maratos(constr_hess=SR1()),
-                        Maratos(constr_jac='2-point', constr_hess=SR1()),
+                        Maratos(constr_hess=SR1),
+                        Maratos(constr_jac='2-point', constr_hess=SR1),
                         MaratosGradInFunc(),
                         HyperbolicIneq(),
                         HyperbolicIneq(constr_hess='3-point'),
-                        HyperbolicIneq(constr_hess=BFGS()),
+                        HyperbolicIneq(constr_hess=BFGS),
                         HyperbolicIneq(constr_jac='3-point',
-                                       constr_hess=BFGS()),
+                                       constr_hess=BFGS),
                         Rosenbrock(),
                         IneqRosenbrock(),
                         EqIneqRosenbrock(),
                         BoundedRosenbrock(),
                         Elec(n_electrons=2),
                         Elec(n_electrons=2, constr_hess='2-point'),
-                        Elec(n_electrons=2, constr_hess=SR1()),
+                        Elec(n_electrons=2, constr_hess=SR1),
                         Elec(n_electrons=2, constr_jac='3-point',
-                             constr_hess=SR1())]
+                             constr_hess=SR1)]
 
     @pytest.mark.parametrize('prob', list_of_problems)
     @pytest.mark.parametrize('grad', ('prob.grad', '3-point', False))


### PR DESCRIPTION
I saw this test flake in https://github.com/scipy/scipy/pull/25847 and had Claude Opus 5 diagnose and draft a fix. TL;DR is that on a single instance of a class has a mutable internal state that can be errantly usued across multiple tests (threads) in `pytest-xdist`. The easy fix is to pass the class (rather than instance) directly, and then instantiate it within the test so that each thread gets its own copy to work with.