### PR TITLE
BUG: special: fix chdtr/chdtrc edge cases on alternative backends

### DIFF
--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -287,8 +287,12 @@ def _chdtr(xp, spsx):
         # The rest can be removed when google/jax#20507 is resolved
         mask = (v == 0) & (x > 0)  # JAX returns NaN
         res = xp.where(mask, 1., res)
-        mask = xp.isinf(v) & xp.isinf(x)  # JAX returns 1.0
-        return xp.where(mask, xp.nan, res)
+        # NaN elsewhere; see gh-24683. `x < 0` is a domain error, and NaN
+        # arguments must propagate (PyTorch's `gammainc` returns a number for
+        # `gammainc(inf, nan)`, `gammainc(nan, 0)`, and `gammainc(nan, inf)`).
+        i_nan = ((xp.isinf(v) & xp.isinf(x))  # JAX returns 1.0
+                 | (x < 0) | xp.isnan(v) | xp.isnan(x))
+        return xp.where(i_nan, xp.nan, res)
     return __chdtr
 
 
@@ -302,8 +306,17 @@ def _chdtrc(xp, spsx):
         return None
 
     def __chdtrc(v, x):
-        res = xp.where(x >= 0, gammaincc(v/2, x/2), 1)
-        i_nan = ((x == 0) & (v == 0)) | xp.isnan(x) | xp.isnan(v) | (v < 0)
+        res = gammaincc(v / 2, x / 2)
+        # Can be removed when google/jax#20507 is resolved
+        mask = (v == 0) & (x > 0)  # JAX returns NaN
+        res = xp.where(mask, 0., res)
+        # `x < 0` is a domain error (it used to produce 1.0 here, but the
+        # reference `chdtrc` returns NaN since gh-22441); NaN arguments must
+        # propagate (PyTorch's `gammaincc` returns a number for
+        # `gammaincc(inf, nan)`, `gammaincc(nan, 0)`, `gammaincc(nan, inf)`).
+        # See gh-24683.
+        i_nan = ((x == 0) & (v == 0)) | (xp.isinf(v) & xp.isinf(x)) | (v < 0)
+        i_nan = i_nan | (x < 0) | xp.isnan(x) | xp.isnan(v)
         res = xp.where(i_nan, xp.nan, res)
         return res
     return __chdtrc

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -385,15 +385,15 @@ def test_ufunc_kwargs(func, n_args, int_only, is_ufunc):
 
 
 @pytest.mark.xfail_xp_backends("dask.array", reason="scipy/scipy#25343")
-@make_xp_test_case(special.chdtr)
-def test_chdtr_gh21311(xp):
-    # the edge case behavior of generic chdtr was not right; see gh-21311
-    # be sure to test at least these cases
-    # should add `np.nan` into the mix when gh-21317 is resolved
-    x = np.asarray([-np.inf, -1., 0., 1., np.inf])
+@pytest.mark.parametrize('func', [special.chdtr, special.chdtrc])
+@make_xp_test_case(special.chdtr, special.chdtrc)
+def test_chdtr_gh21311(func, xp):
+    # the edge case behavior of generic chdtr/chdtrc was not right;
+    # see gh-21311 and gh-24683
+    x = np.asarray([-np.inf, -1., 0., 1., np.inf, np.nan])
     v = x.reshape(-1, 1)
-    ref = special.chdtr(v, x)
-    res = special.chdtr(xp.asarray(v), xp.asarray(x))
+    ref = func(v, x)
+    res = func(xp.asarray(v), xp.asarray(x))
     xp_assert_close(res, xp.asarray(ref))
 
 


### PR DESCRIPTION
#### Reference issue

Closes gh-24683.

#### What does this implement/fix?

`chdtr` and `chdtrc` disagreed with the compiled reference on two edge cases in
the alternative-backend path:

- negative `x` is a domain error and must be NaN. `chdtrc` returned 1.0. The
  reference has returned NaN since gh-22441.
- NaN arguments must propagate. PyTorch's `gammainc`/`gammaincc` return a number
  for `gammainc(inf, nan)`, `gammainc(nan, 0)` and `gammaincc(nan, inf)`.

The issue's reproducer gives 3/36 mismatches for `chdtr` on torch before, 0/36
after. For `chdtrc`, only a 2.9e-15 relative difference remains, which
`xp_assert_close` accepts.

Rewrote `test_chdtr_gh21311` to add `np.nan` to the grid, which its own TODO
asked for once gh-21317 was resolved (gh-22441 did that), and parametrized it
over `chdtrc` as well.

#### Additional information

I could not build SciPy from source on this machine, so the suite was not run
locally. I validated the patched Python against released 1.18.0's compiled
kernels after checking the installed `_chdtr`/`_chdtrc` source is identical to
main's.

#### AI Generation Disclosure

An AI assistant helped investigate this and draft the change and test. I
reproduced the mismatches and verified the result myself.
