### PR TITLE
DOC: stats: fix misspellings in continuous distribution tutorial titles

### DIFF
--- a/doc/source/tutorial/stats/continuous_f.rst
+++ b/doc/source/tutorial/stats/continuous_f.rst
@@ -1,8 +1,8 @@
 
 .. _continuous-f:
 
-Fratio (or F) Distribution
-==========================
+F-ratio (or F) Distribution
+===========================
 
 The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)`
 if :math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom

--- a/doc/source/tutorial/stats/continuous_gumbel_r.rst
+++ b/doc/source/tutorial/stats/continuous_gumbel_r.rst
@@ -2,7 +2,7 @@
 .. _continuous-gumbel_r:
 
 Gumbel (LogWeibull, Fisher-Tippett, Type I Extreme Value) Distribution
-=======================================================================
+======================================================================
 
 One of a class of extreme value distributions (right-skewed).
 

--- a/doc/source/tutorial/stats/continuous_gumbel_r.rst
+++ b/doc/source/tutorial/stats/continuous_gumbel_r.rst
@@ -1,7 +1,7 @@
 
 .. _continuous-gumbel_r:
 
-Gumbel (LogWeibull, Fisher-Tippetts, Type I Extreme Value) Distribution
+Gumbel (LogWeibull, Fisher-Tippett, Type I Extreme Value) Distribution
 =======================================================================
 
 One of a class of extreme value distributions (right-skewed).

--- a/doc/source/tutorial/stats/continuous_lognorm.rst
+++ b/doc/source/tutorial/stats/continuous_lognorm.rst
@@ -1,8 +1,8 @@
 
 .. _continuous-lognorm:
 
-Log Normal (Cobb-Douglass) Distribution
-=======================================
+Log Normal (Cobb-Douglas) Distribution
+======================================
 
 Has one shape parameter :math:`\sigma` >0. (Notice that the "Regress" :math:`A=\log S` where :math:`S` is the scale parameter and :math:`A` is the mean of the underlying normal distribution).
 The support is :math:`x\geq0`.


### PR DESCRIPTION
This PR fixes the misspellings in continuous distribution tutorial titles

#### AI Generation Disclosure

Claude Code in Anthropic's CLI
I used Claude to verify my changes, give me steps, and check the commits. The PR title and the commit message are from Claude
I accepted Claude's changes to the length of "==" sentences

