### PR TITLE
BUG: isotonic_regression: handle empty input

### DIFF
--- a/scipy/optimize/_isotonic.py
+++ b/scipy/optimize/_isotonic.py
@@ -138,6 +138,9 @@ def isotonic_regression(
         wx = np.array(warr[order], order="C", dtype=np.float64, copy=True)
     n = x.shape[0]
     r = np.full(shape=n + 1, fill_value=-1, dtype=np.intp)
+    if n == 0:
+        r[0] = 0
+        return OptimizeResult(x=x, weights=wx, blocks=r)
     x, wx, r, b = pava(x, wx, r)
     # Now that we know the number of blocks b, we only keep the relevant part
     # of r and wx.

--- a/scipy/optimize/tests/test_isotonic_regression.py
+++ b/scipy/optimize/tests/test_isotonic_regression.py
@@ -41,6 +41,15 @@ class TestIsotonicRegression:
         # Only first 3 elements of r are changed.
         assert_allclose(r, [0, 6, 7, -1, -1, -1, -1, -1])
 
+    # related to gh-25886
+    @pytest.mark.parametrize("weights", [None, []])
+    @pytest.mark.parametrize("increasing", [True, False])
+    def test_empty_input(self, weights, increasing):
+        res = isotonic_regression([], weights=weights, increasing=increasing)
+        assert_equal(res.x, np.empty(0))
+        assert_equal(res.weights, np.empty(0))
+        assert_equal(res.blocks, [0])
+
     @pytest.mark.parametrize("y_dtype", [np.float64, np.float32, np.int64, np.int32])
     @pytest.mark.parametrize("w_dtype", [np.float64, np.float32, np.int64, np.int32])
     @pytest.mark.parametrize("w", [None, "ones"])


### PR DESCRIPTION
#### Reference issue

Closes scipy/scipy#25886.

This replaces #25917, which GitHub auto-closed after its branch history was repaired while addressing review feedback. The repaired branch has one commit and the same intended two-file change; the synthetic `monkeypatch` from the earlier test has been removed as requested.

#### What does this implement/fix?

Return a valid empty `OptimizeResult` before calling the PAVA kernel when `isotonic_regression` receives empty input. This avoids the out-of-bounds write that could segfault on Windows.

The regression test covers omitted and explicit empty weights in both increasing and decreasing modes.

#### Additional information

Validation:
- Current repaired source: all four empty-input combinations pass against the local `_isotonic.py` implementation.
- `ruff check` with SciPy's lint configuration passes for both changed files.
- `compileall` passes for both changed files.
- Before the review-only test adjustment, the full focused module passed with 49 tests.

#### AI Generation Disclosure

OpenAI Codex was used to prepare the implementation, regression test, and review follow-up. The resulting changes were reviewed and validated with the focused checks listed above.
