### PR TITLE
MAINT: special: use vendored `packaging.version`

### DIFF
--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import warnings
 
-from packaging import version
+from scipy._external.packaging_version import version
 
 
 def _parse_core_ndims(signature):

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -4,7 +4,7 @@ import pickle
 import pytest
 from hypothesis import given, strategies
 import hypothesis.extra.numpy as npst
-from packaging import version
+from scipy._external.packaging_version import version
 
 from scipy import special
 from scipy.special._support_alternative_backends import _special_funcs

--- a/scipy/special/tests/test_ufunc_infra.py
+++ b/scipy/special/tests/test_ufunc_infra.py
@@ -3,7 +3,7 @@ import pytest
 
 from numpy.testing import assert_equal
 from numpy._core._exceptions import UFuncTypeError
-from packaging import version
+from scipy._external.packaging_version import version
 # ufunc using special._ufuncs_tools._with_cache_optimization
 from scipy.special import mathieu_sem
 # raw ufunc without cache optimization


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I might be completely wrong, in which case apologies, but my impression was we should use our vendored version of `packaging.version` instead of assuming it is installed. I came across this while trying to use the nightly wheels.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai