### PR TITLE
MAINT: spatial: mark plotting functions as out of scope for array api

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from scipy._lib._array_api import xp_capabilities
+
 __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 
 
@@ -17,6 +19,7 @@ def _adjust_bounds(ax, points):
     ax.set_ylim(xy_min[1], xy_max[1])
 
 
+@xp_capabilities(out_of_scope=True)
 def delaunay_plot_2d(tri, ax=None):
     """
     Plot the given Delaunay triangulation in 2-D.
@@ -75,6 +78,7 @@ def delaunay_plot_2d(tri, ax=None):
     return ax.figure
 
 
+@xp_capabilities(out_of_scope=True)
 def convex_hull_plot_2d(hull, ax=None):
     """
     Plot the given convex hull diagram in 2-D.
@@ -135,6 +139,7 @@ def convex_hull_plot_2d(hull, ax=None):
     return ax.figure
 
 
+@xp_capabilities(out_of_scope=True)
 def voronoi_plot_2d(vor, ax=None, **kw):
     """
     Plot the given Voronoi diagram in 2-D.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Marking these as out of scope as matplotlib does not support array api
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai