### PR TITLE
MAINT: special: migrate hyp1f1 to XSF ufunc machinery

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -1776,86 +1776,6 @@ add_newdoc(
     """)
 '''
 
-add_newdoc("hyp1f1",
-    r"""
-    hyp1f1(a, b, x, out=None)
-
-    Confluent hypergeometric function 1F1.
-
-    The confluent hypergeometric function is defined by the series
-
-    .. math::
-
-       {}_1F_1(a; b; x) = \sum_{k = 0}^\infty \frac{(a)_k}{(b)_k k!} x^k.
-
-    See [DLMF]_ for more details. Here :math:`(\cdot)_k` is the
-    Pochhammer symbol; see `poch`.
-
-    Parameters
-    ----------
-    a, b : array_like
-        Real parameters
-    x : array_like
-        Real or complex argument
-    out : ndarray, optional
-        Optional output array for the function results
-
-    Returns
-    -------
-    scalar or ndarray
-        Values of the confluent hypergeometric function
-
-    See Also
-    --------
-    hyperu : another confluent hypergeometric function
-    hyp0f1 : confluent hypergeometric limit function
-    hyp2f1 : Gaussian hypergeometric function
-
-    Notes
-    -----
-    For real values, this function uses the ``hyp1f1`` routine from the C++ Boost
-    library [2]_, for complex values a C translation of the specfun
-    Fortran library [3]_.
-
-    References
-    ----------
-    .. [DLMF] NIST Digital Library of Mathematical Functions
-              https://dlmf.nist.gov/13.2#E2
-    .. [2] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
-    .. [3] S. Zhang and J.M. Jin, "Computation of Special Functions", Wiley 1996.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> import scipy.special as sc
-
-    It is one when `x` is zero:
-
-    >>> sc.hyp1f1(0.5, 0.5, 0)
-    1.0
-
-    It is singular when `b` is a nonpositive integer.
-
-    >>> sc.hyp1f1(0.5, -1, 0)
-    inf
-
-    It is a polynomial when `a` is a nonpositive integer.
-
-    >>> a, b, x = -1, 0.5, np.array([1.0, 2.0, 3.0, 4.0])
-    >>> sc.hyp1f1(a, b, x)
-    array([-1., -3., -5., -7.])
-    >>> 1 + (a / b) * x
-    array([-1., -3., -5., -7.])
-
-    It reduces to the exponential function when ``a = b``.
-
-    >>> sc.hyp1f1(2, 2, [1, 2, 3, 4])
-    array([ 2.71828183,  7.3890561 , 20.08553692, 54.59815003])
-    >>> np.exp([1, 2, 3, 4])
-    array([ 2.71828183,  7.3890561 , 20.08553692, 54.59815003])
-
-    """)
-
 add_newdoc("kn",
     r"""
     kn(n, x, out=None)
@@ -3021,4 +2941,3 @@ add_newdoc("_stirling2_inexact",
     r"""
     Internal function, do not use.
     """)
-

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -237,6 +237,7 @@ special_ufuncs = [
     "hankel2e",
     "huber",
     "hyp0f1",
+    "hyp1f1",
     "hyp2f1",
     "hyperu",
     "i0",

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -222,6 +222,7 @@ extern const char *hankel1e_doc;
 extern const char *hankel2_doc;
 extern const char *hankel2e_doc;
 extern const char *hyp0f1_doc;
+extern const char *hyp1f1_doc;
 extern const char *hyp2f1_doc;
 extern const char *hyperu_doc;
 extern const char *i0_doc;
@@ -1295,6 +1296,12 @@ _special_ufuncs_module_exec(PyObject *module)
                            static_cast<xsf::numpy::fF_F>(xsf::hyp0f1), static_cast<xsf::numpy::dD_D>(xsf::hyp0f1)},
                           "hyp0f1", hyp0f1_doc);
     PyModule_AddObjectRef(module, "hyp0f1", hyp0f1);
+
+    PyObject *hyp1f1 = xsf::numpy::ufunc(
+        {static_cast<xsf::numpy::fff_f>(hyp1f1_float), static_cast<xsf::numpy::ddd_d>(hyp1f1_double),
+         static_cast<xsf::numpy::ffF_F>(xsf::hyp1f1), static_cast<xsf::numpy::ddD_D>(xsf::hyp1f1)},
+        "hyp1f1", hyp1f1_doc);
+    PyModule_AddObjectRef(module, "hyp1f1", hyp1f1);
 
     PyObject *hyp2f1 =
         xsf::numpy::ufunc({static_cast<xsf::numpy::ffff_f>(xsf::hyp2f1), static_cast<xsf::numpy::dddd_d>(xsf::hyp2f1),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -1026,6 +1026,85 @@ const char *hyp0f1_doc = R"(
 
     )";
 
+const char *hyp1f1_doc = R"(
+    hyp1f1(a, b, x, out=None)
+
+    Confluent hypergeometric function 1F1.
+
+    The confluent hypergeometric function is defined by the series
+
+    .. math::
+
+       {}_1F_1(a; b; x) = \sum_{k = 0}^\infty \frac{(a)_k}{(b)_k k!} x^k.
+
+    See [DLMF]_ for more details. Here :math:`(\cdot)_k` is the
+    Pochhammer symbol; see `poch`.
+
+    Parameters
+    ----------
+    a, b : array_like
+        Real parameters
+    x : array_like
+        Real or complex argument
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the confluent hypergeometric function
+
+    See Also
+    --------
+    hyperu : another confluent hypergeometric function
+    hyp0f1 : confluent hypergeometric limit function
+    hyp2f1 : Gaussian hypergeometric function
+
+    Notes
+    -----
+    For real values, this function uses the ``hyp1f1`` routine from the C++ Boost
+    library [2]_, for complex values a C translation of the specfun
+    Fortran library [3]_.
+
+    References
+    ----------
+    .. [DLMF] NIST Digital Library of Mathematical Functions
+              https://dlmf.nist.gov/13.2#E2
+    .. [2] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+    .. [3] S. Zhang and J.M. Jin, "Computation of Special Functions", Wiley 1996.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.special as sc
+
+    It is one when `x` is zero:
+
+    >>> sc.hyp1f1(0.5, 0.5, 0)
+    1.0
+
+    It is singular when `b` is a nonpositive integer.
+
+    >>> sc.hyp1f1(0.5, -1, 0)
+    inf
+
+    It is a polynomial when `a` is a nonpositive integer.
+
+    >>> a, b, x = -1, 0.5, np.array([1.0, 2.0, 3.0, 4.0])
+    >>> sc.hyp1f1(a, b, x)
+    array([-1., -3., -5., -7.])
+    >>> 1 + (a / b) * x
+    array([-1., -3., -5., -7.])
+
+    It reduces to the exponential function when ``a = b``.
+
+    >>> sc.hyp1f1(2, 2, [1, 2, 3, 4])
+    array([ 2.71828183,  7.3890561 , 20.08553692, 54.59815003])
+    >>> np.exp([1, 2, 3, 4])
+    array([ 2.71828183,  7.3890561 , 20.08553692, 54.59815003])
+
+    )";
+
 const char *agm_doc = R"(
     agm(a, b, out=None)
 

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -571,7 +571,7 @@ Real call_hypergeometric_pFq(Real a, Real b, Real x)
 
 template<typename Real>
 static inline
-Real hyp1f1_wrap(Real a, Real b, Real x)
+Real hyp1f1_boost_wrap(Real a, Real b, Real x)
 {
     Real y;
 
@@ -631,19 +631,14 @@ Real hyp1f1_wrap(Real a, Real b, Real x)
 double
 hyp1f1_double(double a, double b, double x)
 {
-    return hyp1f1_wrap(a, b, x);
+    return hyp1f1_boost_wrap(a, b, x);
 }
 
-//
-// NOTE: It would be easy to also provide hyp1f1_float(...), but with the
-// current ufunc generation code, it would not be used.  The ufunc
-// generation code will implement the float types for the ufunc by
-// casting the floats to double and using the double implementation.
-// This is because we also have a complex version that is implemented
-// in a different file, and the ufunc generation code requires just one
-// kernel function per header when there are multiple headers (see the
-// comments in _generate_pyx.py).
-//
+float
+hyp1f1_float(float a, float b, float x)
+{
+    return static_cast<float>(hyp1f1_double(a, b, x));
+}
 
 // patch for boost::math::beta_distribution throwing exception for
 // x = 1, beta < 1 as well as x = 0, alpha < 1

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1390,6 +1390,7 @@ cdef extern from r"cython_special_wrappers.h":
 
     double special_boxcox(double x, double lmbda) nogil
     double special_boxcox1p(double x, double lmbda) nogil
+    npy_cdouble chyp1f1_wrap(double a, double b, npy_cdouble z) nogil
     npy_cdouble special_chyp0f1(double v, npy_cdouble z) nogil
     double special_hyp0f1(double v, double z) nogil
     double special_hyperu(double a, double b, double x) nogil
@@ -1429,6 +1430,7 @@ cdef extern from r"cython_special_wrappers.h":
     double boost_fdtrc_double(double dfn, double dfd, double x) nogil
     float boost_fdtri_float(float dfn, float dfd, float p) nogil
     double boost_fdtri_double(double dfn, double dfd, double p) nogil
+    double boost_hyp1f1_double(double a, double b, double x) nogil
     float boost_log_gammainc_float(float a, float x) nogil
     double boost_log_gammainc_double(double a, double x) nogil
     float boost_log_gammaincc_float(float a, float x) nogil
@@ -1685,9 +1687,6 @@ cdef _proto_fdtridfd_t *_proto_fdtridfd_t_var = &_func_fdtridfd
 
 cdef extern from r"_ufuncs_defs.h":
     cdef npy_int _func_cephes_fresnl_wrap "cephes_fresnl_wrap"(npy_double, npy_double *, npy_double *)nogil
-
-cdef extern from r"_ufuncs_defs.h":
-    cdef npy_cdouble _func_chyp1f1_wrap "chyp1f1_wrap"(npy_double, npy_double, npy_cdouble)nogil
 
 cdef extern from r"_ufuncs_defs.h":
     cdef npy_double _func_j0 "j0"(npy_double)nogil
@@ -2365,9 +2364,9 @@ cpdef Dd_number_t hyp0f1(double x0, Dd_number_t x1) noexcept nogil:
 cpdef Dd_number_t hyp1f1(double x0, double x1, Dd_number_t x2) noexcept nogil:
     """See the documentation for scipy.special.hyp1f1"""
     if Dd_number_t is double:
-        return (<double(*)(double, double, double) noexcept nogil>scipy.special._ufuncs_cxx._export_hyp1f1_double)(x0, x1, x2)
+        return boost_hyp1f1_double(x0, x1, x2)
     elif Dd_number_t is double_complex:
-        return _complexstuff.double_complex_from_npy_cdouble(_func_chyp1f1_wrap(x0, x1, _complexstuff.npy_cdouble_from_double_complex(x2)))
+        return _complexstuff.double_complex_from_npy_cdouble(chyp1f1_wrap(x0, x1, _complexstuff.npy_cdouble_from_double_complex(x2)))
 
 cpdef Dd_number_t hyp2f1(double x0, double x1, double x2, Dd_number_t x3) noexcept nogil:
     """See the documentation for scipy.special.hyp2f1"""

--- a/scipy/special/cython_special_wrappers.cpp
+++ b/scipy/special/cython_special_wrappers.cpp
@@ -801,6 +801,8 @@ float boost_fdtri_float(float dfn, float dfd, float p) { return f_ppf_float(dfn,
 
 double boost_fdtri_double(double dfn, double dfd, double p) { return f_ppf_double(dfn, dfd, p); }
 
+double boost_hyp1f1_double(double a, double b, double x) { return hyp1f1_double(a, b, x); }
+
 float boost_log_gammainc_float(float a, float x) { return lgamma_p_float(a, x); }
 
 double boost_log_gammainc_double(double a, double x) { return lgamma_p_double(a, x); }
@@ -865,5 +867,4 @@ double boost_stdtr_double(double df, double t) { return t_cdf_double(df, t); }
 float boost_stdtrit_float(float df, float p) { return t_ppf_float(df, p); }
 
 double boost_stdtrit_double(double df, double p) { return t_ppf_double(df, p); }
-
 

--- a/scipy/special/cython_special_wrappers.h
+++ b/scipy/special/cython_special_wrappers.h
@@ -431,6 +431,7 @@ float boost_fdtrc_float(float dfn, float dfd, float x);
 double boost_fdtrc_double(double dfn, double dfd, double x);
 float boost_fdtri_float(float dfn, float dfd, float p);
 double boost_fdtri_double(double dfn, double dfd, double p);
+double boost_hyp1f1_double(double a, double b, double x);
 float boost_log_gammainc_float(float a, float x);
 double boost_log_gammainc_double(double a, double x);
 float boost_log_gammaincc_float(float a, float x);

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -179,14 +179,6 @@
         "_cdflib_wrappers.pxd": {
             "fdtridfd": "ddd->d"        }
     },
-    "hyp1f1": {
-        "boost_special_functions.h++": {
-            "hyp1f1_double": "ddd->d"
-	    },
-        "cython_special_wrappers.h": {
-            "chyp1f1_wrap": "ddD->D"
-        }
-    },
     "kn": {
         "_legacy.pxd": {
             "kn_unsafe": "dd->d"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Tentative migration of `hyp1f1` to XSF ufunc machinery. I added an overload `hyp1f1_float` in `boost_special_functions.h` and this seemed like the most natural thing to do.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I worked with Codex on this migration.