### PR TITLE
fix-expm-norm-1-calculation

### DIFF
--- a/scipy/linalg/src/_matfuncs_expm.c
+++ b/scipy/linalg/src/_matfuncs_expm.c
@@ -1,9 +1,9 @@
 #include "_common_array_utils.h"
 
-static float snorm1(float*, float*, const Py_ssize_t);
-static double dnorm1(double*, double*, const Py_ssize_t);
-static float cnorm1(SCIPY_C*, float*, const Py_ssize_t);
-static double znorm1(SCIPY_Z*, double*, const Py_ssize_t);
+static float snorm1_col_major(float*, float*, const Py_ssize_t);
+static double dnorm1_col_major(double*, double*, const Py_ssize_t);
+static float cnorm1_col_major(SCIPY_C*, float*, const Py_ssize_t);
+static double znorm1_col_major(SCIPY_Z*, double*, const Py_ssize_t);
 static float snorm1est(float*, CBLAS_INT);
 static double dnorm1est(double*, CBLAS_INT);
 static float cnorm1est(SCIPY_C*, CBLAS_INT);
@@ -15,56 +15,56 @@ static double znorm1est(SCIPY_Z*, CBLAS_INT);
  *******************************************************************************/
 
  static float
-snorm1(float* A, float* work, const Py_ssize_t n)
+snorm1_col_major(float* A, float* work, const Py_ssize_t n)
 {
     Py_ssize_t i, j;
     float temp = 0.0;
     // Write absolute values of first row of A to work
     for (i = 0; i < n; i++) { work[i] = fabsf(A[i]); }
     // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += fabsf(A[i*n + j]); } }
+    for (i = 0; i < n; i++) { for (j = 1; j < n; j++) { work[i] += fabsf(A[i*n + j]); } }
     temp = 0.0;
     for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
     return temp;
 }
 
 static double
-dnorm1(double* A, double* work, const Py_ssize_t n)
+dnorm1_col_major(double* A, double* work, const Py_ssize_t n)
 {
     Py_ssize_t i, j;
     double temp = 0.0;
     // Write absolute values of first row of A to work
     for (i = 0; i < n; i++) { work[i] = fabs(A[i]); }
     // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += fabs(A[i*n + j]); } }
+    for (i = 0; i < n; i++) { for (j = 1; j < n; j++) { work[i] += fabs(A[i*n + j]); } }
     temp = 0.0;
     for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
     return temp;
 }
 
 static float
-cnorm1(SCIPY_C* A, float* work, const Py_ssize_t n)
+cnorm1_col_major(SCIPY_C* A, float* work, const Py_ssize_t n)
 {
     Py_ssize_t i, j;
     float temp = 0.0;
     // Write absolute values of first row of A to work
     for (i = 0; i < n; i++) { work[i] = cabsf(A[i]); }
     // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += cabsf(A[i*n + j]); } }
+    for (i = 0; i < n; i++) { for (j = 1; j < n; j++) { work[i] += cabsf(A[i*n + j]); } }
     temp = 0.0;
     for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
     return temp;
 }
 
 static double
-znorm1(SCIPY_Z* A, double* work, const Py_ssize_t n)
+znorm1_col_major(SCIPY_Z* A, double* work, const Py_ssize_t n)
 {
     Py_ssize_t i, j;
     double temp = 0.0;
     // Write absolute values of first row of A to work
     for (i = 0; i < n; i++) { work[i] = cabs(A[i]); }
     // Add absolute values of remaining rows of A to work
-    for (i = 1; i < n; i++) { for (j = 0; j < n; j++) { work[j] += cabs(A[i*n + j]); } }
+    for (i = 0; i < n; i++) { for (j = 1; j < n; j++) { work[i] += cabs(A[i*n + j]); } }
     temp = 0.0;
     for (i = 0; i < n; i++) { if (work[i] > temp) { temp = work[i]; } }
     return temp;
@@ -232,7 +232,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     {
         for (j = 0; j < n; j++)
         {
-            absA[j + i*n] = fabsf(Am[j + i*n]);
+            absA[j + i*n] = fabsf(Am[i + j*n]);
         }
     }
 
@@ -245,14 +245,14 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &dbl0, &Am[1*n*n], &n);
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[2*n*n], &n);
     BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[3*n*n], &n);
-    d4 = powf(snorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = powf(snorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = powf(snorm1_col_major(&Am[2*n*n], work_arr, n), 0.25);
+    d6 = powf(snorm1_col_major(&Am[3*n*n], work_arr, n), 1.0/6.0);
     eta0 = fmaxf(d4, d6);
     eta1 = eta0;
 
     // m = 3
     // -------
-    // 1-norm of A**7
+    // 1-norm of |A|**7
     // Alternating matvecs
     // absA * work_arr[n:] = work_arr[:n]
     // absA * work_arr[:n] = work_arr[n:]
@@ -274,7 +274,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 5
     // -------
-    // 1-norm of A**11
+    // 1-norm of |A|**11
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -297,7 +297,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d8 = powf(snorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = powf(snorm1_col_major(&Am[4*n*n], work_arr, n), 0.125);
     } else {
         test = snorm1est(&Am[0], 8);
         // If memory error in s1normest
@@ -307,7 +307,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
 
     eta2 = fmaxf(d6, d8);
 
-    // 1-norm of A**15
+    // 1-norm of |A|**15
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -327,7 +327,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 9
     // -------
-    // 1-norm of A**19
+    // 1-norm of |A|**19
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -354,7 +354,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(sgemm)("N", "N", &n, &n, &n, &dbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d10 = powf(snorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = powf(snorm1_col_major(&Am[4*n*n], work_arr, n), 0.1);
     } else {
         test = snorm1est(&Am[0], 10);
         // If memory error in s1normest
@@ -378,7 +378,7 @@ pick_pade_structure_s(float* Am, const Py_ssize_t size_n, int* m, int* s)
         normA *= powf(2.0, -(*s));
     }
 
-    // 1-norm of A**27
+    // 1-norm of |A|**27
     for (i = 0; i < 4; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -449,7 +449,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     {
         for (j = 0; j < n; j++)
         {
-            absA[j + i*n] = fabs(Am[j + i*n]);
+            absA[j + i*n] = fabs(Am[i + j*n]);
         }
     }
 
@@ -462,14 +462,14 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &dbl0, &Am[1*n*n], &n);
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[2*n*n], &n);
     BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &dbl0, &Am[3*n*n], &n);
-    d4 = pow(dnorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = pow(dnorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = pow(dnorm1_col_major(&Am[2*n*n], work_arr, n), 0.25);
+    d6 = pow(dnorm1_col_major(&Am[3*n*n], work_arr, n), 1.0/6.0);
     eta0 = fmax(d4, d6);
     eta1 = eta0;
 
     // m = 3
     // -------
-    // 1-norm of A**7
+    // 1-norm of |A|**7
     // Alternating matvecs
     // absA * work_arr[n:] = work_arr[:n]
     // absA * work_arr[:n] = work_arr[n:]
@@ -491,7 +491,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 5
     // -------
-    // 1-norm of A**11
+    // 1-norm of |A|**11
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -514,7 +514,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d8 = pow(dnorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = pow(dnorm1_col_major(&Am[4*n*n], work_arr, n), 0.125);
     } else {
         test = dnorm1est(&Am[0], 8);
         // If memory error in d1normest
@@ -524,7 +524,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
 
     eta2 = fmax(d6, d8);
 
-    // 1-norm of A**15
+    // 1-norm of |A|**15
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -544,7 +544,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 9
     // -------
-    // 1-norm of A**19
+    // 1-norm of |A|**19
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -571,7 +571,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(dgemm)("N", "N", &n, &n, &n, &dbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &dbl0, &Am[4*n*n], &n);
-        d10 = pow(dnorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = pow(dnorm1_col_major(&Am[4*n*n], work_arr, n), 0.1);
     } else {
         test = dnorm1est(&Am[0], 10);
         // If memory error in d1normest
@@ -595,7 +595,7 @@ pick_pade_structure_d(double* Am, const Py_ssize_t size_n, int* m, int* s)
         normA *= pow(2.0, -(*s));
     }
 
-    // 1-norm of A**27
+    // 1-norm of |A|**27
     for (i = 0; i < 4; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -669,7 +669,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     {
         for (j = 0; j < n; j++)
         {
-            absA[j + i*n] = cabsf(Am[j + i*n]);
+            absA[j + i*n] = cabsf(Am[i + j*n]);
         }
     }
 
@@ -682,14 +682,14 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &cdbl0, &Am[1*n*n], &n);
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[2*n*n], &n);
     BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[3*n*n], &n);
-    d4 = powf(cnorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = powf(cnorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = powf(cnorm1_col_major(&Am[2*n*n], work_arr, n), 0.25);
+    d6 = powf(cnorm1_col_major(&Am[3*n*n], work_arr, n), 1.0/6.0);
     eta0 = fmaxf(d4, d6);
     eta1 = eta0;
 
     // m = 3
     // -------
-    // 1-norm of A**7
+    // 1-norm of |A|**7
     // Alternating matvecs
     // absA * work_arr[n:] = work_arr[:n]
     // absA * work_arr[:n] = work_arr[n:]
@@ -711,7 +711,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 5
     // -------
-    // 1-norm of A**11
+    // 1-norm of |A|**11
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -734,7 +734,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d8 = powf(cnorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = powf(cnorm1_col_major(&Am[4*n*n], work_arr, n), 0.125);
     } else {
         test = cnorm1est(&Am[0], 8);
         // If memory error in c1normest
@@ -744,7 +744,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
 
     eta2 = fmaxf(d6, d8);
 
-    // 1-norm of A**15
+    // 1-norm of |A|**15
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -764,7 +764,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 9
     // -------
-    // 1-norm of A**19
+    // 1-norm of |A|**19
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -791,7 +791,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(cgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d10 = powf(cnorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = powf(cnorm1_col_major(&Am[4*n*n], work_arr, n), 0.1);
     } else {
         test = cnorm1est(&Am[0], 10);
         // If memory error in c1normest
@@ -815,7 +815,7 @@ pick_pade_structure_c(SCIPY_C* Am, const Py_ssize_t size_n, int* m, int* s)
         normA *= powf(2.0, -(*s));
     }
 
-    // 1-norm of A**27
+    // 1-norm of |A|**27
     for (i = 0; i < 4; i++)
     {
         BLAS_FUNC(sgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -896,7 +896,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     {
         for (j = 0; j < n; j++)
         {
-            absA[j + i*n] = cabs(Am[j + i*n]);
+            absA[j + i*n] = cabs(Am[i + j*n]);
         }
     }
 
@@ -909,14 +909,14 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[0*n*n], &n, &Am[0*n*n], &n, &cdbl0, &Am[1*n*n], &n);
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[1*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[2*n*n], &n);
     BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[1*n*n], &n, &cdbl0, &Am[3*n*n], &n);
-    d4 = pow(znorm1(&Am[2*n*n], work_arr, n), 0.25);
-    d6 = pow(znorm1(&Am[3*n*n], work_arr, n), 1.0/6.0);
+    d4 = pow(znorm1_col_major(&Am[2*n*n], work_arr, n), 0.25);
+    d6 = pow(znorm1_col_major(&Am[3*n*n], work_arr, n), 1.0/6.0);
     eta0 = fmax(d4, d6);
     eta1 = eta0;
 
     // m = 3
     // -------
-    // 1-norm of A**7
+    // 1-norm of |A|**7
     // Alternating matvecs
     // absA * work_arr[n:] = work_arr[:n]
     // absA * work_arr[:n] = work_arr[n:]
@@ -938,7 +938,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 5
     // -------
-    // 1-norm of A**11
+    // 1-norm of |A|**11
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -961,7 +961,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[2*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d8 = pow(znorm1(&Am[4*n*n], work_arr, n), 0.125);
+        d8 = pow(znorm1_col_major(&Am[4*n*n], work_arr, n), 0.125);
     } else {
         test = znorm1est(&Am[0], 8);
         // If memory error in z1normest
@@ -971,7 +971,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
 
     eta2 = fmax(d6, d8);
 
-    // 1-norm of A**15
+    // 1-norm of |A|**15
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -991,7 +991,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
 
     // m = 9
     // -------
-    // 1-norm of A**19
+    // 1-norm of |A|**19
     for (i = 0; i < 2; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);
@@ -1020,7 +1020,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
     if (n < 400)
     {
         BLAS_FUNC(zgemm)("N", "N", &n, &n, &n, &cdbl1, &Am[3*n*n], &n, &Am[2*n*n], &n, &cdbl0, &Am[4*n*n], &n);
-        d10 = pow(znorm1(&Am[4*n*n], work_arr, n), 0.1);
+        d10 = pow(znorm1_col_major(&Am[4*n*n], work_arr, n), 0.1);
     } else {
         test = znorm1est(&Am[0], 10);
         // If memory error in z1normest
@@ -1044,7 +1044,7 @@ pick_pade_structure_z(SCIPY_Z* Am, const Py_ssize_t size_n, int* m, int* s)
         normA *= pow(2.0, -(*s));
     }
 
-    // 1-norm of A**27
+    // 1-norm of |A|**27
     for (i = 0; i < 4; i++)
     {
         BLAS_FUNC(dgemv)("N", &n, &n, &dbl1, absA, &n, &work_arr[n], &int1, &dbl0, &work_arr[0], &int1);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-25864

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixed expm 1-norm calculation issues.

Changed abs-A layout to match formula 5.5 in the original Higham09 article.
Modified the norm-1 function to support the column-major matrix layout.

Updated the comment to match the |A| norm-1 calculation.

#### Additional information
<!--Any additional information you think is important.-->
It turns out the test error would occur if using "T" layout in the BLAS mat-vec function.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used.
