### PR TITLE
BUG: sparse.linalg: fix LinearOperator pickle to preserve __slots__ attributes

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -247,13 +247,30 @@ class LinearOperator:
         self._xp = xp
 
     def __getstate__(self):
-        state = self.__dict__.copy()
-        state["_xp"] = state["_xp"].empty(0)
+        # Start with __dict__ (present unless a subclass suppresses it).
+        state = getattr(self, '__dict__', {}).copy()
+        # Also collect __slots__ attributes from every class in the MRO so
+        # that subclasses that store their state in __slots__ are pickled
+        # correctly.  Skip the standard bookkeeping slots and _xp, which is
+        # handled separately below.
+        _skip = {'__dict__', '__weakref__', '_xp'}
+        for cls in type(self).__mro__:
+            for slot in getattr(cls, '__slots__', ()):
+                if slot not in _skip and slot not in state:
+                    try:
+                        state[slot] = getattr(self, slot)
+                    except AttributeError:
+                        pass  # slot declared but not yet assigned
+        state["_xp"] = self._xp.empty(0)
         return state
 
     def __setstate__(self, state):
         self._xp = array_namespace(state.pop("_xp"))
-        self.__dict__.update(state)
+        # Restore all attributes: use setattr so that __slots__ on subclasses
+        # are populated correctly (self.__dict__.update would silently drop
+        # slot attributes).
+        for key, value in state.items():
+            setattr(self, key, value)
 
     def _init_dtype(self):
         """Determine the dtype by executing `matvec` on an `int8` test vector.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -952,6 +952,34 @@ def test_pickle(xp):
         for k in A.__dict__:
             assert getattr(A, k) == getattr(B, k)
 
+
+def test_pickle_subclass_with_slots():
+    # GH-25871: __getstate__/__setstate__ must preserve __slots__ attributes
+    # from subclasses, not only __dict__ attributes.
+    import pickle
+
+    class DiagonalOperator(interface.LinearOperator):
+        __slots__ = ['_diagonal']
+
+        def __init__(self, diagonal):
+            diagonal = np.asarray(diagonal, dtype=np.float64)
+            self._diagonal = diagonal
+            super().__init__(dtype=diagonal.dtype, shape=(len(diagonal),) * 2)
+
+        def _matvec(self, x):
+            return self._diagonal * x
+
+    op = DiagonalOperator([1.0, 2.0, 3.0])
+    assert hasattr(op, '_diagonal')
+
+    op2 = pickle.loads(pickle.dumps(op))
+    assert hasattr(op2, '_diagonal'), (
+        "__slots__ attribute lost after pickle round-trip"
+    )
+    np.testing.assert_array_equal(op._diagonal, op2._diagonal)
+    np.testing.assert_array_equal(op2.matvec(np.ones(3)), [1.0, 2.0, 3.0])
+
+
 @pytest.mark.xfail_xp_backends('dask.array', reason=(
     "dask does not support broadcast_shapes(). "
     "See: https://github.com/data-apis/array-api-compat/issues/439"


### PR DESCRIPTION
## Summary

Fixes #25871.

`LinearOperator.__getstate__` (added in 1.18.0 for pickling the Array API namespace `_xp`) serializes only `self.__dict__`. This omits any `__slots__` attributes declared by subclasses, causing silent data loss: the subclass appears to unpickle without error, but every slot attribute is silently absent, so the first access to such an attribute raises `AttributeError`.

This is a **regression from < 1.18.0**, where `LinearOperator` defined no `__getstate__` and pickling fell back to Python's default slot-aware mechanism.

### Root cause

```python
# before (broken in 1.18.0):
def __getstate__(self):
    state = self.__dict__.copy()      # slots from subclasses: missing
    state["_xp"] = state["_xp"].empty(0)
    return state

def __setstate__(self, state):
    self._xp = array_namespace(state.pop("_xp"))
    self.__dict__.update(state)       # slot attributes: not restored
```

### Fix

`__getstate__` now walks the full MRO to collect `__slots__` attributes in addition to `__dict__`. `__setstate__` uses `setattr` so that slot attributes are correctly restored.

```python
def __getstate__(self):
    state = getattr(self, '__dict__', {}).copy()
    _skip = {'__dict__', '__weakref__', '_xp'}
    for cls in type(self).__mro__:
        for slot in getattr(cls, '__slots__', ()):
            if slot not in _skip and slot not in state:
                try:
                    state[slot] = getattr(self, slot)
                except AttributeError:
                    pass  # slot declared but not yet assigned
    state["_xp"] = self._xp.empty(0)
    return state

def __setstate__(self, state):
    self._xp = array_namespace(state.pop("_xp"))
    for key, value in state.items():
        setattr(self, key, value)
```

### Testing

Added `test_pickle_subclass_with_slots` which:
- Defines a `DiagonalOperator(LinearOperator)` with `__slots__ = ['_diagonal']`
- Confirms the slot attribute is present before pickling
- Confirms it is present after `pickle.loads(pickle.dumps(op))`
- Confirms `matvec` still works correctly after unpickling

The bug was verified on scipy 1.18.0 before the fix and confirmed absent after the fix.

---
*[This is Claude Code on behalf of Venkateswarlu Nagineni]*
