### PR TITLE
BLD: package: pin meson on win-64 to avoid clang-cl bug

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,7 @@ numpy = "*"
 blas-devel = "*"
 
 [package.host-dependencies."if(host_platform == 'win-64')"]
+meson = "<1.12.0"  # scipy/scipy#25904
 openblas = "*"
 
 


### PR DESCRIPTION
hopefully to restore green CI while we figure out why the meson release has tripped us up in gh-25904