### PR TITLE
MAINT: ndimage.vectorized_filter: restore CuPy support

### DIFF
--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -100,7 +100,8 @@ capabilities_dict = {
         cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "vectorized_filter": xp_capabilities(
-        cpu_only=True, allow_dask_compute=True, jax_jit=False
+        cpu_only=True, allow_dask_compute=True, jax_jit=False,
+        exceptions=["cupy"]
     ),
     "generate_binary_structure": xp_capabilities(out_of_scope=True),
     "map_coordinates": xp_capabilities(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I noticed that #23415 accidentally forgot to transfer the `exceptions=["cupy"]` across.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai