### PR TITLE
BUG: fix _dict_formatter ValueError on empty dict values (gh-25893)

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1063,6 +1063,8 @@ def _dict_formatter(d, n=0, mplus=1, sorter=None):
     `mplus` is additional left padding applied to keys
     """
     if isinstance(d, dict):
+        if not d:
+            return '{}'
         m = max(map(len, list(d.keys()))) + mplus  # width to print keys
         s = '\n'.join([k.rjust(m) + ': ' +  # right justified, width m
                        _indenter(_dict_formatter(v, m+n+2, 0, sorter), m+2)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2596,6 +2596,13 @@ class TestOptimizeResultAttributes:
             # gh13001, OptimizeResult.message should be a str
             assert isinstance(res.message, str)
 
+    def test_repr_with_empty_dict_value(self):
+        # gh-25893: _dict_formatter raised ValueError on empty dict values
+        res = optimize.OptimizeResult(options={})
+        r = repr(res)
+        assert 'options' in r
+        assert '{}' in r
+
 
 def f1(z, *params):
     x, y = z


### PR DESCRIPTION
## Summary

Fixes #25893.

`_dict_formatter` called `max(map(len, list(d.keys())))` without guarding against an empty dict. When `OptimizeResult` (or any `_RichResult` subclass) contained an empty dict as an attribute value, `repr()` raised `ValueError: max() iterable argument is empty`.

## Reproduction

```python
from scipy.optimize import OptimizeResult
print(OptimizeResult(options={}))
# Before: ValueError: max() iterable argument is empty
# After:
#  options: {}
```

Also reproducible directly via:

```python
from scipy._lib._util import _RichResult
print(_RichResult(options={}))
```

## Fix

Added an early-return guard in `_dict_formatter` for empty dicts, returning `'{}'` (the standard Python representation of an empty dict):

```python
if not d:
    return '{}'
```

## Test

Added `test_repr_with_empty_dict_value` to `TestOptimizeResultAttributes` verifying that `repr(OptimizeResult(options={}))` succeeds and includes both `options` and `{}`.
