### PR TITLE
ENH: sparse.csgraph: add min_only to bellman_ford

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -56,6 +56,12 @@ New features
 ``scipy.sparse`` improvements
 =============================
 
+- `scipy.sparse.csgraph.bellman_ford` and `scipy.sparse.csgraph.shortest_path`
+  now support a ``min_only`` argument, matching
+  `scipy.sparse.csgraph.dijkstra`. When ``min_only=True``, a vector of the
+  shortest distances from any of the ``indices`` is returned instead of the
+  full distance matrix. See `gh-25480 <https://github.com/scipy/scipy/issues/25480>`__.
+
 
 
 ``scipy.spatial`` improvements

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -57,10 +57,11 @@ def shortest_path(csgraph, method='auto',
                   return_predecessors=False,
                   unweighted=False,
                   overwrite=False,
-                  indices=None):
+                  indices=None,
+                  bint min_only=False):
     """
     shortest_path(csgraph, method='auto', directed=True, return_predecessors=False,
-                  unweighted=False, overwrite=False, indices=None)
+                  unweighted=False, overwrite=False, indices=None, min_only=False)
 
     Perform a shortest-path graph search on a positive directed or
     undirected graph.
@@ -116,6 +117,14 @@ def shortest_path(csgraph, method='auto',
     indices : array_like or int, optional
         If specified, only compute the paths from the points at the given
         indices. Incompatible with method == 'FW'.
+    min_only : bool, optional
+        If False (default), for every node in the graph, find the shortest path
+        from every node in indices.
+        If True, for every node in the graph, find the shortest path from any
+        of the nodes in indices (which can be substantially faster).
+        Incompatible with methods ``'FW'`` and ``'J'``.
+
+        .. versionadded:: 2.0.0
 
     Returns
     -------
@@ -258,13 +267,21 @@ def shortest_path(csgraph, method='auto',
 
         if indices is not None or Nk < N * N / 4:
             if np.any(edges < 0):
-                method = 'J'
+                if min_only:
+                    method = 'BF'
+                else:
+                    method = 'J'
             else:
                 method = 'D'
         else:
-            method = 'FW'
+            if min_only:
+                method = 'BF' if np.any(edges < 0) else 'D'
+            else:
+                method = 'FW'
 
     if method == 'FW':
+        if min_only:
+            raise ValueError("Cannot specify min_only with method == 'FW'.")
         if indices is not None:
             raise ValueError("Cannot specify indices with method == 'FW'.")
         return floyd_warshall(csgraph, directed,
@@ -275,14 +292,18 @@ def shortest_path(csgraph, method='auto',
     elif method == 'D':
         return dijkstra(csgraph, directed,
                         return_predecessors=return_predecessors,
-                        unweighted=unweighted, indices=indices)
+                        unweighted=unweighted, indices=indices,
+                        min_only=min_only)
 
     elif method == 'BF':
         return bellman_ford(csgraph, directed,
                             return_predecessors=return_predecessors,
-                            unweighted=unweighted, indices=indices)
+                            unweighted=unweighted, indices=indices,
+                            min_only=min_only)
 
     elif method == 'J':
+        if min_only:
+            raise ValueError("Cannot specify min_only with method == 'J'.")
         return johnson(csgraph, directed,
                        return_predecessors=return_predecessors,
                        unweighted=unweighted, indices=indices)
@@ -873,10 +894,11 @@ cdef int _dijkstra_multi_separate(
 
 def bellman_ford(csgraph, directed=True, indices=None,
                  return_predecessors=False,
-                 unweighted=False):
+                 unweighted=False,
+                 bint min_only=False):
     """
     bellman_ford(csgraph, directed=True, indices=None, return_predecessors=False,
-                 unweighted=False)
+                 unweighted=False, min_only=False)
 
     Compute the shortest path lengths using the Bellman-Ford algorithm.
 
@@ -905,17 +927,29 @@ def bellman_ford(csgraph, directed=True, indices=None,
         If True, then find unweighted distances.  That is, rather than finding
         the path between each point such that the sum of weights is minimized,
         find the path such that the number of edges is minimized.
+    min_only : bool, optional
+        If False (default), for every node in the graph, find the shortest path
+        from every node in indices.
+        If True, for every node in the graph, find the shortest path from any
+        of the nodes in indices (which can be substantially faster).
+
+        .. versionadded:: 2.0.0
 
     Returns
     -------
-    dist_matrix : ndarray
-        The N x N matrix of distances between graph nodes. dist_matrix[i,j]
+    dist_matrix : ndarray, shape ([n_indices, ]n_nodes,)
+        The matrix of distances between graph nodes. If min_only=False,
+        dist_matrix has shape (n_indices, n_nodes) and dist_matrix[i, j]
         gives the shortest distance from point i to point j along the graph.
-
-    predecessors : ndarray, shape (n_indices, n_nodes,)
-        Returned only if ``return_predecessors=True``.
-        If `indices` is None then ``n_indices = n_nodes`` and the shape of
-        the matrix becomes ``(n_nodes, n_nodes)``.
+        If min_only=True, dist_matrix has shape (n_nodes,) and contains for
+        a given node the shortest path to that node from any of the nodes
+        in indices.
+    predecessors : ndarray, shape ([n_indices, ]n_nodes,)
+        If ``min_only=False``, this has shape ``(n_indices, n_nodes)``,
+        otherwise it has shape ``(n_nodes,)``.
+        If `indices` is None and ``min_only=False`` then ``n_indices = n_nodes``
+        and the shape of the matrix becomes ``(n_nodes, n_nodes)``.
+        Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
@@ -981,20 +1015,31 @@ def bellman_ford(csgraph, directed=True, indices=None,
         indices[indices < 0] += N
         if np.any(indices < 0) or np.any(indices >= N):
             raise ValueError("indices out of range 0...N")
-    return_shape = indices.shape + (N,)
+    if min_only:
+        return_shape = (N,)
+    else:
+        return_shape = indices.shape + (N,)
     indices = np.atleast_1d(indices).reshape(-1)
 
     # ------------------------------
     # initialize dist_matrix for output
-    dist_matrix = np.empty((len(indices), N), dtype=DTYPE)
-    dist_matrix.fill(np.inf)
-    dist_matrix[np.arange(len(indices)), indices] = 0
+    if min_only:
+        dist_matrix = np.full((1, N), np.inf, dtype=DTYPE)
+        dist_matrix[0, indices] = 0
+    else:
+        dist_matrix = np.empty((len(indices), N), dtype=DTYPE)
+        dist_matrix.fill(np.inf)
+        dist_matrix[np.arange(len(indices)), indices] = 0
 
     # ------------------------------
     # initialize predecessors for output
     if return_predecessors:
-        predecessor_matrix = np.empty((len(indices), N), dtype=ITYPE)
-        predecessor_matrix.fill(NULL_IDX)
+        if min_only:
+            predecessor_matrix = np.empty((1, N), dtype=ITYPE)
+            predecessor_matrix.fill(NULL_IDX)
+        else:
+            predecessor_matrix = np.empty((len(indices), N), dtype=ITYPE)
+            predecessor_matrix.fill(NULL_IDX)
     else:
         predecessor_matrix = np.empty((0, N), dtype=ITYPE)
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -201,6 +201,96 @@ def test_dijkstra_indices_min_only(directed, SP_ans, indices):
     assert_array_almost_equal(SP, min_d_ans)
 
 
+@pytest.mark.parametrize('directed, SP_ans',
+                         ((True, directed_SP),
+                          (False, undirected_SP)))
+@pytest.mark.parametrize('indices', ([0, 2, 4], [0, 4], [3, 4], [0, 0]))
+def test_bellman_ford_indices_min_only(directed, SP_ans, indices):
+    SP_ans = np.array(SP_ans)
+    indices = np.array(indices, dtype=np.int64)
+    min_d_ans = SP_ans[indices].min(axis=0)
+
+    SP, pred = bellman_ford(directed_G,
+                            directed=directed,
+                            indices=indices,
+                            min_only=True,
+                            return_predecessors=True)
+    assert_array_almost_equal(SP, min_d_ans)
+    assert pred.shape == (SP_ans.shape[0],)
+    SP = bellman_ford(directed_G,
+                      directed=directed,
+                      indices=indices,
+                      min_only=True,
+                      return_predecessors=False)
+    assert_array_almost_equal(SP, min_d_ans)
+
+
+def test_bellman_ford_min_only_negative():
+    # min_only on a graph with negative edge weights
+    indices = [0, 1, 2]
+    SP = bellman_ford(directed_negative_weighted_G, directed=True,
+                      indices=indices, min_only=True)
+    assert_allclose(SP, np.array(directed_negative_weighted_SP)[indices].min(axis=0))
+
+
+@pytest.mark.parametrize('directed', (True, False))
+@pytest.mark.parametrize('n', (10, 30))
+def test_bellman_ford_min_only_random(directed, n):
+    rng = np.random.default_rng(12345)
+    # random graph with edges only from i to j with i < j, so no cycles
+    # and no negative cycles even with negative weights
+    dense = np.zeros((n, n))
+    iu = np.triu_indices(n, k=1)
+    keep = rng.random(iu[0].size) < 0.3
+    iu = (iu[0][keep], iu[1][keep])
+    if directed:
+        dense[iu] = rng.uniform(-1, 1, size=iu[0].size)
+    else:
+        dense[iu] = rng.uniform(0, 1, size=iu[0].size)
+        dense = np.maximum(dense, dense.T)
+    G = scipy.sparse.csr_array(dense)
+    v = np.arange(n)
+    rng.shuffle(v)
+    indices = v[:n // 2]
+    full = bellman_ford(G, directed=directed, indices=indices)
+    min_only = bellman_ford(G, directed=directed, indices=indices,
+                            min_only=True)
+    assert_allclose(min_only, full.min(axis=0))
+    full_d, full_p = bellman_ford(G, directed=directed, indices=indices,
+                                  return_predecessors=True)
+    min_d, min_p = bellman_ford(G, directed=directed, indices=indices,
+                                min_only=True, return_predecessors=True)
+    assert_allclose(min_d, full_d.min(axis=0))
+
+
+@pytest.mark.parametrize('directed', (True, False))
+def test_shortest_path_min_only(directed):
+    SP_ans = np.array(directed_SP if directed else undirected_SP)
+    indices = [0, 2, 4]
+    min_d_ans = SP_ans[indices].min(axis=0)
+
+    for method in ('D', 'BF', 'auto'):
+        SP = shortest_path(directed_G, method=method, directed=directed,
+                           indices=indices, min_only=True)
+        assert_array_almost_equal(SP, min_d_ans)
+        # min_only without indices still returns a single row
+        SP_all = shortest_path(directed_G, method=method, directed=directed,
+                               min_only=True)
+        assert_array_almost_equal(SP_all, SP_ans.min(axis=0))
+
+    for method in ('FW', 'J'):
+        assert_raises(ValueError, shortest_path, directed_G, method=method,
+                      directed=directed, indices=indices, min_only=True)
+
+
+def test_shortest_path_min_only_negative_auto():
+    # method='auto' with negative weights must fall back to BF, not J
+    indices = [0, 1, 2]
+    SP = shortest_path(directed_negative_weighted_G, method='auto',
+                       directed=True, indices=indices, min_only=True)
+    assert_allclose(SP, np.array(directed_negative_weighted_SP)[indices].min(axis=0))
+
+
 @pytest.mark.parametrize('n', (10, 100, 1000))
 def test_dijkstra_min_only_random(n):
     rng = np.random.default_rng(7345782358920239234)


### PR DESCRIPTION
## Summary

`scipy.sparse.csgraph.dijkstra` has a `min_only` argument that returns, for
each node, the shortest distance from *any* of the source `indices` instead of
the full `(n_indices, n_nodes)` matrix. This PR adds the same `min_only`
argument to `bellman_ford` and threads it through `shortest_path`, bringing
API uniformity across the shortest-path routines as requested in gh-25480.

## Problem

`bellman_ford` and `shortest_path` could not compute the shortest distance
from any of a set of source vertices in one call; callers had to compute the
full matrix and reduce it themselves, or loop over sources.

## What changed

- `bellman_ford(csgraph, ..., min_only=False)`:
  - `min_only=False` (default): unchanged behavior, `dist_matrix` has shape
    `(n_indices, n_nodes)`.
  - `min_only=True`: `dist_matrix` has shape `(n_nodes,)`, giving the shortest
    distance to each node from any of the sources in `indices`. When
    `return_predecessors=True`, the predecessor array has shape `(n_nodes,)`.
  - The multi-source case is computed with a single Bellman-Ford pass by
    initializing all sources at distance zero, so it is also faster than the
    per-source loop.
- `shortest_path(csgraph, ..., min_only=False)`:
  - Passes `min_only` through to methods `'D'` and `'BF'`.
  - Raises `ValueError` for methods `'FW'` and `'J'` when `min_only=True`
    (Floyd-Warshall cannot return a reduced result; Johnson provides no
    benefit over Bellman-Ford here, as noted in the issue).
  - With `method='auto'`, `min_only=True` now selects `'D'`/`'BF'` instead of
    `'FW'`/`'J'`, so `auto` never fails or wastes work with `min_only`.

## Why this approach

The behavior and return shapes mirror `dijkstra` exactly (including
`indices=None` producing a single `(n_nodes,)` result). The Bellman-Ford
relaxation core is reused unchanged; `min_only` only changes the output
initialization and reshape, so the negative-cycle detection semantics are
preserved.

## Testing

Ran against a locally rebuilt `_shortest_path` extension (Cython 3.1.4,
MSVC 2022, matching scipy's build flags):

- `python -m pytest scipy/sparse/csgraph/tests -q`
  → **1299 passed, 58 skipped, 0 failed** (skips are pre-existing
  environment-related).
- New tests cover:
  - `bellman_ford(min_only=True)` against known directed/undirected graphs
    and against the min over rows of the full result,
  - negative edge weights with `min_only`,
  - a randomized acyclic-graph cross-check of `min_only` vs the full matrix,
  - `shortest_path` with methods `D`/`BF`/`auto`, `indices=None`, negative
    weights under `auto`, and `ValueError` for `FW`/`J`.
- `python tools/refguide/refguide_check.py scipy.sparse.csgraph` → passed.
- `ruff check scipy/sparse/csgraph/tests/test_shortest_path.py` → passed.

## Risks / limitations

- `bellman_ford` with `min_only` does not return the per-target source index
  (unlike `dijkstra`'s `sources` output); the issue did not request it and
  Bellman-Ford's algorithm does not naturally produce it.
- `min_only=True` with `return_predecessors=True` returns a 1-D predecessor
  array; paths can be reconstructed as with `dijkstra`.

Closes #25480.
