### PR TITLE
DEP: io: deprecation warnings for kwarg value `spmatrix=True`

### DIFF
--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -317,6 +317,10 @@ def mmread(source, *, spmatrix=_NoValue):
             on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
+        .. deprecated:: 2.0.0
+            The value `True` for `spmatrix` will no longer be supported in v2.2.
+            The spmatrix classes are deprecated and will be removed then.
+
     Returns
     -------
     a : ndarray or coo_array
@@ -390,6 +394,16 @@ def mmread(source, *, spmatrix=_NoValue):
             prefixes = (os.path.dirname(__file__),)
             warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             spmatrix = True
+        elif spmatrix is True:
+            msg = """The value `spmatrix=True` will no longer be supported in v2.2.
+             The spmatrix classes are deprecated and will be removed then.
+             The return value will always be a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
+             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
 
         if spmatrix:
             return coo_matrix(triplet, shape=shape)

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -481,6 +481,10 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
             on 2D shapes from e.g. ``A.sum(axis=0)``, it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
+        .. deprecated:: 2.0.0
+            The value `True` for `spmatrix` will no longer be supported in v2.2.
+            The spmatrix classes are deprecated and will be removed then.
+
     Returns
     -------
     data : csc_array or csc_matrix
@@ -532,6 +536,16 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
         prefixes = (os.path.dirname(__file__),)
         warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
         spmatrix = True
+    elif spmatrix is True:
+        msg = """The value `spmatrix=True` will no longer be supported in v2.2.
+         The spmatrix classes are deprecated and will be removed then.
+         The return value will always be a sparse array.
+         Unless you use * instead of @, ** for matrix power, or you depend
+         on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
+         See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+         """
+        prefixes = (os.path.dirname(__file__),)
+        warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
 
     if spmatrix:
         return csc_matrix(data)

--- a/scipy/io/_harwell_boeing/tests/test_hb.py
+++ b/scipy/io/_harwell_boeing/tests/test_hb.py
@@ -50,10 +50,11 @@ class TestHBReader:
         m = hb_read(StringIO(SIMPLE), spmatrix=False)
         assert_csc_almost_equal(m, SIMPLE_MATRIX)
         assert isinstance(m, sparray)
-        m = hb_read(StringIO(SIMPLE), spmatrix=True)
-        assert issparse(m) and not isinstance(m, sparray)
         with pytest.deprecated_call(match="The default value for `spmatrix"):
             m = hb_read(StringIO(SIMPLE))  # default
+            assert issparse(m) and not isinstance(m, sparray)
+        with pytest.deprecated_call(match="The value `spmatrix=True"):
+            m = hb_read(StringIO(SIMPLE), spmatrix=True)
             assert issparse(m) and not isinstance(m, sparray)
 
 

--- a/scipy/io/_harwell_boeing/tests/test_hb.py
+++ b/scipy/io/_harwell_boeing/tests/test_hb.py
@@ -50,11 +50,11 @@ class TestHBReader:
         m = hb_read(StringIO(SIMPLE), spmatrix=False)
         assert_csc_almost_equal(m, SIMPLE_MATRIX)
         assert isinstance(m, sparray)
-        with pytest.deprecated_call(match="The default value for `spmatrix"):
-            m = hb_read(StringIO(SIMPLE))  # default
-            assert issparse(m) and not isinstance(m, sparray)
         with pytest.deprecated_call(match="The value `spmatrix=True"):
             m = hb_read(StringIO(SIMPLE), spmatrix=True)
+            assert issparse(m) and not isinstance(m, sparray)
+        with pytest.deprecated_call(match="The default value for `spmatrix"):
+            m = hb_read(StringIO(SIMPLE))  # default
             assert issparse(m) and not isinstance(m, sparray)
 
 

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -102,6 +102,10 @@ def mmread(source, *, spmatrix=_NoValue):
             on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
+        .. deprecated:: 2.0.0
+            The value `True` for `spmatrix` will no longer be supported in v2.2.
+            The spmatrix classes are deprecated and will be removed then.
+
     Returns
     -------
     a : ndarray or coo_array or coo_matrix
@@ -585,6 +589,10 @@ class MMFile:
                 on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
                 See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
+        .. deprecated:: 2.0.0
+            The value `True` for `spmatrix` will no longer be supported in v2.2.
+            The spmatrix classes are deprecated and will be removed then.
+
         Returns
         -------
         a : ndarray or coo_array or coo_matrix
@@ -612,6 +620,16 @@ class MMFile:
             prefixes = (os.path.dirname(__file__),)
             warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             spmatrix = True
+        elif spmatrix is True:
+            msg = """The value `spmatrix=True` will no longer be supported in v2.2.
+             The spmatrix classes are deprecated and will be removed then.
+             The return value will always be a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
+             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
 
         if spmatrix and isinstance(data, coo_array):
             data = coo_matrix(data)

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -105,6 +105,10 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
             on 2D shapes from e.g. ``A.sum(axis=0)``, it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
+        .. deprecated:: 2.0.0
+            The value `True` for `spmatrix` will no longer be supported in v2.2.
+            The spmatrix classes are deprecated and will be removed then.
+
     **kwargs
         The following additional keyword arguments can be passed:
 
@@ -263,6 +267,17 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
                 prefixes = (os.path.dirname(__file__),)
                 warnings.warn(warn_msg, DeprecationWarning, skip_file_prefixes=prefixes)
                 spmatrix = True
+            elif spmatrix is True:
+                msg = """The value `spmatrix=True` will no longer be supported in v2.2.
+                 The spmatrix classes are deprecated and will be removed then.
+                 The return value will always be a sparse array.
+                 Unless you use * instead of @, ** for matrix power, or you depend
+                 on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
+                 See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+                 """
+                prefixes = (os.path.dirname(__file__),)
+                warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+
             if spmatrix:
                 fmt_matrix = coo_matrix if var.format == "coo" else csc_matrix
             else:

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1186,8 +1186,9 @@ def test_empty_sparse():
 
     res = loadmat(sio, spmatrix=False)
     assert isinstance(res['x'], sparray)
-    res = loadmat(sio, spmatrix=True)
-    assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
+    with pytest.deprecated_call(match="The value `spmatrix=True"):
+        res = loadmat(sio, spmatrix=True)
+        assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
     with pytest.deprecated_call(match="The default value for `spmatrix"):
         res = loadmat(sio)  # chk default
         assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -287,9 +287,10 @@ class TestMMIOSparseCSR(TestMMIOArray):
         assert_array_almost_equal(p, b.toarray())
         assert isinstance(b, scipy.sparse.sparray)
 
-        b = mmread(self.fn, spmatrix=True)
-        assert_array_almost_equal(p, b.toarray())
-        assert isinstance(b, scipy.sparse.spmatrix)
+        with pytest.deprecated_call(match="The value `spmatrix=True"):
+            b = mmread(self.fn, spmatrix=True)
+            assert_array_almost_equal(p, b.toarray())
+            assert isinstance(b, scipy.sparse.spmatrix)
 
         with pytest.deprecated_call(match="The default value"):
             b = mmread(self.fn)  # chk default


### PR DESCRIPTION
Because spmatrix is raising deprecation warnings now and will be removed in ~2 releases, we need to deprecate the `spmatrix=True` keyword values in the `scip.io` read functions. This also adds tests that the deprecation warnings show.

This is part of the deprecation process for spmatrix as laid out in #24802.