### PR TITLE
BUG: linalg: fix zero-sized batch errors for `svd` and `qr`

### DIFF
--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -198,7 +198,17 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
             R = np.empty_like(a1, shape=batch_shape + (K, N))
 
         if pivoting:
-            Rj = R, np.arange(N, dtype=np.int64 if HAS_ILP64 else np.int32)
+            if np.any(batch_shape == 0):
+                jpvt = np.empty(
+                    batch_shape + (N,), dtype=np.int64 if HAS_ILP64 else np.int32
+                )
+            else:
+                jpvt = np.tile(
+                    np.arange(N, dtype=np.int64 if HAS_ILP64 else np.int32),
+                    batch_shape + (1,),
+                )
+            Rj = R, jpvt
+
         else:
             Rj = R,
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -165,18 +165,19 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
 
     # accommodate empty matrix
     if a1.size == 0:
+        k = min(m, n)
         u0, s0, v0 = svd(np.eye(2, dtype=a1.dtype))
 
         batch_shape = a1.shape[:-2]
-        s = np.empty_like(a1, shape=batch_shape + (0,), dtype=s0.dtype)
+        s = np.empty_like(a1, shape=batch_shape + (k,), dtype=s0.dtype)
         if full_matrices:
             u = np.empty_like(a1, shape=batch_shape + (m, m), dtype=u0.dtype)
             u[...] = np.identity(m)
             v = np.empty_like(a1, shape=batch_shape + (n, n), dtype=v0.dtype)
             v[...] = np.identity(n)
         else:
-            u = np.empty_like(a1, shape=batch_shape + (m, 0), dtype=u0.dtype)
-            v = np.empty_like(a1, shape=batch_shape + (0, n), dtype=v0.dtype)
+            u = np.empty_like(a1, shape=batch_shape + (m, k), dtype=u0.dtype)
+            v = np.empty_like(a1, shape=batch_shape + (k, n), dtype=v0.dtype)
         if compute_uv:
             return u, s, v
         else:

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -215,14 +215,14 @@ class TestBatch:
         self.batch_test(
             linalg.svd, A, n_out=n_out,
             kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices),
-            test_zero_size=None
+            test_zero_size=True
         )
 
         A = get_random((5, 3, 2, 0), dtype=dtype, rng=rng)
         self.batch_test(
             linalg.svd, A, n_out=n_out,
             kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices),
-            test_zero_size=None
+            test_zero_size=True
         )
 
     @pytest.mark.parametrize('fun', [linalg.polar, linalg.rq])
@@ -240,7 +240,7 @@ class TestBatch:
         a = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         self.batch_test(lambda x: linalg.qr(x, mode=mode, pivoting=pivoting), a,
                         n_out=(1 if mode == 'r' else 2) + 1 if pivoting else 0,
-            test_zero_size=None)
+            test_zero_size=True)
 
     @pytest.mark.parametrize('pivoting', [True, False])
     @pytest.mark.parametrize('dtype', floating)
@@ -417,7 +417,7 @@ class TestBatch:
     def test_svdvals(self, fun, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
-        self.batch_test(fun, A, test_zero_size=None)
+        self.batch_test(fun, A, test_zero_size=True)
 
     @pytest.mark.parametrize('fun_n_out', [(linalg.orthogonal_procrustes, 2),
                                            (linalg.khatri_rao, 1),


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/24158#issuecomment-5259385012

#### What does this implement/fix?
Fixes two issues for empty batches in the functions that got lowered to C/C++ already as pointed out in the comment above.

- Ensure that the svd values array has the correct trailing dimension instead of just 0.
- Return an empty pivoting array with batch dimension rather than just a plain `arange`.

#### Additional information
N/A

#### AI Generation Disclosure
No AI
