### PR TITLE
MAINT: backports in preparation for SciPy `1.18.1`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -391,31 +391,24 @@ jobs:
         submodules: recursive
         persist-credentials: false
 
-    - name: build + test in i686 container
-      run: |
-        set -exuo pipefail
-        # Note: `ccache` not used because it isn't available on i686 CentOS 7
-        docker pull quay.io/pypa/manylinux2014_i686
-        docker run -v $(pwd):/scipy --platform=linux/i386 quay.io/pypa/manylinux2014_i686 /bin/bash -c "cd /scipy && \
-        uname -a && \
-        python3.12 -m venv test && \
-        source test/bin/activate && \
-        python -m pip install spin 'click<8.3.0' meson ninja && \
-        python -m pip install -r requirements/openblas.txt && \
-        # Ensure that scipy-openblas is picked up by the numpy<1.26 build
-        cat > \$HOME/.numpy-site.cfg <<EOL
-        [openblas]
-        libraries = \$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_library())')
-        library_dirs = \$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_lib_dir())')
-        include_dirs = \$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_include_dir())')
-        runtime_library_dirs = \$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_lib_dir())')
-        symbol_prefix = scipy_
-        EOL
-        python -m pip install numpy==2.0.0 -Cbuild-dir=numpy-builddir && \
-        python -m pip install cython pybind11 pytest pytest-timeout pytest-xdist pytest-env mpmath pythran pooch meson hypothesis && \
-        python -c 'import numpy as np; np.show_config()' && \
-        spin build --with-scipy-openblas=32 && \
-        spin test"
+      - name: build + test in i686 container
+        run: |
+          set -exuo pipefail
+          docker pull quay.io/pypa/manylinux_2_28_i686
+          docker run -v $(pwd):/scipy --platform=linux/i386 quay.io/pypa/manylinux_2_28_i686 /bin/bash -c "cd /scipy && \
+          uname -a && \
+          python3.12 -m venv test && \
+          source test/bin/activate && \
+          python -m pip install --upgrade pip && \
+          python -m pip install --group build --group dev-cli --group test-core && \
+          # we want `mpmath` but cannot install `gmpy2` on 32-bit,
+          # so cannot use `--group test-mp`
+          python -m pip install mpmath && \
+          python -m pip install -r requirements/openblas.txt && \
+          python -m pip install numpy==2.0.0 -Cbuild-dir=numpy-builddir && \
+          python -c 'import numpy as np; np.show_config()' && \
+          spin build --with-scipy-openblas=32 && \
+          spin test"
 
   #################################################################################
   distro_multiple_pythons:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,7 +245,7 @@ jobs:
           python3-dbg -m pytest --pyargs scipy -n4 --durations=10 -m "not slow"
 
   #################################################################################
-  gcc9:
+  gcc10:
     # Purpose is to examine builds with oldest-supported gcc and test with pydata/sparse.
     name: Oldest GCC & pydata/sparse, full, py3.12/npMin, pip+pytest
     needs: get_commit_message
@@ -267,7 +267,7 @@ jobs:
       - name: Setup system dependencies
         run: |
           sudo apt-get -y update
-          sudo apt install -y g++-9 gcc-9 gfortran-9
+          sudo apt install -y g++-10 gcc-10 gfortran-10
           sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
             libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev ccache
 
@@ -288,7 +288,7 @@ jobs:
           export PYTHONOPTIMIZE=2
 
           # specify which compilers to use using environment variables
-          CC="ccache gcc-9" CXX="ccache g++-9" FC="ccache gfortran-9" python -m pip install . -v \
+          CC="ccache gcc-10" CXX="ccache g++-10" FC="ccache gfortran-10" python -m pip install . -v \
               --no-build-isolation -Cbuild-dir=build \
               -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas
 

--- a/.mailmap
+++ b/.mailmap
@@ -413,6 +413,7 @@ Melissa Weber Mendonça <melissawm@gmail.com> Melissa Weber <melissawm.github@gm
 Michael Benfield <mike.benfield@gmail.com> mikebenfield <mike.benfield@gmail.com>
 Michael Droettboom <> mdroe <>
 Michael Dunphy <Michael.Dunphy@dfo-mpo.gc.ca> Michael Dunphy <mdunphy@users.noreply.github.com>
+Michael Bratsch <michael.bratsch83@gmail.com> michaelbratsch <michael.bratsch83@gmail.com>
 Michael Hirsch <scienceopen@noreply.github.com> michael <scienceopen@noreply.github.com>
 Michael Hirsch <scienceopen@noreply.github.com> Michael Hirsch <scienceopen@users.noreply.github.com>
 Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOrange@users.noreply.github.com>
@@ -576,6 +577,8 @@ Warren Weckesser <warren.weckesser@gmail.com> warren.weckesser <warren.weckesser
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@enthought.com>
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@localhost>
 Warren Weckesser <warren.weckesser@gmail.com> warren <warren.weckesser@gmail.com>
+Wasim Akram <huaweiwasim7@gmail.com> wasim <huaweiwasim7@gmail.com>
+Wasim Akram <huaweiwasim7@gmail.com> wasimat404 <huaweiwasim7@gmail.com>
 Wendy Liu <ilostwaldo@gmail.com> dellsystem <ilostwaldo@gmail.com>
 WhimsyHippo <hippowiseman789@gmail.com> hippowm <hippowiseman789@gmail.com>
 Will Tirone <will.tirone1@gmail.com> WillTirone <42592742+WillTirone@users.noreply.github.com>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -212,7 +212,7 @@ html_sidebars = {
     "index": ["search-button-field"],
     "**": ["search-button-field", "sidebar-nav-bs"]
 }
-html_js_files = ['custom-icons.js']  # defines custom icon(s) used in header
+html_js_files = [('custom-icons.js', {"defer": "defer"}),]  # for custom header icon(s)
 html_theme_options = {
     "header_links_before_dropdown": 6,
     "icon_links": [

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -129,7 +129,7 @@ As explained in more detail below, the current minimal compiler versions are:
 ==========  ===========================  ===============================  ============================
  Compiler    Default Platform (tested)    Secondary Platform (untested)    Minimal Version
 ==========  ===========================  ===============================  ============================
- GCC         Linux                        AIX, Alpine Linux, OSX           GCC 9.x
+ GCC         Linux                        AIX, Alpine Linux, OSX           GCC 10.3
  LLVM        OSX                          Linux, FreeBSD, Windows          LLVM 12.x
  MSVC        Windows                      -                                Visual Studio 2019 (vc142)
 ==========  ===========================  ===============================  ============================
@@ -147,7 +147,6 @@ Currently, SciPy wheels are being built as follows:
 =========================   ==============================   ====================================   =============================
  Platform                    `CI`_ `Base`_ `Images`_          Compilers                              Comment
 =========================   ==============================   ====================================   =============================
- Linux x86                   ``ubuntu-22.04``                 GCC 10.2.1                             ``cibuildwheel``
  Linux arm                   ``docker-builder-arm64``         GCC 11.3.0                             ``cibuildwheel``
  OSX x86_64 (OpenBLAS)       ``macos-15-intel``               Apple clang 13.1.6/gfortran 15.2.0     ``cibuildwheel``
  OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
@@ -371,7 +370,7 @@ AIX, Alpine Linux and FreeBSD.
 .. _13.x release: https://www.freebsd.org/releases/13.2R/relnotes/
 .. _freebsd-port: https://ports.freebsd.org/cgi/ports.cgi?query=gcc
 
-All the currently lowest-supported compiler versions (GCC 9, LLVM 14,
+All the currently lowest-supported compiler versions (GCC 10, LLVM 14,
 VS2019 with vc142) have full support for the C++17 *core language*,
 which can therefore be used unconditionally.
 However, as of mid-2024, support for the entirety of the C++17 standard library

--- a/doc/source/release/1.18.1-notes.rst
+++ b/doc/source/release/1.18.1-notes.rst
@@ -20,7 +20,7 @@ Authors
 * Dietrich Brunn (1)
 * Evgeni Burovski (1)
 * Aadya Chinubhai (1)
-* Lucas Colley (2)
+* Lucas Colley (3)
 * Tekin Ertekin (1) +
 * Fuyugithub (2) +
 * Ralf Gommers (11)
@@ -28,7 +28,7 @@ Authors
 * Ijtihed Kilani (1) +
 * Andrew Nelson (2)
 * Ilhan Polat (1)
-* Tyler Reddy (34)
+* Tyler Reddy (39)
 * romao05 (1) +
 * Michael Simacek (1) +
 * Jacob Vanderplas (2)
@@ -58,7 +58,6 @@ Issues closed for 1.18.1
 * `#25864 <https://github.com/scipy/scipy/issues/25864>`__: BUG: linalg.expm matrix L1-norm implemented as infinity norm
 * `#25924 <https://github.com/scipy/scipy/issues/25924>`__: BUG: Batched ``linalg.expm`` Accuracy Regression
 
-
 Pull requests for 1.18.1
 ------------------------
 
@@ -84,5 +83,6 @@ Pull requests for 1.18.1
 * `#25690 <https://github.com/scipy/scipy/pull/25690>`__: BUG: special.eval_gegenbauer: fix UBSAN crash for NaN
 * `#25726 <https://github.com/scipy/scipy/pull/25726>`__: dfitpack.c: avoid potentially undefined float->int cast
 * `#25764 <https://github.com/scipy/scipy/pull/25764>`__: BUG: interpolate: flatten the grid coordinates before evaluating...
+* `#25913 <https://github.com/scipy/scipy/pull/25913>`__: BLD: package: pin meson on win-64 to avoid clang-cl bug
 * `#25934 <https://github.com/scipy/scipy/pull/25934>`__: MAINT/BUG:linalg.expm: fix the norms and recover batch handling
 * `#25958 <https://github.com/scipy/scipy/pull/25958>`__: TST: stats - bump some tolerances

--- a/doc/source/release/1.18.1-notes.rst
+++ b/doc/source/release/1.18.1-notes.rst
@@ -5,19 +5,84 @@ SciPy 1.18.1 Release Notes
 .. contents::
 
 SciPy 1.18.1 is a bug-fix release with no new features
-compared to 1.18.0.
+compared to 1.18.0. This release includes binaries on
+PyPI for Python 3.15, and the minimum required version
+of the GCC toolchain has been increased to 10.3.0.
 
 
 
 Authors
 =======
 * Name (commits)
+* Wasim Akram (2) +
+* Jake Bowhay (1)
+* Michael Bratsch (1)
+* Dietrich Brunn (1)
+* Evgeni Burovski (1)
+* Aadya Chinubhai (1)
+* Lucas Colley (2)
+* Tekin Ertekin (1) +
+* Fuyugithub (2) +
+* Ralf Gommers (11)
+* Joren Hammudoglu (1)
+* Ijtihed Kilani (1) +
+* Andrew Nelson (2)
+* Ilhan Polat (1)
+* Tyler Reddy (34)
+* romao05 (1) +
+* Michael Simacek (1) +
+* Jacob Vanderplas (2)
+
+    A total of 18 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.18.1
 ------------------------
 
+* `#23076 <https://github.com/scipy/scipy/issues/23076>`__: BUG: Incorrect use of NumPy scalar types instead of np.dtype...
+* `#24495 <https://github.com/scipy/scipy/issues/24495>`__: BUG: remez hilbert segfault
+* `#25340 <https://github.com/scipy/scipy/issues/25340>`__: MAINT, TYP: some typing-related concerns in 1.18.x
+* `#25351 <https://github.com/scipy/scipy/issues/25351>`__: BUG: forkserver forcing breaks interpreters that don't have it
+* `#25405 <https://github.com/scipy/scipy/issues/25405>`__: [BUG] Py_XDECREF on borrowed refs in fitpack_sphere (iopt==-1)...
+* `#25406 <https://github.com/scipy/scipy/issues/25406>`__: [BUG] Double-free of wrk1/wrk2/iwrk in fitpack_surfit on allocation...
+* `#25435 <https://github.com/scipy/scipy/issues/25435>`__: [BUG] Double-DECREF of ap_t in fitpack_parcur — use-after-free...
+* `#25436 <https://github.com/scipy/scipy/issues/25436>`__: [BUG] PyTuple_SET_ITEM on unchecked NULL args_tuple in DVODE/ZVODE...
+* `#25471 <https://github.com/scipy/scipy/issues/25471>`__: BUG: interpolate: ``BivariateSpline(grid=False)`` returns (1,)-shaped...
+* `#25489 <https://github.com/scipy/scipy/issues/25489>`__: BUG: ``copy.deepcopy`` and ``pickle`` fail for interpolation...
+* `#25522 <https://github.com/scipy/scipy/issues/25522>`__: BUG: test_convergence fails very often on aarch64-linux
+* `#25572 <https://github.com/scipy/scipy/issues/25572>`__: CI: 32-bit Linux job is failing because numpy needs GCC 10 now
+* `#25657 <https://github.com/scipy/scipy/issues/25657>`__: BUG: ``linalg.signm`` unpredictable output dtype
+* `#25730 <https://github.com/scipy/scipy/issues/25730>`__: BUG: RectBivariateSpline interpolation issues with new fitpack...
+* `#25864 <https://github.com/scipy/scipy/issues/25864>`__: BUG: linalg.expm matrix L1-norm implemented as infinity norm
+* `#25924 <https://github.com/scipy/scipy/issues/25924>`__: BUG: Batched ``linalg.expm`` Accuracy Regression
 
 
 Pull requests for 1.18.1
 ------------------------
+
+* `#24923 <https://github.com/scipy/scipy/pull/24923>`__: BUG: sparse: fix ``get_sum_dtype`` return type consistency
+* `#25352 <https://github.com/scipy/scipy/pull/25352>`__: BUG: use ``forkserver`` only when available
+* `#25407 <https://github.com/scipy/scipy/pull/25407>`__: BUG: interpolate: INCREF borrowed refs at assignment in fitpack_sphere
+* `#25443 <https://github.com/scipy/scipy/pull/25443>`__: REL, MAINT: prepare for SciPy 1.18.1
+* `#25450 <https://github.com/scipy/scipy/pull/25450>`__: BUG: interpolate: fix double-free of wrk buffers in fitpack_surfit
+* `#25484 <https://github.com/scipy/scipy/pull/25484>`__: BUG: interpolate: coerce non-contiguous input in surfit wrappers
+* `#25500 <https://github.com/scipy/scipy/pull/25500>`__: BUG: interpolate: ensure interpolators are pickleable
+* `#25507 <https://github.com/scipy/scipy/pull/25507>`__: BUG/MAINT: fix refcounting and error handling in ``fitpack_parcur``
+* `#25508 <https://github.com/scipy/scipy/pull/25508>`__: API: linalg.bandwidth: revert ``int`` to ``np.int64`` type change
+* `#25509 <https://github.com/scipy/scipy/pull/25509>`__: API: stats.binomtest: revert ``k, n`` type change from ``int``...
+* `#25521 <https://github.com/scipy/scipy/pull/25521>`__: BUG: integrate: guard against NULL PyTuple_New in DVODE/ZVODE...
+* `#25542 <https://github.com/scipy/scipy/pull/25542>`__: BUG: interpolate: fix shapes of {Rect,Smooth}BivariateSpline...
+* `#25579 <https://github.com/scipy/scipy/pull/25579>`__: BLD/CI: bump minimum GCC version to 10.3.0, fix i686 Linux CI...
+* `#25581 <https://github.com/scipy/scipy/pull/25581>`__: DOC/MAINT: Make the forum icon in header visible again
+* `#25602 <https://github.com/scipy/scipy/pull/25602>`__: BUG: signal: fix segfault in remez for too-narrow bands
+* `#25609 <https://github.com/scipy/scipy/pull/25609>`__: BUG/TYP: ``interpolate``\ : restore ``__class_getitem__`` methods...
+* `#25632 <https://github.com/scipy/scipy/pull/25632>`__: TST: sparse.linalg: skip tfqmr/rand-sym-pd-F on all platforms
+* `#25638 <https://github.com/scipy/scipy/pull/25638>`__: BUG: ``make_splprep`` does not validate periodic endpoints at...
+* `#25658 <https://github.com/scipy/scipy/pull/25658>`__: BUG: linalg.signm: preserve input dtype for defective matrices
+* `#25690 <https://github.com/scipy/scipy/pull/25690>`__: BUG: special.eval_gegenbauer: fix UBSAN crash for NaN
+* `#25726 <https://github.com/scipy/scipy/pull/25726>`__: dfitpack.c: avoid potentially undefined float->int cast
+* `#25764 <https://github.com/scipy/scipy/pull/25764>`__: BUG: interpolate: flatten the grid coordinates before evaluating...
+* `#25934 <https://github.com/scipy/scipy/pull/25934>`__: MAINT/BUG:linalg.expm: fix the norms and recover batch handling
+* `#25958 <https://github.com/scipy/scipy/pull/25958>`__: TST: stats - bump some tolerances

--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,8 @@ cython = find_program(cy.cmd_array()[0])
 
 # Check compiler is recent enough (see "Toolchain Roadmap" for details)
 if cc.get_id() == 'gcc'
-  if not cc.version().version_compare('>=9.1')
-    error('SciPy requires GCC >= 9.1')
+  if not cc.version().version_compare('>=10.3')
+    error('SciPy requires GCC >= 10.3')
   endif
 elif cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
   if not cc.version().version_compare('>=15.0')

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,6 +36,7 @@ numpy = "*"
 blas-devel = "*"
 
 [package.target.win-64.host-dependencies]
+meson = "<1.12.0"  # scipy/scipy#25904
 openblas = "*"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -525,6 +525,10 @@ def xp_result_type(*args, force_floating=False, xp):
 
     try:  # follow library's preferred promotion rules
         return xp.result_type(*args_not_none)
+    except ValueError:  # all scalars; need at least one array/dtype
+        if not force_floating:
+            raise
+        return xp.result_type(*(args_not_none + [xp.asarray(1.0)])) # skip device check
     except TypeError:  # mixed type promotion isn't defined
         if not force_floating:
             raise

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -7,7 +7,6 @@ import numbers
 from collections import namedtuple
 import inspect
 import math
-import os
 import sys
 import textwrap
 from types import ModuleType

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -582,11 +582,14 @@ class MapWrapper:
             self.pool = pool
             self._mapfunc = self.pool
         else:
-            from multiprocessing import get_context, get_start_method
+            from multiprocessing import (
+                get_all_start_methods, get_context, get_start_method
+            )
 
             method = get_start_method(allow_none=True)
 
-            if method is None and os.name=='posix' and sys.version_info < (3, 14):
+            if (method is None and sys.version_info < (3, 14)
+                    and 'forkserver' in get_all_start_methods()):
                 # Python 3.13 and older used "fork" on posix, which can lead to
                 # deadlocks. This backports that fix to older Python versions.
                 method = 'forkserver'

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -97,7 +97,8 @@ def pytest_configure(config):
             "iterations(n): run the given test function `n` times in each thread",
         )
 
-    if os.name == 'posix' and sys.version_info < (3, 14) and sys.platform != "cygwin":
+    if (sys.version_info < (3, 14)
+            and 'forkserver' in multiprocessing.get_all_start_methods()):
         # On POSIX, Python 3.13 and older uses the 'fork' context by
         # default. Calling fork() from multiple threads leads to
         # deadlocks. This has been changed in 3.14 to 'forkserver'.

--- a/scipy/fft/_duccfft/meson.build
+++ b/scipy/fft/_duccfft/meson.build
@@ -1,11 +1,11 @@
-duccfft_threads = []
+duccfft_args = []
 fft_deps = []
 if is_windows
   if is_mingw
     # mingw-w64 does not implement pthread_pfork, needed by ducc_fft
     # Disable threading completely, because of freezes using threading for
     # mingw-w64 gcc: https://github.com/mreineck/pocketfft/issues/1
-    duccfft_threads += ['-DDUCC0_NO_LOWLEVEL_THREADING']
+    duccfft_args += ['-DDUCC0_NO_LOWLEVEL_THREADING']
   else
     if thread_dep.found()
       # Use native Windows threading for MSVC/Clang. `pthreads` is probably not
@@ -14,7 +14,6 @@ if is_windows
       # progress (see comment on gh-16957).  The ducc FFT sources
       # will include `<threads>` anyway.
       fft_deps += [thread_dep]
-      duccfft_threads += []
     endif
   endif
 else
@@ -30,6 +29,11 @@ if meson.get_compiler('cpp').get_id() == 'gcc'
   duccfft_args += ['-Wno-psabi']
 endif
 
+
+if cc.get_id() == 'gcc' and cc.sizeof('void*') == 4
+  # Disable SIMD, segfaults on Linux i686, see scipy#25572
+  duccfft_args += ['-DDUCC0_NO_SIMD']
+endif
 
 py3.extension_module(
     'pyduccfft',

--- a/scipy/fft/_duccfft/meson.build
+++ b/scipy/fft/_duccfft/meson.build
@@ -21,7 +21,7 @@ else
     fft_deps += [thread_dep]
   endif
 endif
-duccfft_args = duccfft_threads
+
 # Silence GCC -Wpsabi notes about the GCC 10.1 ABI change for passing
 # SIMD-backed structs by value (triggered heavily by ducc0/fft/fft1d_impl.h).
 # The note is informational; SciPy is built against a single compiler ABI.

--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -197,23 +197,22 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_dvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
-        args_tuple = PyTuple_New(2 + nargs);
-        if (args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
-        }
-    } else {
-        args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_dvode_callback->func_args);
+    }
+    args_tuple = PyTuple_New(2 + nargs);
+    if (args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
     }
 
     // Call Python function
@@ -283,23 +282,22 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_dvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
-        jac_args_tuple = PyTuple_New(2 + nargs);
-        if (jac_args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
-        }
-    } else {
-        jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_dvode_callback->func_args);
+    }
+    jac_args_tuple = PyTuple_New(2 + nargs);
+    if (jac_args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
     }
 
     // Call Python Jacobian function
@@ -414,23 +412,22 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_zvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
-        args_tuple = PyTuple_New(2 + nargs);
-        if (args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
-        }
-    } else {
-        args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_zvode_callback->func_args);
+    }
+    args_tuple = PyTuple_New(2 + nargs);
+    if (args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
     }
 
     // Call Python function
@@ -500,23 +497,22 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_zvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
-        jac_args_tuple = PyTuple_New(2 + nargs);
-        if (jac_args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
-        }
-    } else {
-        jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_zvode_callback->func_args);
+    }
+    jac_args_tuple = PyTuple_New(2 + nargs);
+    if (jac_args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
     }
 
     // Call Python Jacobian function

--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -200,6 +200,11 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -281,6 +286,11 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (jac_args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -407,6 +417,11 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -488,6 +503,11 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (jac_args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -262,9 +262,6 @@ class PchipInterpolator(CubicHermiteSpline):
 
     """
 
-    # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None  # type:ignore[assignment]
-
     def __init__(self, x, y, axis=0, extrapolate=None):
         xp = array_namespace(x, y)
         x, _, y, axis, _ = prepare_input(x, y, axis, xp=xp)
@@ -523,9 +520,6 @@ class Akima1DInterpolator(CubicHermiteSpline):
            https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/
 
     """
-
-    # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima",
                  extrapolate:bool | None = None):

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -132,16 +132,18 @@ def _surfit_smth(x, y, z, w, xb, xe, yb, ye, kx, ky, s, eps):
     Wrapper for surfit with iopt=0 (smoothing spline).
     Returns: nx, tx, ny, ty, c, fp, ier
     """
-    x = np.asarray(x, dtype=np.float64)
-    y = np.asarray(y, dtype=np.float64)
-    z = np.asarray(z, dtype=np.float64)
+    # The C binding (_fitpack.surfit_smth) reads these buffers assuming
+    # C-contiguity; coerce strided views.
+    x = np.ascontiguousarray(x, dtype=np.float64)
+    y = np.ascontiguousarray(y, dtype=np.float64)
+    z = np.ascontiguousarray(z, dtype=np.float64)
     m = len(x)
 
     # Handle None w value (default equal weights)
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.asarray(w, dtype=np.float64)
+        w = np.asarray(w, dtype=np.float64, copy=True)
 
     # Handle None bbox values (matching f2py behavior: xb=dmin(x,m), etc.)
     if xb is None:
@@ -176,9 +178,11 @@ def _surfit_lsq(x, y, z, nx, tx, ny, ty, w, xb, xe, yb, ye, kx, ky, eps):
     Wrapper for surfit with iopt=-1 (least squares fit with fixed knots).
     Returns: tx, ty, c, fp, ier
     """
-    x = np.asarray(x, dtype=np.float64)
-    y = np.asarray(y, dtype=np.float64)
-    z = np.asarray(z, dtype=np.float64)
+    # The C binding (_fitpack.surfit_lsq) reads these buffers assuming
+    # C-contiguity; coerce strided views.
+    x = np.ascontiguousarray(x, dtype=np.float64)
+    y = np.ascontiguousarray(y, dtype=np.float64)
+    z = np.ascontiguousarray(z, dtype=np.float64)
     m = len(x)
 
     if w is None:

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1411,8 +1411,13 @@ class _BivariateSplineBase:
         >>> ax2.imshow(zdata_interp)
         >>> plt.show()
         """
-        x = np.atleast_1d(np.asarray(x))
-        y = np.atleast_1d(np.asarray(y))
+        x = np.asarray(x)
+        y = np.asarray(y)
+        # backwards compat, cf https://github.com/scipy/scipy/issues/25471
+        needs_squeeze = (x.ndim == 0) and (y.ndim == 0)
+
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
 
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
@@ -1456,6 +1461,10 @@ class _BivariateSplineBase:
                     raise ValueError(f"Error code returned by bispeu: {ier}")
 
             z = z.reshape(shape)
+
+            if needs_squeeze:
+                z = z.squeeze()
+
         return z
 
     def partial_derivative(self, dx, dy):

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1417,6 +1417,8 @@ class _BivariateSplineBase:
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
         if grid:
+            x = x.ravel()
+            y = y.ravel()
             if x.size == 0 or y.size == 0:
                 return np.zeros((x.size, y.size), dtype=self.tck[2].dtype)
 

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1157,6 +1157,8 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
 
     # postprocess: squeeze out the last dimension: was added to simplify the internals.
     spl.c = spl.c[:, 0]
+    # make periodic if needed
+    spl.extrapolate = "periodic" if periodic else True
     return spl
 
 
@@ -1315,7 +1317,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     if s == 0:
         if t is not None or w is not None or nest is not None:
             raise ValueError("s==0 is for interpolation only")
-        return make_interp_spline(u, x.T, k=k, axis=1), u
+        return make_interp_spline(u, x.T, k=k, bc_type=bc_type, axis=1), u
 
     u, x, w, k, s, ub, ue = _validate_inputs(u, x, w, k, s, ub, ue,
                                              parametric=True, periodic=periodic)
@@ -1329,6 +1331,9 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     # posprocess: `axis=1` so that spl(u).shape == np.shape(x)
     # when `x` is a list of 1D arrays (cf original splPrep)
     cc = spl.c.T
-    spl1 = BSpline(spl.t, cc, spl.k, axis=1)
+    spl1 = BSpline(
+        spl.t, cc, spl.k, axis=1,
+        extrapolate='periodic' if periodic else True
+    )
 
     return spl1, xp.asarray(u)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -514,7 +514,7 @@ class interp1d(_Interpolator1D):
             ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
             + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
             )
-        
+
         return y_new
 
     def _call_nearest(self, x_new):
@@ -1402,6 +1402,18 @@ class PPoly:
         self._xp = xp
         self._xp_internal = xp_internal
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        state.pop("_xp_internal")
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        _, xp_internal = _get_xp_ppoly_cls(self._xp)
+        self._xp_internal = xp_internal
+        self.__dict__.update(state)
+
     @classmethod
     def _construct_from_xp(cls, xp_ppoly, *, xp_external):
         self = object.__new__(cls)
@@ -1920,6 +1932,18 @@ class BPoly:
         self._delegate_to = xp_bpoly_cls(c, x, extrapolate=extrapolate, axis=axis)
         self._xp = xp
         self._xp_internal = xp_internal
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        state.pop("_xp_internal")
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        _, xp_internal = _get_xp_bpoly_cls(self._xp)
+        self._xp_internal = xp_internal
+        self.__dict__.update(state)
 
     @classmethod
     def _construct_from_xp(cls, xp_bpoly, *, xp_external):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1393,6 +1393,9 @@ class PPoly:
     larger than 20-30.
     """
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
+
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
@@ -1924,6 +1927,9 @@ class BPoly:
 
     """  # noqa: E501
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
+
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_bpoly_cls, xp_internal = _get_xp_bpoly_cls(xp)
@@ -2407,6 +2413,9 @@ class NdPPoly:
     unstable.
 
     """
+    
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1781,7 +1781,9 @@ fitpack_sphere(PyObject* Py_UNUSED(dummy), PyObject *args)
         // tt and tp are input arrays that will be modified in-place
         // Acquire pointers to the input arrays without copy
         ap_tt = tt;
+        Py_INCREF(ap_tt);
         ap_tp = tp;
+        Py_INCREF(ap_tp);
 
     } else if (iopt == 0) {
         // SMOOTH
@@ -1842,11 +1844,6 @@ fitpack_sphere(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_r);
     Py_DECREF(ap_w);
 
-    if (iopt == -1) {
-        // LSQ: tt and tp were borrowed, INCREF before returning.
-        Py_INCREF(ap_tt);
-        Py_INCREF(ap_tp);
-    }
     return Py_BuildValue(("iNiNNdi"),
                          nt, PyArray_Return(ap_tt), np, PyArray_Return(ap_tp),
                          PyArray_Return(ap_c), fp, ier);

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1576,8 +1576,11 @@ fitpack_surfit(PyObject* Py_UNUSED(dummy), PyObject *args)
     memcpy(PyArray_DATA(ap_wrk_out), wrk1, (size_t)nc * sizeof(double));
 
     free(wrk1);
+    wrk1 = NULL;
     free(wrk2);
+    wrk2 = NULL;
     free(iwrk);
+    iwrk = NULL;
 
     /* Slice tx, ty to actual sizes nx, ny for return. */
     PyArrayObject *ap_tx_sliced = NULL;

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -2030,6 +2030,7 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
 {
     PyArrayObject *ap_u = NULL, *ap_x = NULL, *ap_w = NULL;
     PyArrayObject *ap_t = NULL, *ap_c = NULL, *ap_wrk = NULL, *ap_iwrk = NULL;
+    PyArrayObject *ap_t_pad = NULL, *ap_t_out = NULL, *ap_c_out = NULL;
     PyObject *u, *x, *w, *t_in, *wrk_in, *iwrk_in;
     int iopt, ipar, idim, m, mx, k, nest, n, nc, lwrk, ier, per;
     double ub, ue, s, fp;
@@ -2130,7 +2131,6 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
     nc = idim * nest;
 
     /* Pad t array to size nest */
-    PyArrayObject *ap_t_pad = NULL;
     dims[0] = nest;
     ap_t_pad = (PyArrayObject *)PyArray_ZEROS(1, dims, NPY_FLOAT64, 0);
     if (ap_t_pad == NULL) {
@@ -2146,7 +2146,6 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
     dims[0] = nc;
     ap_c = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_FLOAT64);
     if (ap_c == NULL) {
-        Py_DECREF(ap_t_pad);
         goto fail;
     }
 
@@ -2183,30 +2182,24 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
                (int *)PyArray_DATA(ap_iwrk), &ier);
     }
 
-    Py_DECREF(ap_x);
-    Py_DECREF(ap_w);
-    Py_DECREF(ap_t);
-    ap_t = NULL;  /* also in fail_after_call; NULL so the XDECREF there is a no-op */
+    Py_CLEAR(ap_x);
+    Py_CLEAR(ap_w);
+    Py_CLEAR(ap_t);
 
     /* Resize t and c to actual output size n */
-    PyArrayObject *ap_t_out = NULL;
-    PyArrayObject *ap_c_out = NULL;
     if (ier <= 3) {
         /* ier <= 0: normal return, ier=1,2,3: warnings but with valid output */
         dims[0] = n;
         ap_t_out = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_FLOAT64);
         if (ap_t_out == NULL) {
-            Py_DECREF(ap_t_pad);
-            goto fail_after_call;
+            goto fail;
         }
         memcpy(PyArray_DATA(ap_t_out), PyArray_DATA(ap_t_pad), n * sizeof(double));
 
         dims[0] = idim * (n - k - 1);
         ap_c_out = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_FLOAT64);
         if (ap_c_out == NULL) {
-            Py_DECREF(ap_t_out);
-            Py_DECREF(ap_t_pad);
-            goto fail_after_call;
+            goto fail;
         }
         /* Copy coefficients dimension by dimension.
          * fpclos stores coefficients with spacing: c[n*(j-1) + i-1] for dimension j, coef i
@@ -2226,16 +2219,12 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
         ap_t_out = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_FLOAT64);
         ap_c_out = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_FLOAT64);
         if (ap_t_out == NULL || ap_c_out == NULL) {
-            Py_XDECREF(ap_t_out);
-            Py_XDECREF(ap_c_out);
-            Py_DECREF(ap_t_pad);
-            goto fail_after_call;
+            goto fail;
         }
     }
 
-    Py_DECREF(ap_t_pad);
-    Py_DECREF(ap_c);
-    ap_c = NULL;  /* also in fail_after_call; NULL so the XDECREF there is a no-op */
+    Py_CLEAR(ap_t_pad);
+    Py_CLEAR(ap_c);
 
     /* Build output dict o = {'u': u, 'ub': ub, 'ue': ue, 'wrk': wrk, 'iwrk': iwrk, 'ier': ier, 'fp': fp} */
     PyObject *o = Py_BuildValue("{s:O,s:d,s:d,s:O,s:O,s:i,s:d}",
@@ -2247,9 +2236,7 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
                                 "ier", ier,
                                 "fp", fp);
     if (o == NULL) {
-        Py_DECREF(ap_t_out);
-        Py_DECREF(ap_c_out);
-        goto fail_after_call;
+        goto fail;
     }
 
     Py_DECREF(ap_u);
@@ -2258,20 +2245,15 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
 
     return Py_BuildValue("NNN", PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), o);
 
-fail_after_call:
-    Py_XDECREF(ap_u);
-    Py_XDECREF(ap_t);
-    Py_XDECREF(ap_c);
-    Py_XDECREF(ap_wrk);
-    Py_XDECREF(ap_iwrk);
-    return NULL;
-
 fail:
     Py_XDECREF(ap_u);
     Py_XDECREF(ap_x);
     Py_XDECREF(ap_w);
     Py_XDECREF(ap_t);
+    Py_XDECREF(ap_t_pad);
     Py_XDECREF(ap_c);
+    Py_XDECREF(ap_t_out);
+    Py_XDECREF(ap_c_out);
     Py_XDECREF(ap_wrk);
     Py_XDECREF(ap_iwrk);
     return NULL;

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -2186,6 +2186,7 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_w);
     Py_DECREF(ap_t);
+    ap_t = NULL;  /* also in fail_after_call; NULL so the XDECREF there is a no-op */
 
     /* Resize t and c to actual output size n */
     PyArrayObject *ap_t_out = NULL;
@@ -2234,6 +2235,7 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
 
     Py_DECREF(ap_t_pad);
     Py_DECREF(ap_c);
+    ap_c = NULL;  /* also in fail_after_call; NULL so the XDECREF there is a no-op */
 
     /* Build output dict o = {'u': u, 'ub': ub, 'ue': ue, 'wrk': wrk, 'iwrk': iwrk, 'ier': ier, 'fp': fp} */
     PyObject *o = PyDict_New();

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -2238,26 +2238,25 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
     ap_c = NULL;  /* also in fail_after_call; NULL so the XDECREF there is a no-op */
 
     /* Build output dict o = {'u': u, 'ub': ub, 'ue': ue, 'wrk': wrk, 'iwrk': iwrk, 'ier': ier, 'fp': fp} */
-    PyObject *o = PyDict_New();
+    PyObject *o = Py_BuildValue("{s:O,s:d,s:d,s:O,s:O,s:i,s:d}",
+                                "u", (PyObject *)ap_u,
+                                "ub", ub,
+                                "ue", ue,
+                                "wrk", (PyObject *)ap_wrk,
+                                "iwrk", (PyObject *)ap_iwrk,
+                                "ier", ier,
+                                "fp", fp);
     if (o == NULL) {
         Py_DECREF(ap_t_out);
         Py_DECREF(ap_c_out);
         goto fail_after_call;
     }
 
-    PyDict_SetItemString(o, "u", (PyObject *)ap_u);
-    PyDict_SetItemString(o, "ub", PyFloat_FromDouble(ub));
-    PyDict_SetItemString(o, "ue", PyFloat_FromDouble(ue));
-    PyDict_SetItemString(o, "wrk", (PyObject *)ap_wrk);
-    PyDict_SetItemString(o, "iwrk", (PyObject *)ap_iwrk);
-    PyDict_SetItemString(o, "ier", PyLong_FromLong(ier));
-    PyDict_SetItemString(o, "fp", PyFloat_FromDouble(fp));
-
     Py_DECREF(ap_u);
     Py_DECREF(ap_wrk);
     Py_DECREF(ap_iwrk);
 
-    return Py_BuildValue(("NNO"), PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), o);
+    return Py_BuildValue("NNN", PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), o);
 
 fail_after_call:
     Py_XDECREF(ap_u);

--- a/scipy/interpolate/src/dfitpack.c
+++ b/scipy/interpolate/src/dfitpack.c
@@ -1,4 +1,5 @@
 #include "dfitpack.h"
+#include <limits.h>
 
 // The following are not yet translated from the original FITPACK Fortran77 code.
 // cocosp
@@ -1238,7 +1239,8 @@ restart_iteration:
         npl1 = nplus * 2;
         rn = nplus;
         if ((fpold - *fp) > acc) {
-            npl1 = (int)(rn * fpms / (fpold - *fp));
+            double val = rn * fpms / (fpold - *fp);
+            npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
         }
 
         {
@@ -1811,7 +1813,10 @@ restart_iteration:
         if (*ier == 0) {
             npl1 = nplus * 2;
             rn = (double)nplus;
-            if (fpold - *fp > acc) { npl1 = (int)(rn * fpms / (fpold - *fp)); }
+            if (fpold - *fp > acc) {
+                double val = rn * fpms / (fpold - *fp);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
+            }
             // nplus = min(nplus*2, max(npl1, nplus/2, 1))
             int temp1 = npl1;
             int temp2 = nplus / 2;
@@ -4000,7 +4005,8 @@ restart_iteration:
             npl1 = nplus * 2;
             rn = (double)nplus;
             if ((fpold - *fp) > acc) {
-                npl1 = (int)(rn * fpms / (fpold - *fp));
+                double val = rn * fpms / (fpold - *fp);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
             }
             // nplus = min0(nplus*2,max0(npl1,nplus/2,1))
             int temp1 = nplus * 2;
@@ -4725,7 +4731,8 @@ restart_iteration:
         npl1 = nplus * 2;
         rn = nplus;
         if ((fpold - *fp) > acc) {
-            npl1 = (int)(rn * fpms / (fpold - *fp));
+            double val = rn * fpms / (fpold - *fp);
+            npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
         }
         // min0(nplus*2,max0(npl1,nplus/2,1))
         int temp1 = npl1;
@@ -5630,7 +5637,8 @@ restart_iteration:
             int npl1 = (*nplusx) * 2;
             double rn = (double)(*nplusx);
             if (*reducx > acc) {
-                npl1 = (int)(rn * fpms / (*reducx));
+                double val = rn * fpms / (*reducx);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
             }
             // nplx = min0(nplusx*2,max0(npl1,nplusx/2,1))
             int temp1 = (*nplusx) * 2;
@@ -5650,7 +5658,8 @@ restart_iteration:
             int npl1 = (*nplusy) * 2;
             double rn = (double)(*nplusy);
             if (*reducy > acc) {
-                npl1 = (int)(rn * fpms / (*reducy));
+                double val = rn * fpms / (*reducy);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
             }
             // nply = min0(nplusy*2,max0(npl1,nplusy/2,1))
             int temp1 = (*nplusy) * 2;
@@ -7022,7 +7031,10 @@ L120:
         if (*nu != 8) {
             npl1 = *nplusu * 2;
             rn = (double)(*nplusu);
-            if (*reducu > acc) { npl1 = (int)(rn * fpms / (*reducu)); }
+            if (*reducu > acc) {
+                double val = rn * fpms / (*reducu);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
+            }
             int max1 = (npl1 > *nplusu / 2) ? npl1 : *nplusu / 2;
             int max2 = (max1 > 1) ? max1 : 1;
             nplu = (*nplusu * 2 < max2) ? *nplusu * 2 : max2;
@@ -7032,7 +7044,10 @@ L120:
         if (*nv != 8) {
             npl1 = *nplusv * 2;
             rn = (double)(*nplusv);
-            if (*reducv > acc) { npl1 = (int)(rn * fpms / (*reducv)); }
+            if (*reducv > acc) {
+                double val = rn * fpms / (*reducv);
+                npl1 = (val > INT_MAX) ? INT_MAX : (int)val;
+            }
             int max1 = (npl1 > *nplusv / 2) ? npl1 : *nplusv / 2;
             int max2 = (max1 > 1) ? max1 : 1;
             nplv = (*nplusv * 2 < max2) ? *nplusv * 2 : max2;

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -4055,6 +4055,24 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
         xp_assert_close(np.r_[spl.c, [0]*(spl.k+1)],
                         tck[1])
 
+    @pytest.mark.parametrize("s", [1, 1e-8, 42])
+    def test_spline_endpoints_match(self, s):
+        """make_splrep with bc_type='periodic' must produce a periodic
+        spline."""
+        theta = np.linspace(0, 1, 11)
+        y = np.cos(2*np.pi*theta)
+        spl = make_splrep(theta, y, s=s, bc_type="periodic")
+        xp_assert_close(spl(theta[0]), spl(theta[-1]), atol=1e-12)
+        assert spl.extrapolate == 'periodic'
+        # check wraparound: spl(u + delta) = spl(u + 2 * delta)
+        xp_assert_close(spl(theta[-1] + 0.2), spl(theta[0] + 0.2), atol=1e-12)
+        xp_assert_close(spl(theta[0] - 0.2), spl(theta[-1] - 0.2), atol=1e-12)
+        # check k-derivatives
+        nus = np.arange(spl.k)
+        vals_right = np.array([spl(theta[-1] + 0.2, nu) for nu in nus])
+        vals_left = np.array([spl(theta[0] + 0.2, nu) for nu in nus])
+        xp_assert_close(vals_right, vals_left, atol=1e-10)
+
     @pytest.mark.parametrize("k_fp", [(1, -0.0001), (2, -0.0001), (3, -8.62e-05)])
     @pytest.mark.parametrize("s", [1e-4])
     def test_fperiodic_basic_fit(self, k_fp, s):
@@ -4078,7 +4096,6 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
         y_check = bs(x_check)
 
         xp_assert_close(y_check[0], y_check[1])
-
 
 @make_xp_test_case(make_splprep)
 class TestMakeSplprep:
@@ -4116,7 +4133,6 @@ class TestMakeSplprep:
         # values: note axis=1
         xp_assert_close(spl(u),
                         BSpline(t, c, k, axis=1)(u), atol=1e-15)
-
     @pytest.mark.parametrize('s', [0, 0.1, 1e-3, 1e-5])
     def test_array_not_list(self, s):
         # the argument of splPrep is either a list of arrays or a 2D array (sigh)
@@ -4205,7 +4221,7 @@ class TestMakeSplprepPeriodic:
         y = [np.sin(x), np.cos(x)]
 
         # the number of knots depends on `s` (this is by construction)
-        num_knots = {0: 14, 1e-4: 16, 1e-5: 16, 1e-6: 16}
+        num_knots = {0: 16, 1e-4: 16, 1e-5: 16, 1e-6: 16}
 
         # construct the splines
         (t, c, k), u_ = splprep(y, s=s, per=1)
@@ -4220,6 +4236,25 @@ class TestMakeSplprepPeriodic:
         # values: note axis=1
         xp_assert_close(spl(u), BSpline(t, c, k, axis=1)(u),
                         atol=1e-06, rtol=1e-06)
+
+    @pytest.mark.parametrize("s", [1, 1e-8, 42])
+    def test_spline_endpoints_match(self, s):
+        """make_splprep with bc_type='periodic' must produce a periodic
+        spline: matching endpoint values, extrapolate='periodic'."""
+        theta = np.linspace(0, 1, 11)
+        x = np.sin(2*np.pi*theta)
+        y = np.cos(2*np.pi*theta)
+        spl, u = make_splprep([x, y], u=theta, s=s, bc_type="periodic")
+        xp_assert_close(spl(u[0]), spl(u[-1]), atol=1e-12)
+        assert spl.extrapolate == 'periodic'
+        # check wraparound: spl(u + delta) = spl(u + 2 * delta)
+        xp_assert_close(spl(u[-1] + 0.2), spl(u[0] + 0.2), atol=1e-12)
+        xp_assert_close(spl(u[0] - 0.2), spl(u[-1] - 0.2), atol=1e-12)
+        # check k-derivatives match
+        nus = np.arange(spl.k)
+        vals_right = np.array([spl(u[-1] + 0.2, nu) for nu in nus])
+        vals_left = np.array([spl(u[0] + 0.2, nu) for nu in nus])
+        xp_assert_close(vals_right, vals_left, atol=1e-10)
 
     @pytest.mark.parametrize('s', [0, 1e-4, 1e-5, 1e-6])
     def test_array_not_list(self, s):
@@ -4289,6 +4324,33 @@ class TestMakeSplprepPeriodic:
         assert spl(u).shape == (1, 8)
         xp_assert_close(spl(u), [x], atol=1e-15)
 
+    @pytest.mark.parametrize("bc_type", [None, "not-a-knot", "periodic"])
+    @pytest.mark.parametrize("matching_endpoints", [True, False])
+    def test_bc_type_match_s0(self, bc_type, matching_endpoints):
+        # make_splprep at s=0 must match bc_type correctly to
+        # make_interp_spline, for every bc_type, endpoint-matching
+        theta = np.linspace(0, 1, 11)
+        x = np.sin(2*np.pi*theta)
+        y = np.cos(2*np.pi*theta)
+
+        if not matching_endpoints:
+            x = x.copy()
+            x[-1] = 1
+
+        periodic = (bc_type == "periodic")
+        should_raise = periodic and not matching_endpoints
+        xy = np.column_stack([x, y])
+        if should_raise:
+            with assert_raises(ValueError):
+                make_splprep([x, y], u=theta, s=0, bc_type=bc_type)
+            with assert_raises(ValueError):
+                make_interp_spline(theta, xy, bc_type=bc_type)
+        else:
+            spl, u = make_splprep([x, y], u=theta, s=0, bc_type=bc_type)
+            expected = make_interp_spline(theta, xy, bc_type=bc_type)
+            xp_assert_close(spl.c, expected.c, atol=1e-12)
+            xp_assert_close(spl.t, expected.t, atol=1e-12)
+            assert spl.extrapolate == expected.extrapolate
 
 class BatchSpline:
     # BSpline-line class with reference batch behavior

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1481,6 +1481,54 @@ class TestRectBivariateSpline:
             Interpolator(GridPosLats, nonGridPosLons)
         assert "y must be strictly increasing" in str(exc_info.value)
 
+    def test_grid_sparse_meshgrid(self):
+        # gh-25730
+        x = np.arange(-10.0, 10.0)
+        y = np.arange(-20.0, 20.0)
+        lut = RectBivariateSpline(x, y, np.hypot(x[:, None], y[None, :]), s=0)
+
+        xi = np.linspace(-10.0, 10.0, 25)
+        yi = np.linspace(-20.0, 20.0, 30)
+        xs, ys = np.meshgrid(xi, yi, sparse=True, indexing="ij")
+        assert xs.ndim == 2 and ys.ndim == 2
+
+        xp_assert_close(lut(xs, ys), lut(xi, yi), atol=1e-14)
+
+    def test_grid_sparse_meshgrid_values(self):
+        # gh-25730
+        # The snippet from the issue, without its denominator so that no nans
+        # enter the fit. Reference values obtained by running it on scipy 1.16.1.
+        x = np.arange(-10, 10)
+        y = np.arange(-20, 20)
+        x_mesh, y_mesh = np.meshgrid(x, y)
+        z = np.sin(np.sqrt(x_mesh**2 + y_mesh**2))
+
+        xi = np.linspace(-10, 10, endpoint=True, num=3)
+        yi = np.linspace(-20, 20, endpoint=True, num=3)
+        xs, ys = np.meshgrid(xi, yi, sparse=True)
+
+        expected = np.array([
+            [-3.61178317e-01, 9.12945251e-01, 5.94013869e-02],
+            [-5.44021111e-01, -2.15105711e-16, 4.12118485e-01],
+            [4.97086683e-01, 1.49877210e-01, 8.23386213e-01],
+        ])
+        xp_assert_close(RectBivariateSpline(y, x, z, s=0)(ys, xs), expected, atol=1e-14)
+
+    def test_not_increasing_input_2d(self):
+        # gh-25730
+        x = np.arange(5.0)
+        y = np.arange(6.0)
+        lut = RectBivariateSpline(x, y, np.hypot(x[:, None], y[None, :]), s=0)
+
+        decreasing = np.array([3.0, 1.0, 4.0])
+        with assert_raises(ValueError) as exc_info:
+            lut(decreasing[:, None], y[None, :])
+        assert "x must be strictly increasing" in str(exc_info.value)
+
+        with assert_raises(ValueError) as exc_info:
+            lut(x[:, None], decreasing[None, :])
+        assert "y must be strictly increasing" in str(exc_info.value)
+
     def _sample_large_2d_data(self, nx, ny):
         rng = np.random.default_rng(1)
         x = np.arange(nx)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -746,6 +746,92 @@ class TestSmoothBivariateSpline:
         xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
 
+def _contiguous(a):
+    """C-contiguous reference layout."""
+    return np.ascontiguousarray(a, dtype=np.float64)
+
+
+def _strided(a):
+    """Return a non-contiguous view of `a`, interleaved with NaN. A read that
+    wrongly assumes C-contiguity picks up a NaN; a correct strided read does
+    not."""
+    a = np.asarray(a, dtype=np.float64)
+    v = np.stack([a, np.full_like(a, np.nan)], axis=-1)[..., 0]
+    assert not v.flags["C_CONTIGUOUS"]
+    return v
+
+
+# Builders for the non-contiguous-input sweep below. Each applies `prep` to
+# every array input and returns the fit evaluated at fixed points (flattened).
+# Data is regenerated identically per call (fixed seed) so the only difference
+# between two calls is `prep`.
+def _scattered_data():
+    rng = np.random.default_rng(0)
+    src = rng.uniform(-5, 5, (400, 2))
+    x, y = src[:, 0].copy(), src[:, 1].copy()
+    return x, y, x ** 2 + y
+
+
+def _sphere_scattered_data():
+    rng = np.random.default_rng(0)
+    theta = rng.uniform(0.1, np.pi - 0.1, 200)
+    phi = rng.uniform(0.1, 2 * np.pi - 0.1, 200)
+    return theta, phi, np.sin(theta) * np.cos(phi)
+
+
+def _fit_smooth_bivariate(prep):
+    x, y, z = _scattered_data()
+    return SmoothBivariateSpline(prep(x), prep(y), prep(z), kx=2, ky=2).ev(x, y)
+
+
+def _fit_lsq_bivariate(prep):
+    x, y, z = _scattered_data()
+    t = np.linspace(-4, 4, 3)
+    return LSQBivariateSpline(prep(x), prep(y), prep(z), prep(t), prep(t),
+                              kx=2, ky=2).ev(x, y)
+
+
+def _fit_rect_bivariate(prep):
+    gx, gy = np.linspace(0, 1, 12), np.linspace(0, 1, 14)
+    gz = np.sin(gx[:, None]) * np.cos(gy[None, :])
+    spl = RectBivariateSpline(prep(gx), prep(gy), prep(gz))
+    return spl(np.linspace(0.1, 0.9, 5), np.linspace(0.1, 0.9, 5)).ravel()
+
+
+def _fit_smooth_sphere(prep):
+    theta, phi, r = _sphere_scattered_data()
+    spl = SmoothSphereBivariateSpline(prep(theta), prep(phi), prep(r), s=2.0)
+    return spl.ev(theta, phi)
+
+
+def _fit_lsq_sphere(prep):
+    theta, phi, r = _sphere_scattered_data()
+    tt = np.linspace(0, np.pi, 5)[1:-1]
+    tp = np.linspace(0, 2 * np.pi, 5)[1:-1]
+    return LSQSphereBivariateSpline(prep(theta), prep(phi), prep(r),
+                                    prep(tt), prep(tp)).ev(theta, phi)
+
+
+def _fit_rect_sphere(prep):
+    u = np.linspace(0, np.pi, 14)[1:-1]
+    v = np.linspace(0, 2 * np.pi, 14, endpoint=False)
+    rg = np.sin(u[:, None]) * np.cos(v[None, :])
+    return RectSphereBivariateSpline(prep(u), prep(v), prep(rg))(u, v).ravel()
+
+
+@pytest.mark.parametrize("fit", [
+    pytest.param(_fit_smooth_bivariate, id="SmoothBivariateSpline"),
+    pytest.param(_fit_lsq_bivariate, id="LSQBivariateSpline"),
+    pytest.param(_fit_rect_bivariate, id="RectBivariateSpline"),
+    pytest.param(_fit_smooth_sphere, id="SmoothSphereBivariateSpline"),
+    pytest.param(_fit_lsq_sphere, id="LSQSphereBivariateSpline"),
+    pytest.param(_fit_rect_sphere, id="RectSphereBivariateSpline"),
+])
+def test_bivariate_spline_noncontiguous_input(fit):
+    # The FITPACK C bindings read x/y/z/w buffers assuming C-contiguity.
+    xp_assert_close(fit(_strided), fit(_contiguous))
+
+
 class TestLSQSphereBivariateSpline:
     def setup_method(self):
         # define the input data and coordinates

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -745,6 +745,18 @@ class TestSmoothBivariateSpline:
                                      kx=1, ky=1)
         xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
+    def test_0d(self):
+        # regression test for https://github.com/scipy/scipy/issues/25471
+        # result shapes checked with SciPy 1.16.3 (pre FITPACK C port)
+        rng = np.random.default_rng(0)
+        xs, ys = rng.random(30), rng.random(30)
+        zs = xs * ys
+        s = SmoothBivariateSpline(xs, ys, zs)(0.4, 0.5, grid=False)
+        assert s.ndim == 0
+
+        s = SmoothBivariateSpline(xs, ys, zs)([0.4], 0.5, grid=False)
+        assert s.ndim == 1
+
 
 def _contiguous(a):
     """C-contiguous reference layout."""
@@ -1639,6 +1651,16 @@ class TestRectBivariateSpline:
         z_spl = spl_eval(spl, x, y)
         assert not np.isnan(z_spl).any()
         xp_assert_close(z_spl, z, atol=0.1, rtol=0.1)
+
+    def test_0d(self):
+        # regression test for https://github.com/scipy/scipy/issues/25471
+        # result shapes checked with SciPy 1.16.3 (pre FITPACK C port)
+        x = np.arange(6.0)
+        r = RectBivariateSpline(x, x, np.outer(x, x))(2.5, 3.5, grid=False)
+        assert r.ndim == 0
+
+        r = RectBivariateSpline(x, x, np.outer(x, x))([2.5], 3.5, grid=False)
+        assert r.ndim == 1
 
 
 class TestRectSphereBivariateSpline:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,3 +1,5 @@
+import pickle
+
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal,
     make_xp_test_case, is_cupy, _xp_copy_to_numpy
@@ -11,7 +13,10 @@ import numpy as np
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
         splrep, splev, splantider, splint, sproot, Akima1DInterpolator,
-        NdPPoly, BSpline, PchipInterpolator)
+        NdPPoly, BSpline, PchipInterpolator, make_interp_spline, CubicSpline,
+        FloaterHormannInterpolator, BarycentricInterpolator, KroghInterpolator,
+        CubicHermiteSpline, LinearNDInterpolator, NearestNDInterpolator,
+        CloughTocher2DInterpolator, RBFInterpolator, RegularGridInterpolator)
 
 from scipy.special import poch, gamma
 
@@ -2800,3 +2805,47 @@ def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew, nu=None):
         out[jout] = val
 
     return out
+
+@pytest.mark.parametrize("interp", [make_interp_spline,  # BSpline
+                                    CubicSpline,
+                                    PchipInterpolator,
+                                    Akima1DInterpolator,
+                                    FloaterHormannInterpolator,
+                                    BarycentricInterpolator,
+                                    KroghInterpolator,
+                                    lambda x, y: BPoly.from_derivatives(
+                                        x,[[yi, yi, yi] for yi in y]),
+                                    lambda x, y: CubicHermiteSpline(x, y, y)])  # PPoly
+def test_pickleable_1D(interp):
+    x = np.linspace(0, 1, 10)
+    y = np.exp(x)
+    x_eval = np.linspace(0, 1, 100)
+    obj = interp(x, y)
+    y1 = obj(x_eval)
+    y2 = pickle.loads(pickle.dumps(obj))(x_eval)
+    xp_assert_close(y1, y2, atol=1e-12)
+
+
+@pytest.mark.parametrize("interp", [LinearNDInterpolator,
+                                    NearestNDInterpolator,
+                                    CloughTocher2DInterpolator,
+                                    RBFInterpolator,
+                                    RegularGridInterpolator,])
+def test_pickleable_2D(interp):
+    # generate data on a regular grid
+    x = np.linspace(0, 1, 5)
+    y = np.linspace(0, 1, 5)
+    X, Y = np.meshgrid(x, y)
+    Z = np.exp(X + Y)
+    points = np.column_stack([X.ravel(), Y.ravel()])
+    if interp is RegularGridInterpolator:
+        obj = interp((x, y), Z)
+    else:
+        obj = interp(points, Z.ravel())
+    x_eval = np.linspace(0, 1, 10)
+    y_eval = np.linspace(0, 1, 10)
+    X_eval, Y_eval = np.meshgrid(x_eval, y_eval)
+    eval_points = np.column_stack([X_eval.ravel(), Y_eval.ravel()])
+    Z1 = obj(eval_points)
+    Z2 = pickle.loads(pickle.dumps(obj))(eval_points)
+    xp_assert_close(Z1, Z2, atol=1e-12)

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -827,7 +827,7 @@ def signm(A):
     # min_nonzero_sv = vals[(vals>max_sv*errtol).tolist().count(1)-1]
     # c = 0.5/min_nonzero_sv
     c = 0.5/max_sv
-    S0 = A + c*np.identity(A.shape[0])
+    S0 = A + c*np.identity(A.shape[0], dtype=A.dtype)
     prev_errest = errest
     for i in range(100):
         iS0 = inv(S0)

--- a/scipy/linalg/_misc.py
+++ b/scipy/linalg/_misc.py
@@ -204,15 +204,15 @@ def bandwidth(a):
 
     Returns
     -------
-    lower : np.int64 | nDArray[np.int64]
-        Lower bandwidth. a scalar ``np.int64`` is assigned per
+    lower : int | ndarray
+        Lower bandwidth. A scalar ``np.int64`` is assigned per
         2D slice of the input array of last two dimensions. A value of 0
         means the slice is upper triangular; ``N - 1`` means the lower part
-        is full. If the input array is 2D then a scalar int64 is returned.
-    upper : np.int64 | nDArray[np.int64]
+        is full. If the input array is 2D then an :class:`int` is returned.
+    upper : int | ndarray
         Upper bandwidth. Same shape rules as `lower`. A value of 0
         means the slice is lower triangular; ``M - 1`` means the upper
-        part is full. If the input array is 2D then a scalar int64 is returned.
+        part is full. If the input array is 2D then a scalar :class:`int` is returned.
 
     Raises
     ------

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1401,17 +1401,16 @@ _linalg_bandwidth(PyObject* Py_UNUSED(dummy), PyObject* args) {
         }
     }
 
-    // 2D: return tuple of np.int64 scalars; N-d: return tuple of int64 arrays
+    // 2D: return tuple of int scalars; N-d: return tuple of int64 arrays
     if (ndim == 2) {
-        PyArray_Descr *descr = PyArray_DescrFromType(NPY_INT64);
-        PyObject *lb_obj = PyArray_Scalar(&lb_data[0], descr, NULL);
-        PyObject *ub_obj = PyArray_Scalar(&ub_data[0], descr, NULL);
-        Py_DECREF(descr);
+        // TODO: use PyLong_FromInt64 from py314+
+        PyObject *lb_obj = PyLong_FromSsize_t((Py_ssize_t)lb_data[0]);
+        PyObject *ub_obj = PyLong_FromSsize_t((Py_ssize_t)ub_data[0]);
         Py_DECREF(ap_lb); Py_DECREF(ap_ub);
-        return Py_BuildValue("(NN)", lb_obj, ub_obj);
+        return Py_BuildValue("NN", lb_obj, ub_obj);
     }
 
-    return Py_BuildValue("(NN)", (PyObject *)ap_lb, (PyObject *)ap_ub);
+    return Py_BuildValue("NN", (PyObject *)ap_lb, (PyObject *)ap_ub);
 }
 
 

--- a/scipy/linalg/src/_matfuncs_expm.c
+++ b/scipy/linalg/src/_matfuncs_expm.c
@@ -1,77 +1,73 @@
 #include "_common_array_utils.h"
 
-static float snorm1(float*, float*, const Py_ssize_t);
-static double dnorm1(double*, double*, const Py_ssize_t);
-static float cnorm1(SCIPY_C*, float*, const Py_ssize_t);
-static double znorm1(SCIPY_Z*, double*, const Py_ssize_t);
-static float snorm1est(float*, CBLAS_INT);
-static double dnorm1est(double*, CBLAS_INT);
-static float cnorm1est(SCIPY_C*, CBLAS_INT);
-static double znorm1est(SCIPY_Z*, CBLAS_INT);
+static float snorm1(float*, const Py_ssize_t);
+static double dnorm1(double*, const Py_ssize_t);
+static float cnorm1(SCIPY_C*, const Py_ssize_t);
+static double znorm1(SCIPY_Z*, const Py_ssize_t);
+static float snorm1est(float*, CBLAS_INT, CBLAS_INT);
+static double dnorm1est(double*, CBLAS_INT, CBLAS_INT);
+static float cnorm1est(SCIPY_C*, CBLAS_INT, CBLAS_INT);
+static double znorm1est(SCIPY_Z*, CBLAS_INT, CBLAS_INT);
 
 
-/*******************************************************************************
- *******************************************************************************
- *******************************************************************************/
+/***********************************************************************
+ ********1-Norm functions for Column-major arrays **********************
+ ***********************************************************************/
 
- static float
-snorm1(float* A, float* work, const Py_ssize_t n)
+static float
+snorm1(float* A, const Py_ssize_t n)
 {
-    Py_ssize_t i, j;
-    float temp = 0.0;
-    // Write absolute values of first row of A to work
-    for (i = 0; i < n; i++) { work[i] = fabsf(A[i]); }
-    // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += fabsf(A[i*n + j]); } }
-    temp = 0.0;
-    for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
-    return temp;
+    float norm = 0.0;
+    for (Py_ssize_t i = 0; i < n; i++)
+    {
+        float abscolsum = 0.0;
+        for (Py_ssize_t j = 0; j < n; j++) { abscolsum += fabsf(A[i*n + j]); }
+        if (abscolsum > norm) { norm = abscolsum; }
+    }
+    return norm;
 }
 
 static double
-dnorm1(double* A, double* work, const Py_ssize_t n)
+dnorm1(double* A, const Py_ssize_t n)
 {
-    Py_ssize_t i, j;
-    double temp = 0.0;
-    // Write absolute values of first row of A to work
-    for (i = 0; i < n; i++) { work[i] = fabs(A[i]); }
-    // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += fabs(A[i*n + j]); } }
-    temp = 0.0;
-    for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
-    return temp;
+    double norm = 0.0;
+    for (Py_ssize_t i = 0; i < n; i++)
+    {
+        double abscolsum = 0.0;
+        for (Py_ssize_t j = 0; j < n; j++) { abscolsum += fabs(A[i*n + j]); }
+        if (abscolsum > norm) { norm = abscolsum; }
+    }
+    return norm;
 }
 
 static float
-cnorm1(SCIPY_C* A, float* work, const Py_ssize_t n)
+cnorm1(SCIPY_C* A, const Py_ssize_t n)
 {
-    Py_ssize_t i, j;
-    float temp = 0.0;
-    // Write absolute values of first row of A to work
-    for (i = 0; i < n; i++) { work[i] = cabsf(A[i]); }
-    // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += cabsf(A[i*n + j]); } }
-    temp = 0.0;
-    for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
-    return temp;
+    float norm = 0.0;
+    for (Py_ssize_t i = 0; i < n; i++)
+    {
+        float abscolsum = 0.0;
+        for (Py_ssize_t j = 0; j < n; j++) { abscolsum += cabsf(A[i*n + j]); }
+        if (abscolsum > norm) { norm = abscolsum; }
+    }
+    return norm;
 }
 
 static double
-znorm1(SCIPY_Z* A, double* work, const Py_ssize_t n)
+znorm1(SCIPY_Z* A, const Py_ssize_t n)
 {
-    Py_ssize_t i, j;
-    double temp = 0.0;
-    // Write absolute values of first row of A to work
-    for (i = 0; i < n; i++) { work[i] = cabs(A[i]); }
-    // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += cabs(A[i*n + j]); } }
-    temp = 0.0;
-    for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
-    return temp;
+    double norm = 0.0;
+    for (Py_ssize_t i = 0; i < n; i++)
+    {
+        double abscolsum = 0.0;
+        for (Py_ssize_t j = 0; j < n; j++) { abscolsum += cabs(A[i*n + j]); }
+        if (abscolsum > norm) { norm = abscolsum; }
+    }
+    return norm;
 }
 
 static float
-snorm1est(float* A, CBLAS_INT n)
+snorm1est(float* A, CBLAS_INT n, CBLAS_INT p)
 {
     CBLAS_INT from = 2*n, to = n, kase = 0, tempint, int1 = 1;
     CBLAS_INT isave[3];
@@ -81,17 +77,21 @@ snorm1est(float* A, CBLAS_INT n)
     if (!work_arr) { return -100; }
     CBLAS_INT* iwork_arr = PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (!iwork_arr) { PyMem_RawFree(work_arr);return -101; }
-    // 1-norm estimator by reverse communication
+    // 1-norm estimator of A**p by reverse communication
     // dlacon( n, v, x, isgn, est, kase )
     BLAS_FUNC(slacn2)(&n, work_arr, &work_arr[n], iwork_arr, &est, &kase, isave);
 
     while (kase)
     {
-        opA = (kase == 1 ? "T" : "N");
-        tempint = from;
-        from = to;
-        to = tempint;
-        BLAS_FUNC(sgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        // lacn2 asks for A @ x when kase is 1 and A.T @ x otherwise
+        opA = (kase == 1 ? "N" : "T");
+        for (CBLAS_INT k = 0; k < p; k++)
+        {
+            tempint = from;
+            from = to;
+            to = tempint;
+            BLAS_FUNC(sgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        }
         BLAS_FUNC(slacn2)(&n, work_arr, &work_arr[to], iwork_arr, &est, &kase, isave);
     }
 
@@ -103,7 +103,7 @@ snorm1est(float* A, CBLAS_INT n)
 
 
 static double
-dnorm1est(double* A, CBLAS_INT n)
+dnorm1est(double* A, CBLAS_INT n, CBLAS_INT p)
 {
     CBLAS_INT from = 2*n, to = n, kase = 0, tempint, int1 = 1;
     CBLAS_INT isave[3];
@@ -113,17 +113,21 @@ dnorm1est(double* A, CBLAS_INT n)
     if (!work_arr) { return -100; }
     CBLAS_INT* iwork_arr = PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (!iwork_arr) { PyMem_RawFree(work_arr);return -101; }
-    // 1-norm estimator by reverse communication
+    // 1-norm estimator of A**p by reverse communication
     // dlacon( n, v, x, isgn, est, kase )
     BLAS_FUNC(dlacn2)(&n, work_arr, &work_arr[n], iwork_arr, &est, &kase, isave);
 
     while (kase)
     {
-        opA = (kase == 1 ? "T" : "N");
-        tempint = from;
-        from = to;
-        to = tempint;
-        BLAS_FUNC(dgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        // dlacn2 asks for A @ x when kase is 1 and A.T @ x otherwise
+        opA = (kase == 1 ? "N" : "T");
+        for (CBLAS_INT k = 0; k < p; k++)
+        {
+            tempint = from;
+            from = to;
+            to = tempint;
+            BLAS_FUNC(dgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        }
         BLAS_FUNC(dlacn2)(&n, work_arr, &work_arr[to], iwork_arr, &est, &kase, isave);
     }
 
@@ -135,7 +139,7 @@ dnorm1est(double* A, CBLAS_INT n)
 
 
 static float
-cnorm1est(SCIPY_C* A, CBLAS_INT n)
+cnorm1est(SCIPY_C* A, CBLAS_INT n, CBLAS_INT p)
 {
     CBLAS_INT from = 2*n, to = n, kase = 0, tempint, int1 = 1;
     CBLAS_INT isave[3];
@@ -149,11 +153,15 @@ cnorm1est(SCIPY_C* A, CBLAS_INT n)
 
     while (kase)
     {
-        opA = (kase == 1 ? "C" : "N");
-        tempint = from;
-        from = to;
-        to = tempint;
-        BLAS_FUNC(cgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        // lacn2 asks for A @ x when kase is 1 and A.conj().T @ x otherwise
+        opA = (kase == 1 ? "N" : "C");
+        for (CBLAS_INT k = 0; k < p; k++)
+        {
+            tempint = from;
+            from = to;
+            to = tempint;
+            BLAS_FUNC(cgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        }
         BLAS_FUNC(clacn2)(&n, work_arr, &work_arr[to], &est, &kase, isave);
     }
 
@@ -164,7 +172,7 @@ cnorm1est(SCIPY_C* A, CBLAS_INT n)
 
 
 static double
-znorm1est(SCIPY_Z* A, CBLAS_INT n)
+znorm1est(SCIPY_Z* A, CBLAS_INT n, CBLAS_INT p)
 {
     CBLAS_INT from = 2*n, to = n, kase = 0, tempint, int1 = 1;
     CBLAS_INT isave[3];
@@ -178,11 +186,15 @@ znorm1est(SCIPY_Z* A, CBLAS_INT n)
 
     while (kase)
     {
-        opA = (kase == 1 ? "C" : "N");
-        tempint = from;
-        from = to;
-        to = tempint;
-        BLAS_FUNC(zgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        // lacn2 asks for A @ x when kase is 1 and A.conj().T @ x otherwise
+        opA = (kase == 1 ? "N" : "C");
+        for (CBLAS_INT k = 0; k < p; k++)
+        {
+            tempint = from;
+            from = to;
+            to = tempint;
+            BLAS_FUNC(zgemv)(opA, &n, &n, &dbl1, A, &n, &work_arr[from], &int1, &dbl0, &work_arr[to], &int1);
+        }
         BLAS_FUNC(zlacn2)(&n, work_arr, &work_arr[to], &est, &kase, isave);
     }
 
@@ -200,19 +212,18 @@ static void
 pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
 {
     Py_ssize_t i, j;
-    Py_ssize_t dims[2];
     int lm = 0;
     CBLAS_INT int1 = 1, n = (CBLAS_INT)size_n;
     float normA, dbl1 = 1.0, dbl0 = 0.0;
     float d4, d6, d8, d10, eta0, eta1, eta2, eta3, eta4, two_pow_s, temp, test;
     float theta[5];
     float coeff[5];
-    // work_arr is two (n,) cols that will be used multiplying absA, alternating.
+    // work_arr is two (n,) cols that will be used multiplying absA.T, alternating.
     float* restrict work_arr = &Am[6*n*n];
     float* restrict absA = &Am[5*n*n];
 
-    dims[0] = n;
-    dims[1] = n;
+    *m = 0;
+    *s = 0;
     theta[0] = 1.495585217958292e-002;
     theta[1] = 2.539398330063230e-001;
     theta[2] = 9.504178996162932e-001;
@@ -237,7 +248,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     }
 
     // First spin = normest(|A|, m=1)
-    BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
+    BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
     normA = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > normA) { normA = work_arr[n+i]; } }
 
@@ -245,8 +256,8 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &dbl0, &Am[1*n*n], &n);
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[2*n*n], &n);
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[3*n*n], &n);
-    d4 = powf(snorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = powf(snorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = powf(snorm1(&Am[2*n*n], n), 0.25);
+    d6 = powf(snorm1(&Am[3*n*n], n), 1.0/6.0);
     eta0 = fmaxf(d4, d6);
     eta1 = eta0;
 
@@ -254,12 +265,12 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     // -------
     // 1-norm of A**7
     // Alternating matvecs
-    // absA * work_arr[n:] = work_arr[:n]
-    // absA * work_arr[:n] = work_arr[n:]
+    // absA.T * work_arr[n:] = work_arr[:n]
+    // absA.T * work_arr[:n] = work_arr[n:]
     for (i = 0; i < 3; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -277,8 +288,8 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**11
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -297,9 +308,9 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d8 = powf(snorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = powf(snorm1(&Am[4*n*n], n), 0.125);
     } else {
-        test = snorm1est(&Am[0], 8);
+        test = snorm1est(&Am[0], n, 8);
         // If memory error in s1normest
         if (test <= -100.0) { *m = -3; return; }
         d8 = powf(test, 0.125);
@@ -310,8 +321,8 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**15
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -330,8 +341,8 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**19
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -354,9 +365,9 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d10 = powf(snorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = powf(snorm1(&Am[4*n*n], n), 0.1);
     } else {
-        test = snorm1est(&Am[0], 10);
+        test = snorm1est(&Am[0], n, 10);
         // If memory error in s1normest
         if (test <= -100.0) { *m = -4; return; }
         d10 = powf(test, 0.1);
@@ -381,8 +392,8 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**27
     for (i = 0; i < 4; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -417,19 +428,18 @@ static void
 pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
 {
     Py_ssize_t i, j;
-    Py_ssize_t dims[2];
     int lm = 0;
     CBLAS_INT int1 = 1, n = (CBLAS_INT)size_n;
     double normA, dbl1 = 1.0, dbl0 = 0.0;
     double d4, d6, d8, d10, eta0, eta1, eta2, eta3, eta4, two_pow_s, temp, test;
     double theta[5];
     double coeff[5];
-    // work_arr is two (n,) cols that will be used multiplying absA, alternating.
+    // work_arr is two (n,) cols that will be used multiplying absA.T, alternating.
     double* restrict work_arr = &Am[6*n*n];
     double* restrict absA = &Am[5*n*n];
 
-    dims[0] = n;
-    dims[1] = n;
+    *m = 0;
+    *s = 0;
     theta[0] = 1.495585217958292e-002;
     theta[1] = 2.539398330063230e-001;
     theta[2] = 9.504178996162932e-001;
@@ -454,7 +464,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     }
 
     // First spin = normest(|A|, m=1)
-    BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
+    BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
     normA = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > normA) { normA = work_arr[n+i]; } }
 
@@ -462,8 +472,8 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &dbl0, &Am[1*n*n], &n);
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[2*n*n], &n);
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[3*n*n], &n);
-    d4 = pow(dnorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = pow(dnorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = pow(dnorm1(&Am[2*n*n], n), 0.25);
+    d6 = pow(dnorm1(&Am[3*n*n], n), 1.0/6.0);
     eta0 = fmax(d4, d6);
     eta1 = eta0;
 
@@ -471,12 +481,12 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     // -------
     // 1-norm of A**7
     // Alternating matvecs
-    // absA * work_arr[n:] = work_arr[:n]
-    // absA * work_arr[:n] = work_arr[n:]
+    // absA.T * work_arr[n:] = work_arr[:n]
+    // absA.T * work_arr[:n] = work_arr[n:]
     for (i = 0; i < 3; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -494,8 +504,8 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**11
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -514,9 +524,9 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d8 = pow(dnorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = pow(dnorm1(&Am[4*n*n], n), 0.125);
     } else {
-        test = dnorm1est(&Am[0], 8);
+        test = dnorm1est(&Am[0], n, 8);
         // If memory error in d1normest
         if (test <= -100.0) { *m = -3; return; }
         d8 = pow(test, 0.125);
@@ -527,8 +537,8 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**15
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -547,8 +557,8 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**19
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -571,9 +581,9 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d10 = pow(dnorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = pow(dnorm1(&Am[4*n*n], n), 0.1);
     } else {
-        test = dnorm1est(&Am[0], 10);
+        test = dnorm1est(&Am[0], n, 10);
         // If memory error in d1normest
         if (test <= -100.0) { *m = -4; return; }
         d10 = pow(test, 0.1);
@@ -598,8 +608,8 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**27
     for (i = 0; i < 4; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -634,7 +644,6 @@ static void
 pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
 {
     Py_ssize_t i, j;
-    Py_ssize_t dims[2];
     int lm = 0;
     CBLAS_INT int1 = 1, n = (CBLAS_INT)size_n;
     float normA;
@@ -643,13 +652,13 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     float d4, d6, d8, d10, eta0, eta1, eta2, eta3, eta4, two_pow_s, temp, test;
     float theta[5];
     float coeff[5];
-    // work_arr is two (n,) cols that will be used multiplying absA, alternating.
+    // work_arr is two (n,) cols that will be used multiplying absA.T, alternating.
     // Am is complex, but work_arr and absA are real.
     float* restrict work_arr = (float*)&Am[6*n*n];
     float* restrict absA = (float*)&Am[5*n*n];
 
-    dims[0] = n;
-    dims[1] = n;
+    *m = 0;
+    *s = 0;
     theta[0] = 1.495585217958292e-002;
     theta[1] = 2.539398330063230e-001;
     theta[2] = 9.504178996162932e-001;
@@ -674,7 +683,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     }
 
     // First spin = normest(|A|, m=1)
-    BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
+    BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
     normA = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > normA) { normA = work_arr[n+i]; } }
 
@@ -682,8 +691,8 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &cdbl0, &Am[1*n*n], &n);
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[2*n*n], &n);
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[3*n*n], &n);
-    d4 = powf(cnorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = powf(cnorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = powf(cnorm1(&Am[2*n*n], n), 0.25);
+    d6 = powf(cnorm1(&Am[3*n*n], n), 1.0/6.0);
     eta0 = fmaxf(d4, d6);
     eta1 = eta0;
 
@@ -691,12 +700,12 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     // -------
     // 1-norm of A**7
     // Alternating matvecs
-    // absA * work_arr[n:] = work_arr[:n]
-    // absA * work_arr[:n] = work_arr[n:]
+    // absA.T * work_arr[n:] = work_arr[:n]
+    // absA.T * work_arr[:n] = work_arr[n:]
     for (i = 0; i < 3; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -714,8 +723,8 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**11
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -734,9 +743,9 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d8 = powf(cnorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = powf(cnorm1(&Am[4*n*n], n), 0.125);
     } else {
-        test = cnorm1est(&Am[0], 8);
+        test = cnorm1est(&Am[0], n, 8);
         // If memory error in c1normest
         if (test <= -100.0) { *m = -3; return; }
         d8 = powf(test, 0.125);
@@ -747,8 +756,8 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**15
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -767,8 +776,8 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**19
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -791,9 +800,9 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d10 = powf(cnorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = powf(cnorm1(&Am[4*n*n], n), 0.1);
     } else {
-        test = cnorm1est(&Am[0], 10);
+        test = cnorm1est(&Am[0], n, 10);
         // If memory error in c1normest
         if (test <= -100.0) { *m = -4; return; }
         d10 = powf(test, 0.1);
@@ -818,8 +827,8 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**27
     for (i = 0; i < 4; i++)
     {
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -861,7 +870,6 @@ static void
 pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
 {
     Py_ssize_t i, j;
-    Py_ssize_t dims[2];
     int lm = 0;
     CBLAS_INT int1 = 1, n = (CBLAS_INT)size_n;
     double normA;
@@ -870,13 +878,13 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     double d4, d6, d8, d10, eta0, eta1, eta2, eta3, eta4, two_pow_s, temp, test;
     double theta[5];
     double coeff[5];
-    // work_arr is two (n,) cols that will be used multiplying absA, alternating.
+    // work_arr is two (n,) cols that will be used multiplying absA.T, alternating.
     // Am is complex, but work_arr and absA are double.
     double* restrict work_arr = (double*)&Am[6*n*n];
     double* restrict absA = (double*)&Am[5*n*n];
 
-    dims[0] = n;
-    dims[1] = n;
+    *m = 0;
+    *s = 0;
     theta[0] = 1.495585217958292e-002;
     theta[1] = 2.539398330063230e-001;
     theta[2] = 9.504178996162932e-001;
@@ -901,7 +909,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     }
 
     // First spin = normest(|A|, m=1)
-    BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
+    BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, work_arr, &int1, &dbl0, &work_arr[n], &int1);
     normA = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > normA) { normA = work_arr[n+i]; } }
 
@@ -909,8 +917,8 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &cdbl0, &Am[1*n*n], &n);
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[2*n*n], &n);
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[3*n*n], &n);
-    d4 = pow(znorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = pow(znorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = pow(znorm1(&Am[2*n*n], n), 0.25);
+    d6 = pow(znorm1(&Am[3*n*n], n), 1.0/6.0);
     eta0 = fmax(d4, d6);
     eta1 = eta0;
 
@@ -918,12 +926,12 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     // -------
     // 1-norm of A**7
     // Alternating matvecs
-    // absA * work_arr[n:] = work_arr[:n]
-    // absA * work_arr[:n] = work_arr[n:]
+    // absA.T * work_arr[n:] = work_arr[:n]
+    // absA.T * work_arr[:n] = work_arr[n:]
     for (i = 0; i < 3; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -941,8 +949,8 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**11
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -961,9 +969,9 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d8 = pow(znorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = pow(znorm1(&Am[4*n*n], n), 0.125);
     } else {
-        test = znorm1est(&Am[0], 8);
+        test = znorm1est(&Am[0], n, 8);
         // If memory error in z1normest
         if (test <= -100.0) { *m = -3; return; }
         d8 = pow(test, 0.125);
@@ -974,8 +982,8 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**15
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -994,8 +1002,8 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**19
     for (i = 0; i < 2; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -1020,9 +1028,9 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d10 = pow(znorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = pow(znorm1(&Am[4*n*n], n), 0.1);
     } else {
-        test = znorm1est(&Am[0], 10);
+        test = znorm1est(&Am[0], n, 10);
         // If memory error in z1normest
         if (test <= -100.0) { *m = -4; return; }
         d10 = pow(test, 0.1);
@@ -1047,8 +1055,8 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     // 1-norm of A**27
     for (i = 0; i < 4; i++)
     {
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
-        BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, absA, &n, &work_arr[0], &int1, &dbl0, &work_arr[n], &int1);
     }
     temp = 0.0;
     for (i = 0; i < n; i++)  { if (work_arr[n+i] > temp) { temp = work_arr[n+i]; } }
@@ -2191,8 +2199,6 @@ pade_UV_calc_z(SCIPY_Z* restrict Am, CBLAS_INT* restrict ipiv, const Py_ssize_t 
 void
 matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
 {
-    int m = 0, s = 0, is_lower = 0;
-    int64_t lband = 0, uband = 0;
     // --------------------------------------------------------------------
     // Input Array Attributes
     // --------------------------------------------------------------------
@@ -2208,10 +2214,10 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
         for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
     }
 
-    // expm requires 6*n*n + 2*n workspace.
+    // expm requires 6*n*n + 4*n workspace.
     // 5*n*n is for holding the powers of A
     // n*n for holding the absolute values of A
-    // 2*n is both for 1-norm calculations
+    // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
     float* restrict Am = malloc(sizeof(float)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
@@ -2226,6 +2232,8 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
     |                    MAIN nxn SLICE LOOP                             |
     ====================================================================*/
     for (npy_intp idx = 0; idx < outer_size; idx++) {
+        int m = 0, s = 0, is_lower = 0;
+        int64_t lband = 0, uband = 0;
         // See sqrtm for explanation of the loop and offset calculations
         npy_intp offset = 0;
         npy_intp temp_idx = idx;
@@ -2348,8 +2356,6 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
 void
 matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
 {
-    int m = 0, s = 0, is_lower = 0;
-    int64_t lband = 0, uband = 0;
     // --------------------------------------------------------------------
     // Input Array Attributes
     // --------------------------------------------------------------------
@@ -2365,10 +2371,10 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
         for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
     }
 
-    // expm requires 6*n*n + 2*n workspace.
+    // expm requires 6*n*n + 4*n workspace.
     // 5*n*n is for holding the powers of A
     // n*n for holding the absolute values of A
-    // 2*n is both for 1-norm calculations
+    // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
     double* restrict Am = malloc(sizeof(double)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
@@ -2383,6 +2389,8 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
     |                    MAIN nxn SLICE LOOP                             |
     ====================================================================*/
     for (npy_intp idx = 0; idx < outer_size; idx++) {
+        int m = 0, s = 0, is_lower = 0;
+        int64_t lband = 0, uband = 0;
         // See sqrtm for explanation of the loop and offset calculations
         npy_intp offset = 0;
         npy_intp temp_idx = idx;
@@ -2505,8 +2513,6 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
 void
 matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info)
 {
-    int m = 0, s = 0, is_lower = 0;
-    int64_t lband = 0, uband = 0;
     // --------------------------------------------------------------------
     // Input Array Attributes
     // --------------------------------------------------------------------
@@ -2522,10 +2528,10 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
         for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
     }
 
-    // expm requires 6*n*n + 2*n workspace.
+    // expm requires 6*n*n + 4*n workspace.
     // 5*n*n is for holding the powers of A
     // n*n for holding the absolute values of A
-    // 2*n is both for 1-norm calculations
+    // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
     SCIPY_C* restrict Am = malloc(sizeof(SCIPY_C)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
@@ -2540,6 +2546,8 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
     |                    MAIN nxn SLICE LOOP                             |
     ====================================================================*/
     for (npy_intp idx = 0; idx < outer_size; idx++) {
+        int m = 0, s = 0, is_lower = 0;
+        int64_t lband = 0, uband = 0;
         // See sqrtm for explanation of the loop and offset calculations
         npy_intp offset = 0;
         npy_intp temp_idx = idx;
@@ -2710,8 +2718,6 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
 void
 matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info)
 {
-    int m = 0, s = 0, is_lower = 0;
-    int64_t lband = 0, uband = 0;
     // --------------------------------------------------------------------
     // Input Array Attributes
     // --------------------------------------------------------------------
@@ -2726,10 +2732,10 @@ matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info
     {
         for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
     }
-    // expm requires 6*n*n + 2*n workspace.
+    // expm requires 6*n*n + 4*n workspace.
     // 5*n*n is for holding the powers of A
     // n*n for holding the absolute values of A
-    // 2*n is both for 1-norm calculations
+    // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
     SCIPY_Z* restrict Am = malloc(sizeof(SCIPY_Z)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
@@ -2744,6 +2750,8 @@ matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info
     |                    MAIN nxn SLICE LOOP                             |
     ====================================================================*/
     for (npy_intp idx = 0; idx < outer_size; idx++) {
+        int m = 0, s = 0, is_lower = 0;
+        int64_t lband = 0, uband = 0;
         // See sqrtm for explanation of the loop and offset calculations
         npy_intp offset = 0;
         npy_intp temp_idx = idx;

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -62,8 +62,13 @@ class TestBatch:
             for j in range(batch_shape[1]):
                 arrays_ij = (array[i, j] for array in arrays)
                 ref = fun(*arrays_ij, **kwargs)
-                ref = ((np.asarray(ref),) if n_out == 1 else
-                       tuple(np.asarray(refk) for refk in ref))
+                # see gh-25508:
+                if (np.dtype(np.int_).itemsize == 4 and
+                     n_out > 1 and isinstance(ref[0], int)):
+                     ref = tuple(np.asarray(refk, dtype=np.int64) for refk in ref)
+                else:
+                     ref = ((np.asarray(ref),) if n_out == 1 else
+                            tuple(np.asarray(refk) for refk in ref))
                 for k in range(n_out):
                     assert_allclose(res[k][i, j], ref[k])
                     assert np.shape(res[k][i, j]) == ref[k].shape

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -88,6 +88,17 @@ class TestSignM:
         signm(a)
         #XXX: what would be the correct result?
 
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64,
+                                       np.complex64, np.complex128])
+    def test_signm_dtype_preservation(self, dtype):
+        # gh-25657: signm upcast float32/complex64 for defective matrices
+        # (the iterative fall-through branch) while the non-defective branch
+        # preserved dtype. Output dtype must depend on input dtype, not values.
+        non_defective = np.array([[2, 1], [0, 3]], dtype=dtype)  # distinct eigs
+        defective = np.array([[2, 1], [0, 2]], dtype=dtype)      # repeated eig
+        assert signm(non_defective).dtype == dtype
+        assert signm(defective).dtype == dtype
+
 
 class TestLogM:
     @pytest.mark.filterwarnings("ignore:.*inaccurate.*:RuntimeWarning")

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -851,6 +851,26 @@ class TestExpM:
             next_res = expm(A)
             np.testing.assert_array_almost_equal(first_res, next_res)
 
+    @pytest.mark.parametrize('dt', [np.float32, np.float64,
+                                    np.complex64, np.complex128])
+    def test_gh25924(self, dt):
+        # The scaling exponent of a slice that needed scaling and squaring
+        # leaked into the following slices that did not, squaring their
+        # unscaled results and returning expm(2**s * A) instead of expm(A).
+        rng = np.random.default_rng(1234)
+        n, batch = 6, 4
+        A = rng.standard_normal((batch, n, n))
+        if np.issubdtype(dt, np.complexfloating):
+            A = A + 1j*rng.standard_normal((batch, n, n))
+        A = A.astype(dt)
+        # First slice needs scaling and squaring, the remaining ones do not.
+        A[0] *= 8
+        A[1:] /= np.abs(A[1:]).sum(axis=1).max(axis=-1)[:, None, None]
+
+        one_at_a_time = np.stack([expm(x) for x in A])
+        assert_allclose(expm(A), one_at_a_time,
+                        rtol=10*np.finfo(dt).eps, atol=0)
+
 
 class TestExpmFrechet:
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -941,7 +941,7 @@ class TestCurveFit:
                         jac=jac2, absolute_sigma=absolute_sigma)
 
                 assert_allclose(popt1, popt2, rtol=1.4e-7, atol=1e-14)
-                assert_allclose(pcov1, pcov2, rtol=1.4e-7, atol=1e-14)
+                assert_allclose(pcov1, pcov2, rtol=1.5e-7, atol=1e-14)
 
     @pytest.mark.parametrize("absolute_sigma", [False, True])
     def test_curvefit_scalar_sigma(self, absolute_sigma):

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3122,7 +3122,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
 
     >>> fsf2 = signal.place_poles(A, B, P)  # uses YT method
     >>> fsf2.computed_poles
-    array([-8.6659, -5.0566, -0.5   , -0.2   ])
+    array([-8.6659, -5.0566, -0.5   , -0.2   ]) # may vary
 
     >>> fsf3 = signal.place_poles(A, B, P, rtol=-1, maxiter=100)
     >>> fsf3.X

--- a/scipy/signal/_sigtoolsmodule.cc
+++ b/scipy/signal/_sigtoolsmodule.cc
@@ -472,7 +472,8 @@ static double wate(double freq, double *fx, double *wtx, int lband, int jtype)
 
 static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
                      double *response, double *weight, int type, int maxiter,
-                     int grid_density, int *niter_out) {
+                     int grid_density, int *niter_out, int *ngrid_out,
+                     int *nfcns_out) {
 
   int jtype, nbands, nfilt, lgrid, nz;
   int neg, nodd, nm1;
@@ -567,6 +568,15 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
     ngrid = j - 1;
     if (neg == nodd) {
 	if (grid[ngrid] > (0.5-delf)) --ngrid;
+    }
+
+    /* Need at least nfcns+1 grid points for the extremal frequencies;
+       a too-narrow band yields fewer and overruns the arrays (gh-24495). */
+    if (ngrid < nfcns + 1) {
+	*ngrid_out = ngrid;
+	*nfcns_out = nfcns;
+	free(tempstor);
+	return -3;
     }
 
     /*
@@ -840,6 +850,7 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
     double oldvalue, *dptr, fs = 1.0;
     char mystr[255];
     int niter = -1;
+    int ngrid = -1, nfcns = -1;
 
     if (!PyArg_ParseTuple(args, "iOOO|idii", &numtaps, &bands, &des, &weight,
                           &type, &fs, &maxiter, &grid_density)) {
@@ -904,7 +915,7 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
                     (double *)PyArray_DATA(a_bands),
                     (double *)PyArray_DATA(a_des),
                     (double *)PyArray_DATA(a_weight),
-                    type, maxiter, grid_density, &niter);
+                    type, maxiter, grid_density, &niter, &ngrid, &nfcns);
     if (err < 0) {
         if (err == -1) {
             snprintf(mystr, sizeof(mystr), "Failure to converge at iteration %d, try reducing transition band width.\n", niter);
@@ -913,6 +924,15 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
         }
         else if (err == -2) {
             PyErr_NoMemory();
+            goto fail;
+        }
+        else if (err == -3) {
+            snprintf(mystr, sizeof(mystr),
+                "Band edges are too close together to build the dense "
+                "frequency grid: it has only %d point(s) but at least %d "
+                "(one per extremal frequency) are required. Widen the bands, "
+                "reduce numtaps, or increase grid_density.", ngrid, nfcns + 1);
+            PyErr_SetString(PyExc_ValueError, mystr);
             goto fail;
         }
     }

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -569,6 +569,14 @@ class TestRemez:
         weight = xp.asarray([1.0, 2.0])
         remez(21, bands, desired, weight=weight)
 
+    @pytest.mark.parametrize('type', ['bandpass', 'differentiator', 'hilbert'])
+    def test_gh_24495_narrow_band(self, type):
+        # A band too narrow for the dense grid used to segfault (gh-24495).
+        with pytest.raises(ValueError, match="Band edges are too close"):
+            remez(101, [1000, 1000], [1], fs=20000, type=type)
+        with pytest.raises(ValueError, match="Band edges are too close"):
+            remez(101, [1000, 1011.5], [1], fs=20000, type=type)
+
 
 @make_xp_test_case(firls)
 class TestFirls:

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -335,9 +335,9 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
 def get_sum_dtype(dtype: np.dtype) -> np.dtype | type[np.generic]:
     """Mimic numpy's casting for np.sum"""
     if dtype.kind == 'u' and np.can_cast(dtype, np.uint):
-        return np.uint
+        return np.dtype(np.uint)
     if np.can_cast(dtype, np.int_):
-        return np.int_
+        return np.dtype(np.int_)
     return dtype
 
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -23,6 +23,10 @@ from scipy._lib._gcutils import assert_deallocated
 _ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
 
+def _is_32bit():
+    return np.intp(0).itemsize < 8
+
+
 def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
     """
     Return tolerance values suitable for a given test:
@@ -77,6 +81,11 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
             # missing more cases, from PR 14798
             rtol *= 10
             atol *= 10
+
+    if _is_32bit():
+        # Small tolerance bumps needed on i686 linux after moving
+        # from GCC 10.2 to 14.2
+        rtol *= 2
 
     return tol, rtol, atol
 

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -319,6 +319,12 @@ def test_maxiter(case, xp, batch_A, batch_b):
 def test_convergence(case, xp, batch_A, batch_b):
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Struggles to converge with single precision on some platforms")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
+        # Numerical stability is borderline for single precision, tfqmr stagnates at a
+        # relative residual ||b - Ax||/||b|| of ~2e-2, failure yes/no depends on
+        # platform-specific rounding behavior (see, e.g., scipy#25522)
+        pytest.skip("Fails to converge with single precision on some platforms")
+
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     A = case.A
 
@@ -350,6 +356,9 @@ def test_precond_dummy(case, xp, batch_A, batch_b):
         pytest.skip("Struggles to converge with single precision")
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Hits divide-by-zero with single precision")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
+        # Numerical stability is borderline for float32 (see, scipy#25522)
+        pytest.skip("Fails to converge with single precision on some platforms")
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
 

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -37,6 +37,10 @@ _SOLVERS = [bicg, bicgstab, cg, cgs, gcrotmk, gmres, lgmres,
 CB_TYPE_FILTER = ".*called without specifying `callback_type`.*"
 
 
+def _is_32bit():
+    return np.intp(0).itemsize < 8
+
+
 def _assert_success(*, A, x, b, xp, rtol=1.0, atol=0.0, less_equal=False):
     Ax = xp.squeeze(A @ x[..., xp.newaxis], axis=-1)
     residual = Ax - b
@@ -319,11 +323,8 @@ def test_maxiter(case, xp, batch_A, batch_b):
 def test_convergence(case, xp, batch_A, batch_b):
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Struggles to converge with single precision on some platforms")
-    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
-        # Numerical stability is borderline for single precision, tfqmr stagnates at a
-        # relative residual ||b - Ax||/||b|| of ~2e-2, failure yes/no depends on
-        # platform-specific rounding behavior (see, e.g., scipy#25522)
-        pytest.skip("Fails to converge with single precision on some platforms")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
+        pytest.skip("Fails to converge on i686 (32-bit) linux")
 
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     A = case.A
@@ -356,16 +357,15 @@ def test_precond_dummy(case, xp, batch_A, batch_b):
         pytest.skip("Struggles to converge with single precision")
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Hits divide-by-zero with single precision")
-    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name):
-        # Numerical stability is borderline for float32 (see, scipy#25522)
-        pytest.skip("Fails to converge with single precision on some platforms")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
+        pytest.skip("Fails to converge on i686 (32-bit) linux")
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
 
     rtol = 1e-8 if np.finfo(dtype).eps < 1e-8 else 1.2e-3
 
     A = case.A
-    
+
     # NOTE: the following was previously uncommented as dead code --
     # was the intention to set `A = dia_array(...)`?
 
@@ -404,7 +404,7 @@ def test_precond_inverse(case, xp, batch_A, batch_b):
         pytest.skip("specific to poisson1d and poisson2d cases")
     if case.solver is qmr:
         pytest.skip("skipped for qmr")
-    
+
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     rtol = 1e-8
 
@@ -472,7 +472,7 @@ def test_atol(solver, xp, batch_A, batch_b):
     b = 1e3 * rng.uniform(size=(*batch_b, 10))
 
     dtype = xpx.default_dtype(xp)
-    A = xp.asarray(A, dtype=dtype) 
+    A = xp.asarray(A, dtype=dtype)
     b = xp.asarray(b, dtype=dtype)
 
     tols = np.r_[0, np.logspace(-9, 2, 7), np.inf]
@@ -506,7 +506,7 @@ def test_atol(solver, xp, batch_A, batch_b):
 @pytest.mark.parametrize("batch_b", [()])
 def test_zero_rhs(solver, xp, batch_A, batch_b):
     rng = np.random.default_rng(1684414984100503)
-    dtype = xpx.default_dtype(xp) 
+    dtype = xpx.default_dtype(xp)
     A = xp.asarray(rng.random(size=(*batch_A, 10, 10)), dtype=dtype)
     A = A @ A.mT + 10 * xp.eye(10)
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -334,6 +334,19 @@ class TestSparseUtils:
             np.dtype('int64')
         )
 
+    @pytest.mark.parametrize("dtype,expected", [
+        (np.dtype('uint32'), np.dtype(np.uint)),
+        (np.dtype('int32'), np.dtype(np.int_)),
+        (np.dtype(np.uint), np.dtype(np.uint)),
+        (np.dtype(np.int_), np.dtype(np.int_)),
+        (np.dtype('float64'), np.dtype('float64')),
+        (np.dtype('complex64'), np.dtype('complex64')),
+    ])
+    def test_get_sum_dtype(self, dtype, expected):
+        result = sputils.get_sum_dtype(dtype)
+        assert isinstance(result, np.dtype)
+        assert_equal(result, expected)
+
     # tests public broadcast_shapes largely from
     # numpy/numpy/lib/tests/test_stride_tricks.py
     # first 3 cause np.broadcast to raise index too large, but not sputils

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -189,12 +189,9 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
 
 @cython.cdivision(True)
 cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcept nogil:
-    cdef long long ni
-
     # If n is an integer, use more stable `eval_gegenbauer_l`
-    ni = <long long> n
-    if number_t is double and n == ni and n < 1e10:
-        return <number_t> eval_gegenbauer_l(<Py_ssize_t> ni, alpha, <double> x)
+    if number_t is double and n >= 0 and n < 1e10 and n == <long long> n:
+        return <number_t> eval_gegenbauer_l(<Py_ssize_t> n, alpha, <double> x)
 
     cdef double a, b, c, d
     cdef number_t g

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -551,7 +551,7 @@ BOOST_TESTS = [
         data(elliprg, 'ellint_rg_xyy_ipp-ellint_rg_xyy', (0, 1, 2), 3,
              rtol=7.5e-16),
         data(elliprg, 'ellint_rg_xy0_ipp-ellint_rg_xy0', (0, 1, 2), 3,
-             rtol=5e-16),
+             rtol=5.2e-16),
         data(elliprg, 'ellint_rg_00x_ipp-ellint_rg_00x', (0, 1, 2), 3,
              rtol=5e-16),
         data(elliprj, 'ellint_rj_data_ipp-ellint_rj_data', (0, 1, 2, 3), 4,

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -265,7 +265,7 @@ def test_genlaguerre_nan(n, alpha, x):
     assert nan_laguerre == nan_arg
 
 
-@pytest.mark.parametrize('n', [0, 1, 2, 3.2])
+@pytest.mark.parametrize('n', [0, 1, 2, 3.2, np.nan])
 @pytest.mark.parametrize('alpha', [0.0, 1, np.nan])
 @pytest.mark.parametrize('x', [1e-6, 2, np.nan])
 def test_gegenbauer_nan(n, alpha, x):

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy._external.array_api_extra as xpx
-from scipy._lib._array_api import xp_capabilities, array_namespace, xp_promote, is_jax
+from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_promote, is_jax,
+                                   is_lazy_array)
 from scipy.optimize.elementwise import find_root
 from scipy.special import ndtri
 from scipy.special import _ufuncs as scu
@@ -28,8 +29,9 @@ class BinomTestResult:
 
     """
     def __init__(self, k, n, alternative, statistic, pvalue, xp):
-        self.k = k
-        self.n = n
+        lazy = is_lazy_array(k)
+        self.k = int(k) if not lazy and statistic.ndim == 0 and not xp.isnan(k) else k
+        self.n = int(n) if not lazy and statistic.ndim == 0 and not xp.isnan(n) else n
         self.alternative = alternative
         self.statistic = statistic
         self.pvalue = pvalue
@@ -104,7 +106,10 @@ class BinomTestResult:
                              'the interval [0, 1].')
 
         xp = self._xp
-        k, n, confidence_level = xp_promote(self.k, self.n, confidence_level, xp=xp)
+        k, n, confidence_level = xp_promote(
+            self.k, self.n, confidence_level,
+            xp=xp, force_floating=True,
+        )
         if method == 'exact':
             low, high = _binom_exact_conf_int(
                 k, n, confidence_level, self.alternative, xp=xp)
@@ -174,9 +179,11 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction, *, x
     return lo, hi
 
 
-@xp_capabilities(skip_backends=[('dask.array', "")], cpu_only=True,
-                 reason="binomial distribution ufuncs only available for NumPy",
-                 extra_note="`alternative='two-sided'` is incompatible with JAX arrays.")
+@xp_capabilities(
+    skip_backends=[('dask.array', "")], cpu_only=True,
+    reason="binomial distribution ufuncs only available for NumPy",
+    extra_note="`alternative='two-sided'` is incompatible with JAX arrays.",
+)
 def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -22,7 +22,7 @@ def test_kde_1d():
     xx = np.asarray([0.1, 0.5, 0.9])
     loc, scale = gkde.dataset, np.sqrt(gkde.covariance)
     assert_allclose(
-        gkde(xx), 
+        gkde(xx),
         stats.norm.pdf(xx[:, None], loc=loc, scale=scale).sum(axis=-1) / gkde.n,
         rtol=5e-14
     )
@@ -65,7 +65,7 @@ def test_kde_1d_weighted():
 
     pdf = stats.norm.pdf
     assert_allclose(
-        gkde(xx), 
+        gkde(xx),
         np.sum(pdf(xx[:, None], loc=loc, scale=scale) * gkde.weights, axis=-1),
         rtol=5e-14
     )
@@ -181,7 +181,7 @@ def test_kde_2d_weighted(n_basesample):
     assert_allclose(
         gkde(xx.T),
         np.sum(pdf(arg, cov=gkde.covariance) * gkde.weights, axis=-1),
-        rtol=5e-14
+        rtol=6e-14
     )
 
     # ... and cdf

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1150,7 +1150,7 @@ class TestBinomTest:
                               alternative=alternative)
         xp_assert_close(res.pvalue, xp.asarray(pval, dtype=dtype), rtol=1e-12)
         xp_assert_equal(res.statistic, xp.asarray(0.2, dtype=dtype))
-        ci = res.proportion_ci(confidence_level=0.95)
+        ci = res.proportion_ci(confidence_level=xp.asarray(0.95, dtype=dtype))
         xp_assert_close(ci.low, xp.asarray(ci_low, dtype=dtype), rtol=1e-12)
         xp_assert_close(ci.high, xp.asarray(ci_high, dtype=dtype), rtol=1e-12)
 
@@ -1170,7 +1170,7 @@ class TestBinomTest:
                               alternative=alternative)
         xp_assert_close(res.pvalue, xp.asarray(pval, dtype=dtype), rtol=1e-6)
         xp_assert_equal(res.statistic, xp.asarray(0.06, dtype=dtype))
-        ci = res.proportion_ci(confidence_level=0.99)
+        ci = res.proportion_ci(confidence_level=xp.asarray(0.99, dtype=dtype))
         xp_assert_close(ci.low, xp.asarray(ci_low, dtype=dtype), rtol=1e-6)
         xp_assert_close(ci.high, xp.asarray(ci_high, dtype=dtype), rtol=1e-6)
 
@@ -1187,7 +1187,7 @@ class TestBinomTest:
         res = stats.binomtest(0, n=10, p=xp.asarray(0.25, dtype=dtype),
                               alternative=alternative)
         xp_assert_close(res.pvalue, xp.asarray(pval, dtype=dtype), rtol=1e-6)
-        ci = res.proportion_ci(confidence_level=0.95)
+        ci = res.proportion_ci(confidence_level=xp.asarray(0.95, dtype=dtype))
         xp_assert_equal(ci.low, xp.asarray(0.0, dtype=dtype))
         xp_assert_close(ci.high, xp.asarray(ci_high, dtype=dtype), rtol=1e-6)
 
@@ -1204,7 +1204,7 @@ class TestBinomTest:
         res = stats.binomtest(10, n=10, p=xp.asarray(0.25, dtype=dtype),
                               alternative=alternative)
         xp_assert_close(res.pvalue, xp.asarray(pval, dtype=dtype), rtol=1e-6)
-        ci = res.proportion_ci(confidence_level=0.95)
+        ci = res.proportion_ci(confidence_level=xp.asarray(0.95, dtype=dtype))
         xp_assert_equal(ci.high, xp.asarray(1.0, dtype=dtype))
         xp_assert_close(ci.low, xp.asarray(ci_low, dtype=dtype), rtol=1e-6)
 
@@ -1248,6 +1248,7 @@ class TestBinomTest:
             method = 'wilsoncc'
         else:
             method = 'wilson'
+        conf = xp.asarray(conf, dtype=dtype)
         ci = res.proportion_ci(confidence_level=conf, method=method)
         xp_assert_close(ci.low, xp.asarray(ci_low, dtype=dtype), rtol=1e-6)
         xp_assert_close(ci.high, xp.asarray(ci_high, dtype=dtype), rtol=1e-6)
@@ -1335,15 +1336,24 @@ class TestBinomTest:
 
         xp_assert_close(res.statistic, xp.asarray(float(ref.statistic), dtype=dtype))
         xp_assert_close(res.pvalue, xp.asarray(float(ref.pvalue), dtype=dtype))
-        xp_assert_close(res.n, xp.asarray(float(ref.n), dtype=dtype))
-        xp_assert_close(res.k, xp.asarray(float(ref.k), dtype=dtype))
+
+        if res.statistic.ndim == 0:
+            if not is_lazy_array(res.n):
+                assert isinstance(res.n, int)
+                assert isinstance(res.k, int)
+            assert res.n == ref.n
+            assert res.k == ref.k
+        else:
+            xp_assert_close(res.n, xp.asarray(int(ref.n)))
+            xp_assert_close(res.k, xp.asarray(int(ref.k)))
 
         if (is_array_api_strict(xp) or is_jax(xp)) and method == 'exact':
             # array API strict and JAX don't support exact CI right now
             return
 
-        res = res.proportion_ci(method=method)
-        ref = ref.proportion_ci(method=method)
+        confidence_level = xp.asarray(0.95, dtype=dtype)
+        res = res.proportion_ci(method=method, confidence_level=confidence_level)
+        ref = ref.proportion_ci(method=method, confidence_level=0.95)
 
         xp_assert_close(res.low, xp.asarray(float(ref.low), dtype=dtype))
         xp_assert_close(res.high, xp.asarray(float(ref.high), dtype=dtype))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2990,7 +2990,7 @@ class TestBoxcoxNormmax(NormmaxTest):
 
         res = stats.boxcox_normmax(x, method='all', nan_policy='omit')
         ref = stats.boxcox_normmax(x[~np.isnan(x)], method='all')
-        np.testing.assert_allclose(res, ref)
+        np.testing.assert_allclose(res, ref, rtol=2e-7)
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -763,7 +763,7 @@ class TestPearsonr:
         y = rng.random(10)
         res = stats.pearsonr(x, y, axis=1)
         ref = stats.pearsonr(x, y, axis=-1)
-        assert_equal(res.statistic, ref.statistic)
+        assert_allclose(res.statistic, ref.statistic, rtol=3e-16)
 
     @pytest.mark.parametrize('axis', [0, 1, None])
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])


### PR DESCRIPTION
Following the release of NumPy `2.5.2`, the stage is mostly set (with 1 or 2 exceptions noted below), for us to release SciPy `1.18.1` with Python `3.15.0rc1` (ABI stable) binaries. There is also a substantial accumulation of merged backports, so makes sense to start thinking about the release for both reasons. cc @h-vetinari @jorenham

TODO:

- [x] pretty sure we need a `pythran` release for `3.15` support per https://github.com/serge-sans-paille/pythran/issues/2446
- [x] sort out potential bump in minimum `gcc` version required per https://github.com/scipy/scipy/pull/25579 (it has 5 separate commits and merge conflicts--that's the main reason I don't have it here yet, but there is maybe a little judgement required anyway b/c of the `gcc` min version bump)
- [x] make sure regular CI is passing here (skipped for now--too many known issues remain)
- [x] update the release notes to reflect the backports and new `3.15` binaries (`.mailmap` if needed as well)
- [x] There are [3 unmerged PRs with backport labels](https://github.com/scipy/scipy/pulls?q=is%3Aopen+is%3Apr+label%3Abackport-candidate) -- some of these including static typing fixes that I think Joren prefers we resolve b/c of lack of healthy workarounds in type checkers

Backports included here (so far):

1. gh-24923
2. gh-25352
3. gh-25407
4. gh-25450
5. gh-25484
6. gh-25500
7. gh-25507
8. gh-25521
9. gh-25581
10. gh-25602
11. gh-25609
12. gh-25632
13. gh-25638
14. gh-25658
15. gh-25690
16. gh-25726
17. gh-25764
18. gh-25958
19. gh-25934
20. gh-25509
21. gh-25542
22. gh-25508
23. gh-25579
24. gh-25913


#### AI Generation Disclosure

No AI tools used