### PR TITLE
DOC: signal.buttap: add Examples to docstring

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4730,6 +4730,28 @@ def buttap(N, *, xp=None, device=None):
     --------
     butter : Filter design function using this prototype
 
+    Examples
+    --------
+    Design a 3rd-order analog lowpass Butterworth filter prototype:
+
+    >>> from scipy import signal
+    >>> z, p, k = signal.buttap(3)
+
+    Butterworth prototypes have no zeros, so `z` is empty:
+
+    >>> z
+    array([], dtype=float64)
+
+    The poles lie on the unit circle in the left-half of the complex plane:
+
+    >>> p
+    array([-0.5+0.8660254j, -1.0+0.j        , -0.5-0.8660254j])
+
+    The system gain is normalized to 1:
+
+    >>> k
+    1.0
+
     """
     if xp is None:
         xp = np_compat


### PR DESCRIPTION
#### Reference issue
Closes gh-7168 (partially)

#### What does this implement/fix?
Adds an Examples section to the `scipy.signal.buttap` docstring.

[docs only]