### PR TITLE
DOC: stats: clarify moments section for alpha distribution

### DIFF
--- a/doc/source/tutorial/stats/continuous_alpha.rst
+++ b/doc/source/tutorial/stats/continuous_alpha.rst
@@ -16,7 +16,7 @@ is a scale-parameter). The support for the standard form is :math:`x>0`.
 
      M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx
 
-No moments?
+The raw moment :math:`E[X^r]` exists if and only if :math:`r < 1`.
 
 .. math::
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Clarify moments section for alpha distribution.

As $x \to \infty$, the density is proportional to $x^{-2}$ so that $x^{r} f(x)$ behaves like $x^{r-2}$. The corresponding integral converges for $r<1$.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Asked Gemini pro to check and I did some quick numerical checks with Mathematica.