### PR TITLE
DOC: add example to eval_chebyt docstring

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -1007,6 +1007,37 @@ add_newdoc("eval_chebyt",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E11_2
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.special as sc
+
+    Basic checks — T_n(x) = cos(n * arccos(x)) for x in [-1, 1]:
+
+    >>> sc.eval_chebyt(0, 0.5)
+    1.0
+    >>> sc.eval_chebyt(1, 0.5)
+    0.5
+    >>> sc.eval_chebyt(2, 0.5)
+    -0.5
+    >>> sc.eval_chebyt(3, 0.5)
+    -1.0
+
+    Array of degrees works too:
+
+    >>> sc.eval_chebyt(np.arange(5), 0.5)
+    array([ 1. ,  0.5, -0.5, -1. , -0.5])
+
+    Trig identity check — T_4(cos(π/4)) should equal cos(π):
+
+    >>> sc.eval_chebyt(4, np.cos(np.pi / 4))
+    -1.0
+
+    Non-integer n falls back to the hypergeometric definition:
+
+    >>> sc.eval_chebyt(1.5, 0.5)
+    0.0
+
     """)
 
 add_newdoc("eval_chebyu",


### PR DESCRIPTION
#### Reference issue
Addresses gh-7168.

#### What does this implement/fix?
Adds an `Examples` section to the docstring of `scipy.special.eval_chebyt`,
which was previously missing one.

The example demonstrates:
- basic evaluations of the polynomial for small integer degrees
- passing an array of degrees to evaluate at the same point
- the trigonometric identity `T_n(x) = cos(n * arccos(x))` for integer `n`
  and `x` in `[-1, 1]`
- behavior for non-integer `n`, which falls back to the Gauss
  hypergeometric function

All output values shown were run and verified against a local scipy
installation before submitting.

#### Additional information
This is a first-time contribution, picked from the "good first issue"
list of functions missing examples in gh-7168.

#### AI Generation Disclosure
An AI coding assistant was used during preparation of this PR for the
following supporting tasks: locating the relevant source file
(`scipy/special/_add_newdocs.py`) among scipy's compiled Cython/C special
functions, explaining the mathematical background of Chebyshev
polynomials, and pointing me to existing similar docstring examples
(`eval_chebys`, `eval_chebyc`) as formatting references.

The content of the Examples section itself — the specific values chosen,
the explanatory text, and verification that the printed outputs are
correct — was written and independently verified by me. At one point
during this process an AI-generated draft of the Examples section was
produced; I discarded that draft and wrote the final version myself, as
required by this issue's stated policy against AI-generated examples.