### PR TITLE
BUG: spatial.transform: fix `Rotation.mean` float32 precision on xp backend

### DIFF
--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -548,6 +548,7 @@ def mean(
         w = xp.reshape(w, w.shape[: len(keep_axes)] + (-1, 1))
         K = (q * w).mT @ q
 
+    K = K / xp.prod(xp.asarray(q.shape[len(keep_axes) :], device=device))
     _, v = xp.linalg.eigh(K)
     return v[..., -1]
 

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -548,6 +548,8 @@ def mean(
         w = xp.reshape(w, w.shape[: len(keep_axes)] + (-1, 1))
         K = (q * w).mT @ q
 
+    # Relying on the eigh decomposition to normalize for us instead of dividing by N is
+    # numerically worse. See #25891
     K = K / xp.prod(xp.asarray(q.shape[len(keep_axes) :], device=device))
     _, v = xp.linalg.eigh(K)
     return v[..., -1]

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -550,7 +550,7 @@ def mean(
 
     # Relying on the eigh decomposition to normalize for us instead of dividing by N is
     # numerically worse. See #25891
-    K = K / xp.prod(xp.asarray(q.shape[len(keep_axes) :], device=device))
+    K /= xp.prod(xp.asarray(q.shape[len(keep_axes) :], device=device), dtype=K.dtype)
     _, v = xp.linalg.eigh(K)
     return v[..., -1]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

### Reference issue
Maybe closes #25888

### What does this implement/fix?
Divide by the number of reduced quaternions before the `eigh` decomposition to improve precision.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
None