### PR TITLE
ENH: signal: add Array API support for `czt_points`

### DIFF
--- a/scipy/signal/_czt.py
+++ b/scipy/signal/_czt.py
@@ -87,7 +87,7 @@ def czt_points(m, w=None, a=1+0j, *, xp=None, device=None):
 
     a = xp.asarray(a, device=device)
     w = xp.asarray(w, device=device) if w is not None else None
-    dtype = xp_result_type(a, w, xp.float64, force_floating=True, xp=xp)
+    dtype = xp_result_type(a, w, force_floating=True, xp=xp)
     a = xp.astype(a, dtype)
     w = xp.astype(w, dtype) if w is not None else None
     k = xp.arange(m, device=device, dtype=xp.float64)

--- a/scipy/signal/_czt.py
+++ b/scipy/signal/_czt.py
@@ -6,6 +6,8 @@ import cmath
 import numbers
 import numpy as np
 from numpy import pi, arange
+from scipy._lib._array_api import xp_result_type
+from scipy._external.array_api_compat import numpy as np_compat
 from scipy.fft import fft, ifft, next_fast_len
 
 __all__ = ['czt', 'zoom_fft', 'CZT', 'ZoomFFT', 'czt_points']
@@ -27,7 +29,7 @@ def _validate_sizes(n, m):
     return m
 
 
-def czt_points(m, w=None, a=1+0j):
+def czt_points(m, w=None, a=1+0j, *, xp=None, device=None):
     """
     Return the points at which the chirp z-transform is computed.
 
@@ -40,6 +42,10 @@ def czt_points(m, w=None, a=1+0j):
         Defaults to equally spaced points around the entire unit circle.
     a : complex, optional
         The starting point in the complex plane.  Default is 1+0j.
+    xp : array_namespace, optional
+        The namespace for the return array. Default is None, where NumPy is used.
+    device : device, optional
+        The device for the return array. Default is None.
 
     Returns
     -------
@@ -74,18 +80,23 @@ def czt_points(m, w=None, a=1+0j):
     >>> plt.axis('equal')
     >>> plt.show()
     """
+    if xp is None:
+        xp = np_compat
+
     m = _validate_sizes(1, m)
 
-    k = arange(m)
-
-    a = 1.0 * a  # at least float
+    a = xp.asarray(a, device=device)
+    w = xp.asarray(w, device=device) if w is not None else None
+    dtype = xp_result_type(a, w, xp.float64, force_floating=True, xp=xp)
+    a = xp.astype(a, dtype)
+    w = xp.astype(w, dtype) if w is not None else None
+    k = xp.arange(m, device=device, dtype=xp.float64)
 
     if w is None:
         # Nothing specified, default to FFT
-        return a * np.exp(2j * pi * k / m)
+        return a * xp.exp(2j * xp.pi * k / m)
     else:
         # w specified
-        w = 1.0 * w  # at least float
         return a * w**-k
 
 

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -113,8 +113,8 @@ def correlation_lags_signature(in1_len, in2_len, mode='full'):
     return np
 
 
-def czt_points_signature(m, w=None, a=(1+0j)):
-    return np
+def czt_points_signature(m, w=None, a=(1+0j), *, xp=None, device=None):
+    return np if xp is None else xp
 
 
 def gammatone_signature(

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -80,7 +80,6 @@ untested = {
     "coherence",
     "csd",
     "czt",
-    "czt_points",
     "dbode",
     "dfreqresp",
     "dlsim",

--- a/scipy/signal/tests/test_czt.py
+++ b/scipy/signal/tests/test_czt.py
@@ -4,7 +4,7 @@
 A unit test module for czt.py
 '''
 import pytest
-from scipy._lib._array_api import xp_assert_close
+from scipy._lib._array_api import is_numpy, make_xp_test_case, xp_assert_close
 from scipy.fft import fft
 from scipy.signal import (czt, zoom_fft, czt_points, CZT, ZoomFFT)
 import numpy as np
@@ -164,24 +164,43 @@ def test_czt_math(impulse, m, w, a):
                     czt_points(m=m, w=w, a=a)**-2, rtol=1e-10)
 
 
-def test_int_args():
+def test_czt_int_args():
     # Integer argument `a` was producing all 0s
     xp_assert_close(abs(czt([0, 1], m=10, a=2)), 0.5*np.ones(10), rtol=1e-15)
-    xp_assert_close(czt_points(11, w=2),
-                    1/(2**np.arange(11, dtype=np.complex128)), rtol=1e-30)
 
 
-def test_czt_points():
+@make_xp_test_case(czt_points)
+def test_czt_points_int_args(xp):
+    xp_assert_close(czt_points(11, w=2, xp=xp),
+                    1/(2**xp.arange(11, dtype=xp.complex128)), rtol=1e-14)
+
+
+@make_xp_test_case(czt_points)
+def test_czt_points(xp):
     for N in (1, 2, 3, 8, 11, 100, 101, 10007):
-        xp_assert_close(czt_points(N), np.exp(2j*np.pi*np.arange(N)/N),
-                        rtol=1e-30)
+        xp_assert_close(czt_points(N, xp=xp),
+                        xp.exp(2j*xp.pi*xp.arange(N, dtype=xp.float64)/N),
+                        rtol=1e-14)
 
-    xp_assert_close(czt_points(7, w=1), np.ones(7, dtype=np.complex128), rtol=1e-30)
-    xp_assert_close(czt_points(11, w=2.),
-                    1/(2**np.arange(11, dtype=np.complex128)), rtol=1e-30)
+    xp_assert_close(czt_points(7, w=1, xp=xp),
+                    xp.ones(7, dtype=xp.complex128), rtol=1e-30)
+    xp_assert_close(czt_points(11, w=2, xp=xp),
+                    1/(2**xp.arange(11, dtype=xp.complex128)), rtol=1e-14)
 
-    func = CZT(12, m=11, w=2., a=1)
-    xp_assert_close(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
+    if is_numpy(xp):
+        func = CZT(12, m=11, w=2., a=1)
+        xp_assert_close(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
+
+
+@make_xp_test_case(czt_points)
+def test_czt_points_dtype(xp):
+    for name in ("int32", "int64", "float32", "float64",
+                 "complex64", "complex128"):
+        dtype = getattr(xp, name)
+        value = xp.asarray(1, dtype=dtype)
+        expected = (xp.complex128 if xp.isdtype(dtype, "complex floating")
+                    else xp.float64)
+        assert czt_points(7, w=value, a=value, xp=xp).dtype == expected
 
 
 @pytest.mark.parametrize('cls, args', [(CZT, (100,)), (ZoomFFT, (100, 0.2))])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Add Array API support for `signal.czt_points`. I tried to follow the best I could the pattern used for [signal.buttap](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.buttap.html). It seems that only CuPy has their own implementation (see [here](https://docs.cupy.dev/en/latest/reference/generated/cupyx.scipy.signal.czt_points.html))

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

worked with Codex on the changes.
