### PR TITLE
 BUG: optimize.shgo: reorder `X_min` along with `minimizer_pool` in `sort_min_pool`

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1255,6 +1255,7 @@ class SHGO:
     def sort_min_pool(self):
         # Sort to find minimum func value in min_pool
         self.ind_f_min = np.argsort(self.minimizer_pool_F)
+        self.X_min = np.array(self.X_min)[self.ind_f_min]
         self.minimizer_pool = np.array(self.minimizer_pool)[self.ind_f_min]
         self.minimizer_pool_F = np.array(self.minimizer_pool_F)[
             self.ind_f_min]

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -796,6 +796,21 @@ class TestShgoArguments:
         options = {'local_iter': 4}
         run_test(test5_1, n=60, options=options)
 
+    def test_14_1_sort_min_pool_x_min(self):
+        """Test that `sort_min_pool` reorders `X_min` consistently with
+        `minimizer_pool` and `minimizer_pool_F`"""
+        shc = SHGO(lambda x: x[0], [(0, 1)])
+        # unsorted, parallel arrays as populated by `SHGO.minimizers`
+        shc.X_min = np.array([[3.], [1.], [2.]])
+        shc.minimizer_pool = np.array(['c', 'a', 'b'])
+        shc.minimizer_pool_F = np.array([3., 1., 2.])
+
+        shc.sort_min_pool()
+
+        assert_allclose(shc.X_min, [[1.], [2.], [3.]])
+        assert_allclose(shc.minimizer_pool_F, [1., 2., 3.])
+        assert (shc.minimizer_pool == ['a', 'b', 'c']).all()
+
     def test_15_min_every_iter(self):
         """Test minimize every iter options and cover function cache"""
         options = {'minimize_every_iter': True}


### PR DESCRIPTION

#### Reference issue
Closes gh-#25838

#### What does this implement/fix?
This fixes the ordering of X_min in shgo algorithm function  so that it evaluates best candidates. Also implements 'test_14_1_sort_min_pool_x_min' a test for checking that sort_min_pool sorts X_min correctly

#### Additional information


#### AI Generation Disclosure
Claude Code Sonnet-5 and Opus-5 was used to generate the code. Then reviewed by myself