### PR TITLE
BUG: handle empty input in fftpack convolve_z

### DIFF
--- a/scipy/fftpack/convolve.pyx
+++ b/scipy/fftpack/convolve.pyx
@@ -108,6 +108,9 @@ def convolve_z(inout, omega_real, omega_imag, overwrite_x=False):
         raise ValueError(
             "inout and omega must be 1-dimensional arrays of the same length")
 
+    if n == 0:
+        return X_arr
+
     r2r_fftpack(X_arr, None, True, True, out=X_arr)
 
     X[0] *= wr[0] + wi[0]

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -1,5 +1,8 @@
 # Created by Pearu Peterson, September 2002
 
+import subprocess
+import sys
+
 from numpy.testing import (assert_, assert_equal, assert_array_almost_equal,
                            assert_array_almost_equal_nulp, assert_array_less)
 import pytest
@@ -144,6 +147,23 @@ class _TestFFTBase:
     def test_invalid_sizes(self):
         assert_raises(ValueError, fft, [])
         assert_raises(ValueError, fft, [[1,1],[2,2]], -5)
+
+
+def test_convolve_z_empty_input_does_not_crash():
+    code = """
+import numpy as np
+from scipy.fftpack import convolve
+
+result = convolve.convolve_z(np.zeros(0), np.zeros(0), np.zeros(0))
+assert result.shape == (0,)
+assert result.dtype == np.float64
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 class TestDoubleFFT(_TestFFTBase):


### PR DESCRIPTION
Fixes #25849

## Summary

`fftpack.convolve_z` accessed the first element of an empty input before the FFTPACK path could return, causing a segmentation fault. This change returns an empty `float64` result after shape validation and before that access.

The regression test runs the empty-input case in a subprocess so the pre-fix crash is isolated from the test process.

## Validation

- `python3 -m pytest -q scipy/fftpack/tests/` — 554 passed, 1 expected failure
- Ruff check passed
- `git diff --check` passed