### PR TITLE
 BUG: optimize.shgo: fix minhgrd stopping too early with minimize_every_iter

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1009,9 +1009,20 @@ class SHGO:
                          f' (minimum growth = {self.minhgrd})')
         return self.stop_global
 
-    def stopping_criteria(self):
+    def stopping_criteria(self, between_it=True):
         """
         Various stopping criteria ran every iteration
+
+        Parameters
+        ----------
+        between_it : bool
+            The homology growth criterion (``minhgrd``) tracks the growth
+            of the homology group rank *between* outer sampling
+            iterations. It is stateful, so it must only be evaluated from
+            `iterate_all`'s outer loop, once per iteration. Pass
+            ``between_it=False`` for calls made from within a single
+            iteration (e.g. from `minimise_pool`) so that they don't
+            consume the growth this criterion is meant to measure.
 
         Returns
         -------
@@ -1029,7 +1040,7 @@ class SHGO:
             self.finite_time()
         if self.f_min_true is not None:
             self.finite_precision()
-        if self.minhgrd is not None:
+        if self.minhgrd is not None and between_it:
             self.finite_homology_growth()
         return self.stop_global
 
@@ -1222,7 +1233,7 @@ class SHGO:
 
         while not self.stop_l_iter:
             # Global stopping criteria:
-            self.stopping_criteria()
+            self.stopping_criteria(between_it=False)
 
             # Note first iteration is outside loop:
             if force_iter:

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -742,6 +742,30 @@ class TestShgoArguments:
         run_test(test1_1, n=None, iters=None, options=options,
                  sampling_method='simplicial')
 
+    def test_8_1_minhgrd_minimize_every_iter(self):
+        """Test that `minhgrd=0` does not force `shgo` to stop after a
+        single iteration when `minimize_every_iter=True`. Before the fix,
+        `hgrd` was always corrupted to 0 by an inner `stopping_criteria`
+        call, so even `minhgrd=0` (a no-op threshold: `hgrd <= 0` should
+        only be true on genuine stalls) stopped the run immediately.
+        Fixes gh-25845"""
+        centers = np.arange(10) + 0.5
+        depths = np.linspace(0.9, 0.05, 10)
+
+        def f(x):
+            x = x[0]
+            i = int(np.clip(x, 0, 9.999))
+            return depths[i] + (x - centers[i]) ** 2
+
+        bounds = [(0, 10)]
+
+        result = shgo(f, bounds, n=10, sampling_method='sobol',
+                       minimizer_kwargs={'method': 'COBYQA'},
+                       options={'minimize_every_iter': True, 'local_iter': 1,
+                                'maxiter': 20, 'minhgrd': 0})
+
+        assert result.nit > 1
+
     def test_9_cons_g(self):
         """Test single function constraint passing"""
         SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])


### PR DESCRIPTION

#### Reference issue
  Closes gh-25845

#### What does this implement/fix?
  SHGO.stopping_criteria calls finite_homology_growth whenever minhgrd is set  a stateful check tracking growth between
  outer iterations. But it was also called from inside minimise_pool's inner polishing loop. Added a guardrail parameter ´between_it´ to prevent calling ´finite_homology_growth()´ between inner loop iterations.

#### Additional information
Added a test similar to the issue code to test whether the algorithm did more than 1 iteration when minhgrd = 0

#### AI Generation Disclosure
The code in this PR was generated by Claude Code Sonnet-5 and Opus-5, reviewed by me