### PR TITLE
MAINT: cluster: complete array api coverage table by marking `DisjointSet` and `ClusterNode` out of scope

### DIFF
--- a/scipy/_lib/_disjoint_set.py
+++ b/scipy/_lib/_disjoint_set.py
@@ -1,8 +1,10 @@
 """
 Disjoint set data structure
 """
+from scipy._lib._array_api import xp_capabilities
 
 
+@xp_capabilities(out_of_scope=True)
 class DisjointSet:
     """Disjoint set data structure for incremental connectivity queries.
 

--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -978,6 +978,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
         return result
 
 
+@xp_capabilities(out_of_scope=True)
 class ClusterNode:
     """
     A tree node class for representing a cluster.


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Neither use arrays so can be safely marked as out of scope. 
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai