### PR TITLE
DOC: sparse.linalg.LinearOperator: clarify powers

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -172,8 +172,8 @@ class LinearOperator:
 
     `LinearOperator` instances can also be multiplied and added with each
     other. Square instances can be raised to non-negative integer powers with
-    ``A ** p``, representing ``p`` repeated applications of ``A`` rather than
-    a matrix exponential. All of these operations are lazy: the result is a
+    ``A ** p``, representing ``p`` repeated applications of ``A`` (rather than
+    a matrix exponential). All of these operations are lazy: the result is a
     new, composite `LinearOperator` that defers operations to the original
     operators and combines the results.
 
@@ -195,7 +195,7 @@ class LinearOperator:
     array([ 2.,  3.])
     >>> A @ np.ones(2)
     array([ 2.,  3.])
-    >>> A ** 2 @ np.ones(2)
+    >>> A**2 @ np.ones(2)
     array([ 4.,  9.])
 
     """  # numpydoc ignore=PR01,PR02

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -151,6 +151,7 @@ class LinearOperator:
     __call__
     __add__
     __truediv__
+    __pow__
     __rmul__
     __rmatmul__
 
@@ -169,11 +170,12 @@ class LinearOperator:
     It is assumed that `matmat`, `rmatvec`, and `rmatmat` would result in
     the same dtype of the output given an ``int8`` input as `matvec`.
 
-    `LinearOperator` instances can also be multiplied, added with each
-    other, and raised to integral powers, all lazily: the result of these
-    operations
-    is always a new, composite `LinearOperator`, that defers linear
-    operations to the original operators and combines the results.
+    `LinearOperator` instances can also be multiplied and added with each
+    other. Square instances can be raised to non-negative integer powers with
+    ``A ** p``, representing ``p`` repeated applications of ``A`` rather than
+    a matrix exponential. All of these operations are lazy: the result is a
+    new, composite `LinearOperator` that defers operations to the original
+    operators and combines the results.
 
     More details regarding how to subclass a `LinearOperator` and several
     examples of concrete `LinearOperator` instances can be found in the
@@ -193,6 +195,8 @@ class LinearOperator:
     array([ 2.,  3.])
     >>> A @ np.ones(2)
     array([ 2.,  3.])
+    >>> A ** 2 @ np.ones(2)
+    array([ 4.,  9.])
 
     """  # numpydoc ignore=PR01,PR02
 

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -768,6 +768,11 @@ class LinearOperator:
                 return mT(self.T.matmat(mT(x)))
 
     def __pow__(self, p):
+        """Raise this linear operator to a non-negative integer power.
+
+        The operator must be square. The returned `LinearOperator` lazily
+        represents ``p`` repeated applications of this operator.
+        """
         self._check_matching_namespace(p)
         if xp_isscalar(p):
             return _PowerLinearOperator(self, p, xp=self._xp)


### PR DESCRIPTION
#### Reference issue

Closes gh-22318.

#### What does this implement/fix?

Clarifies that powers of square `LinearOperator` instances represent repeated
operator application, not a matrix exponential. It also documents the
non-negative integer restriction, lists `__pow__` among the available methods,
and adds a small executable example.

#### Additional information

Local validation:

- `spin lint --diff-against upstream/main`
- `spin test -t scipy.sparse.linalg.tests.test_interface` (236 passed, 36 skipped)
- `spin test scipy/sparse/linalg/_interface.py -- --doctest-modules` (3 passed)
- `spin refguide-check --no-build -s sparse.linalg`

#### AI Generation Disclosure

OpenAI Codex was used to inspect the issue and implementation, help draft the
documentation wording and example, and run local validation. I reviewed the
final one-file change against the implementation and verified all reported test
results.
