### PR TITLE
ENH: spatial.procrustes: add array api support

### DIFF
--- a/scipy/spatial/_procrustes.py
+++ b/scipy/spatial/_procrustes.py
@@ -5,13 +5,18 @@ This code was originally written by Justin Kucynski and ported over from
 scikit-bio by Yoshiki Vazquez-Baeza.
 """
 
-import numpy as np
+
 from scipy.linalg import orthogonal_procrustes
+from scipy._lib._array_api import array_namespace, xp_capabilities
 
 
 __all__ = ['procrustes']
 
 
+@xp_capabilities(
+    jax_jit=False,
+    skip_backends=[("dask.array", "full_matrices=True is not supported by dask")]
+)
 def procrustes(data1, data2):
     r"""Procrustes analysis, a similarity test for two data sets.
 
@@ -97,8 +102,9 @@ def procrustes(data1, data2):
     0
 
     """
-    mtx1 = np.array(data1, dtype=np.float64, copy=True)
-    mtx2 = np.array(data2, dtype=np.float64, copy=True)
+    xp = array_namespace(data1, data2)
+    mtx1 = xp.asarray(data1, dtype=xp.float64, copy=True)
+    mtx2 = xp.asarray(data2, dtype=xp.float64, copy=True)
 
     if mtx1.ndim != 2 or mtx2.ndim != 2:
         raise ValueError("Input matrices must be two-dimensional")
@@ -108,11 +114,11 @@ def procrustes(data1, data2):
         raise ValueError("Input matrices must be >0 rows and >0 cols")
 
     # translate all the data to the origin
-    mtx1 -= np.mean(mtx1, 0)
-    mtx2 -= np.mean(mtx2, 0)
+    mtx1 -= xp.mean(mtx1, axis=0)
+    mtx2 -= xp.mean(mtx2, axis=0)
 
-    norm1 = np.linalg.norm(mtx1)
-    norm2 = np.linalg.norm(mtx2)
+    norm1 = xp.linalg.matrix_norm(mtx1)
+    norm2 = xp.linalg.matrix_norm(mtx2)
 
     if norm1 == 0 or norm2 == 0:
         raise ValueError("Input matrices must contain >1 unique points")
@@ -123,10 +129,10 @@ def procrustes(data1, data2):
 
     # transform mtx2 to minimize disparity
     R, s = orthogonal_procrustes(mtx1, mtx2)
-    mtx2 = np.dot(mtx2, R.T) * s
+    mtx2 = (mtx2 @ R.T) * s
 
     # measure the dissimilarity between the two datasets
-    disparity = np.sum(np.square(mtx1 - mtx2))
+    disparity = xp.sum(xp.square(mtx1 - mtx2))
 
     return mtx1, mtx2, disparity
 

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -3,7 +3,8 @@ import math
 from pytest import raises as assert_raises
 
 from scipy.spatial import procrustes
-from scipy._lib._array_api import make_xp_test_case, xp_assert_close, xp_assert_equal
+from scipy._lib._array_api import make_xp_test_case
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 
 @make_xp_test_case(procrustes)

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -1,116 +1,119 @@
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal, assert_almost_equal
+import math
+
 from pytest import raises as assert_raises
 
 from scipy.spatial import procrustes
+from scipy._lib._array_api import make_xp_test_case, xp_assert_close, xp_assert_equal
 
 
+@make_xp_test_case(procrustes)
 class TestProcrustes:
-    def setup_method(self):
+    def get_data(self, xp):
         """creates inputs"""
         # an L
-        self.data1 = np.array([[1, 3], [1, 2], [1, 1], [2, 1]], 'd')
+        data1 = xp.asarray([[1, 3], [1, 2], [1, 1], [2, 1]])
 
         # a larger, shifted, mirrored L
-        self.data2 = np.array([[4, -2], [4, -4], [4, -6], [2, -6]], 'd')
+        data2 = xp.asarray([[4, -2], [4, -4], [4, -6], [2, -6]])
 
         # an L shifted up 1, right 1, and with point 4 shifted an extra .5
         # to the right
         # pointwise distance disparity with data1: 3*(2) + (1 + 1.5^2)
-        self.data3 = np.array([[2, 4], [2, 3], [2, 2], [3, 2.5]], 'd')
+        data3 = xp.asarray([[2, 4], [2, 3], [2, 2], [3, 2.5]])
 
         # data4, data5 are standardized (trace(A*A') = 1).
         # procrustes should return an identical copy if they are used
         # as the first matrix argument.
-        shiftangle = np.pi / 8
-        self.data4 = np.array([[1, 0], [0, 1], [-1, 0],
-                              [0, -1]], 'd') / np.sqrt(4)
-        self.data5 = np.array([[np.cos(shiftangle), np.sin(shiftangle)],
-                              [np.cos(np.pi / 2 - shiftangle),
-                               np.sin(np.pi / 2 - shiftangle)],
-                              [-np.cos(shiftangle),
-                               -np.sin(shiftangle)],
-                              [-np.cos(np.pi / 2 - shiftangle),
-                               -np.sin(np.pi / 2 - shiftangle)]],
-                              'd') / np.sqrt(4)
+        shiftangle = xp.asarray(xp.pi / 8)
+        data4 = xp.asarray([[1., 0], [0, 1], [-1, 0], [0, -1]]) / math.sqrt(4)
+        data5 = xp.asarray([[xp.cos(shiftangle), xp.sin(shiftangle)],
+                            [xp.cos(xp.pi / 2 - shiftangle),
+                             xp.sin(xp.pi / 2 - shiftangle)],
+                            [-xp.cos(shiftangle),
+                             -xp.sin(shiftangle)],
+                            [-xp.cos(xp.pi / 2 - shiftangle),
+                             -xp.sin(xp.pi / 2 - shiftangle)]]) / math.sqrt(4)
+        return data1, data2, data3, data4, data5
 
-    def test_procrustes(self):
+    def test_procrustes(self, xp):
         # tests procrustes' ability to match two matrices.
         #
         # the second matrix is a rotated, shifted, scaled, and mirrored version
         # of the first, in two dimensions only
         #
         # can shift, mirror, and scale an 'L'?
-        a, b, disparity = procrustes(self.data1, self.data2)
-        assert_allclose(b, a)
-        assert_almost_equal(disparity, 0.)
+        data1, data2, data3, data4, data5 = self.get_data(xp)
+        a, b, disparity = procrustes(data1, data2)
+        xp_assert_close(b, a)
+        xp_assert_close(disparity, 0., atol=1e-15)
 
         # if first mtx is standardized, leaves first mtx unchanged?
-        m4, m5, disp45 = procrustes(self.data4, self.data5)
-        assert_equal(m4, self.data4)
+        m4, m5, disp45 = procrustes(data4, data5)
+        xp_assert_equal(m4, data4)
 
         # at worst, data3 is an 'L' with one point off by .5
-        m1, m3, disp13 = procrustes(self.data1, self.data3)
+        m1, m3, disp13 = procrustes(data1, data3)
         #assert_(disp13 < 0.5 ** 2)
 
-    def test_procrustes2(self):
+    def test_procrustes2(self, xp):
         # procrustes disparity should not depend on order of matrices
-        m1, m3, disp13 = procrustes(self.data1, self.data3)
-        m3_2, m1_2, disp31 = procrustes(self.data3, self.data1)
-        assert_almost_equal(disp13, disp31)
+        data1, data2, data3, data4, data5 = self.get_data(xp)
+        m1, m3, disp13 = procrustes(data1, data3)
+        m3_2, m1_2, disp31 = procrustes(data3, data1)
+        xp_assert_close(disp13, disp31)
 
         # try with 3d, 8 pts per
-        rand1 = np.array([[2.61955202, 0.30522265, 0.55515826],
-                         [0.41124708, -0.03966978, -0.31854548],
-                         [0.91910318, 1.39451809, -0.15295084],
-                         [2.00452023, 0.50150048, 0.29485268],
-                         [0.09453595, 0.67528885, 0.03283872],
-                         [0.07015232, 2.18892599, -1.67266852],
-                         [0.65029688, 1.60551637, 0.80013549],
-                         [-0.6607528, 0.53644208, 0.17033891]])
+        rand1 = xp.asarray([[2.61955202, 0.30522265, 0.55515826],
+                            [0.41124708, -0.03966978, -0.31854548],
+                            [0.91910318, 1.39451809, -0.15295084],
+                            [2.00452023, 0.50150048, 0.29485268],
+                            [0.09453595, 0.67528885, 0.03283872],
+                            [0.07015232, 2.18892599, -1.67266852],
+                            [0.65029688, 1.60551637, 0.80013549],
+                            [-0.6607528, 0.53644208, 0.17033891]])
 
-        rand3 = np.array([[0.0809969, 0.09731461, -0.173442],
-                         [-1.84888465, -0.92589646, -1.29335743],
-                         [0.67031855, -1.35957463, 0.41938621],
-                         [0.73967209, -0.20230757, 0.52418027],
-                         [0.17752796, 0.09065607, 0.29827466],
-                         [0.47999368, -0.88455717, -0.57547934],
-                         [-0.11486344, -0.12608506, -0.3395779],
-                         [-0.86106154, -0.28687488, 0.9644429]])
+        rand3 = xp.asarray([[0.0809969, 0.09731461, -0.173442],
+                            [-1.84888465, -0.92589646, -1.29335743],
+                            [0.67031855, -1.35957463, 0.41938621],
+                            [0.73967209, -0.20230757, 0.52418027],
+                            [0.17752796, 0.09065607, 0.29827466],
+                            [0.47999368, -0.88455717, -0.57547934],
+                            [-0.11486344, -0.12608506, -0.3395779],
+                            [-0.86106154, -0.28687488, 0.9644429]])
         res1, res3, disp13 = procrustes(rand1, rand3)
         res3_2, res1_2, disp31 = procrustes(rand3, rand1)
-        assert_almost_equal(disp13, disp31)
+        xp_assert_close(disp13, disp31)
 
-    def test_procrustes_shape_mismatch(self):
+    def test_procrustes_shape_mismatch(self, xp):
         assert_raises(ValueError, procrustes,
-                      np.array([[1, 2], [3, 4]]),
-                      np.array([[5, 6, 7], [8, 9, 10]]))
+                      xp.asarray([[1, 2], [3, 4]]),
+                      xp.asarray([[5, 6, 7], [8, 9, 10]]))
 
-    def test_procrustes_empty_rows_or_cols(self):
-        empty = np.array([[]])
+    def test_procrustes_empty_rows_or_cols(self, xp):
+        empty = xp.asarray([[]])
         assert_raises(ValueError, procrustes, empty, empty)
 
-    def test_procrustes_no_variation(self):
+    def test_procrustes_no_variation(self, xp):
         assert_raises(ValueError, procrustes,
-                      np.array([[42, 42], [42, 42]]),
-                      np.array([[45, 45], [45, 45]]))
+                      xp.asarray([[42, 42], [42, 42]]),
+                      xp.asarray([[45, 45], [45, 45]]))
 
-    def test_procrustes_bad_number_of_dimensions(self):
+    def test_procrustes_bad_number_of_dimensions(self, xp):
         # fewer dimensions in one dataset
         assert_raises(ValueError, procrustes,
-                      np.array([1, 1, 2, 3, 5, 8]),
-                      np.array([[1, 2], [3, 4]]))
+                      xp.asarray([1, 1, 2, 3, 5, 8]),
+                      xp.asarray([[1, 2], [3, 4]]))
 
         # fewer dimensions in both datasets
         assert_raises(ValueError, procrustes,
-                      np.array([1, 1, 2, 3, 5, 8]),
-                      np.array([1, 1, 2, 3, 5, 8]))
+                      xp.asarray([1, 1, 2, 3, 5, 8]),
+                      xp.asarray([1, 1, 2, 3, 5, 8]))
 
         # zero dimensions
-        assert_raises(ValueError, procrustes, np.array(7), np.array(11))
+        assert_raises(ValueError, procrustes, xp.asarray(7), xp.asarray(11))
 
         # extra dimensions
         assert_raises(ValueError, procrustes,
-                      np.array([[[11], [7]]]),
-                      np.array([[[5, 13]]]))
+                      xp.asarray([[[11], [7]]]),
+                      xp.asarray([[[5, 13]]]))
 

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -11,21 +11,22 @@ class TestProcrustes:
     def get_data(self, xp):
         """creates inputs"""
         # an L
-        data1 = xp.asarray([[1, 3], [1, 2], [1, 1], [2, 1]])
+        data1 = xp.asarray([[1, 3], [1, 2], [1, 1], [2, 1]], dtype=xp.float64)
 
         # a larger, shifted, mirrored L
-        data2 = xp.asarray([[4, -2], [4, -4], [4, -6], [2, -6]])
+        data2 = xp.asarray([[4, -2], [4, -4], [4, -6], [2, -6]], dtype=xp.float64)
 
         # an L shifted up 1, right 1, and with point 4 shifted an extra .5
         # to the right
         # pointwise distance disparity with data1: 3*(2) + (1 + 1.5^2)
-        data3 = xp.asarray([[2, 4], [2, 3], [2, 2], [3, 2.5]])
+        data3 = xp.asarray([[2, 4], [2, 3], [2, 2], [3, 2.5]], dtype=xp.float64)
 
         # data4, data5 are standardized (trace(A*A') = 1).
         # procrustes should return an identical copy if they are used
         # as the first matrix argument.
-        shiftangle = xp.asarray(xp.pi / 8)
-        data4 = xp.asarray([[1., 0], [0, 1], [-1, 0], [0, -1]]) / math.sqrt(4)
+        data4 = xp.asarray([[1., 0], [0, 1], [-1, 0], [0, -1]],
+                           dtype=xp.float64) / math.sqrt(4)
+        shiftangle = xp.asarray(xp.pi / 8, dtype=xp.float64)
         data5 = xp.asarray([[xp.cos(shiftangle), xp.sin(shiftangle)],
                             [xp.cos(xp.pi / 2 - shiftangle),
                              xp.sin(xp.pi / 2 - shiftangle)],
@@ -45,7 +46,7 @@ class TestProcrustes:
         data1, data2, data3, data4, data5 = self.get_data(xp)
         a, b, disparity = procrustes(data1, data2)
         xp_assert_close(b, a)
-        xp_assert_close(disparity, 0., atol=1e-15)
+        xp_assert_close(disparity, xp.asarray(0., dtype=xp.float64), atol=1e-15)
 
         # if first mtx is standardized, leaves first mtx unchanged?
         m4, m5, disp45 = procrustes(data4, data5)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
A pretty simple array api conversion.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai