### PR TITLE
BUG: optimize.minimize: do not mutate the caller's Bounds object

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -10,6 +10,7 @@ Functions
 __all__ = ['minimize', 'minimize_scalar']
 
 
+import copy
 from warnings import warn
 
 import numpy as np
@@ -1110,6 +1111,7 @@ def _validate_bounds(bounds, x0, meth):
         raise ValueError(msg)
 
     msg = "The number of bounds is not compatible with the length of `x0`."
+    bounds = copy.copy(bounds)  # don't broadcast onto the caller's object
     try:
         bounds.lb = np.broadcast_to(bounds.lb, x0.shape)
         bounds.ub = np.broadcast_to(bounds.ub, x0.shape)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3192,6 +3192,27 @@ def test_bounds_with_list():
     )
 
 
+@pytest.mark.parametrize('method', ('nelder-mead', 'powell', 'l-bfgs-b', 'tnc',
+                                    'slsqp', 'cobyla', 'cobyqa', 'trust-constr'))
+def test_minimize_does_not_mutate_bounds(method):
+    # `minimize` broadcast lb/ub onto the caller's `Bounds`; cf. gh-8419
+    bounds = optimize.Bounds(0., np.inf)
+    lb, ub, keep_feasible = bounds.lb, bounds.ub, bounds.keep_feasible
+    optimize.minimize(optimize.rosen, [0.5, 0.5], method=method, bounds=bounds)
+    assert bounds.lb is lb
+    assert bounds.ub is ub
+    assert bounds.keep_feasible is keep_feasible
+
+
+def test_minimize_bounds_reusable_across_sizes():
+    # consequence of the above: a dimension-agnostic `Bounds` was only usable once
+    bounds = optimize.Bounds(0., np.inf)
+    optimize.minimize(optimize.rosen, [0.5, 0.5], method='trust-constr',
+                      bounds=bounds)
+    optimize.minimize(optimize.rosen, [0.5, 0.5, 0.5], method='trust-constr',
+                      bounds=bounds)
+
+
 @pytest.mark.parametrize('method', (
     'slsqp', 'cg', 'cobyqa', 'powell','nelder-mead', 'bfgs', 'l-bfgs-b',
     'trust-constr'))


### PR DESCRIPTION
While investigating the flaky tests, I hit a speedbump: `bounds` gets modified inplace so a dimension-agnostic `Bounds` can only be used once. The two tests added here (real TDD!) fail on `main` but pass on this PR. In the same class as #8419.

Changes drafted by Claude Opus 5 and reviewed by me, PR text is mine.