### PR TITLE
DEP: spatial: kdtree deprecation warnings for output_type values 

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -6,10 +6,13 @@
 
 # cython: cpow=True
 
+import warnings
 
 import numpy as np
 import scipy.sparse
 from scipy._lib._util import copy_if_needed
+
+from scipy._lib.deprecation import _NoValue
 
 cimport numpy as np
 
@@ -1495,7 +1498,7 @@ cdef class cKDTree:
     def sparse_distance_matrix(cKDTree self, cKDTree other,
                                np.float64_t max_distance,
                                np.float64_t p=2.0,
-                               output_type='dok_matrix'):
+                               output_type=_NoValue):
         """
         sparse_distance_matrix(other, max_distance, p=2.0, output_type='dok_matrix')
 
@@ -1527,7 +1530,7 @@ cdef class cKDTree:
                `output_type` will be deprecated at v2.0 and switch from
                'dok_matrix' to 'dok_array' in v2.2.
                The values 'dok_matrix' and 'coo_matrix' continue
-               to work, but will go away eventually.
+               to work now, but will go away too.
 
         Returns
         -------
@@ -1581,18 +1584,47 @@ cdef class cKDTree:
             sparse_distance_matrix(
                 self.cself, other.cself, p, max_distance, res.buf)
 
+        if output_type == _NoValue:
+            msg = """The default value for `output_type` will become `dok_array` in v2.2.
+             That means the default return type will become a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set `output_type="dok_array"`.
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            output_type = 'dok_matrix'
+
         if output_type == 'dict':
             return res.dict()
         elif output_type == 'ndarray':
             return res.ndarray()
-        elif output_type == 'dok_matrix':
-            return res.dok_matrix(self.n, other.n)
         elif output_type == 'dok_array':
             return res.dok_array(self.n, other.n)
-        elif output_type == 'coo_matrix':
-            return res.coo_matrix(self.n, other.n)
         elif output_type == 'coo_array':
             return res.coo_array(self.n, other.n)
+        elif output_type == 'dok_matrix':
+            msg = f"""The keyword output_type="dok_matrix" will not be supported in v2.2
+             Use output_type="dok_array".
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set to "dok_array" and wrap the return in dok_matrix().
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            return res.dok_matrix(self.n, other.n)
+        elif output_type == 'coo_matrix':
+            msg = f"""The keyword output_type="coo_matrix" will not be supported in v2.2
+             Use output_type="coo_array".
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set to "coo_array" and wrap the return in coo_matrix().
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            return res.coo_matrix(self.n, other.n)
         else:
             raise ValueError('Invalid output type')
 

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -239,7 +239,7 @@ cdef class coo_entries:
                                        shape=(m, n))
 
     def dok_matrix(coo_entries self, m, n):
-        return self.coo_matrix(m,n).todok()
+        return scipy.sparse.dok_matrix(self.coo_array(m,n).todok())
 
 
 # ordered_pair wrapper
@@ -1595,7 +1595,7 @@ cdef class cKDTree:
              """
             prefixes = (os.path.dirname(__file__),)
             warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
-            output_type = 'dok_matrix'
+            return res.dok_matrix(self.n, other.n)
 
         if output_type == 'dict':
             return res.dict()

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1584,8 +1584,9 @@ cdef class cKDTree:
             sparse_distance_matrix(
                 self.cself, other.cself, p, max_distance, res.buf)
 
+        # handle default and already warned from KDTree (workaround stacklevel issues)
         if output_type == _NoValue:
-            msg = """The default value for `output_type` will become `dok_array` in v2.2.
+            msg = """The default value for `output_type` will become `dok_array` in v2.2
              That means the default return type will become a sparse array.
              Unless you use * instead of @, ** for matrix power, or you depend
              on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -1593,9 +1594,25 @@ cdef class cKDTree:
              https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
              To silence this message, set `output_type="dok_array"`.
              """
-            prefixes = (os.path.dirname(__file__),)
-            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+            msg = f"""The keyword output_type="dok_matrix" will not be supported in v2.2
+             The intended replacement is output_type="dok_array".
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set to "dok_array" and, if needed, wrap the
+             return in dok_matrix().
+             """
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+            warnings.filterwarnings("ignore", "dok_matrix is being repl")
             return res.dok_matrix(self.n, other.n)
+        elif output_type == 'caught_dok_matrix':
+            warnings.filterwarnings("ignore", "dok_matrix is being repl")
+            return res.dok_matrix(self.n, other.n)
+        elif output_type == 'caught_coo_matrix':
+            warnings.filterwarnings("ignore", "coo_matrix is being repl")
+            return res.coo_matrix(self.n, other.n)
 
         if output_type == 'dict':
             return res.dict()
@@ -1607,23 +1624,29 @@ cdef class cKDTree:
             return res.coo_array(self.n, other.n)
         elif output_type == 'dok_matrix':
             msg = f"""The keyword output_type="dok_matrix" will not be supported in v2.2
-             Use output_type="dok_array".
+             The intended replacement is output_type="dok_array".
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
              See the spmatrix to sparray migration guide for details.
              https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-             To silence this message, set to "dok_array" and wrap the return in dok_matrix().
+             To silence this message, set to "dok_array" and, if needed, wrap the
+             return in dok_matrix().
              """
-            prefixes = (os.path.dirname(__file__),)
-            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+            warnings.filterwarnings("ignore", "dok_matrix is being repl")
             return res.dok_matrix(self.n, other.n)
         elif output_type == 'coo_matrix':
             msg = f"""The keyword output_type="coo_matrix" will not be supported in v2.2
-             Use output_type="coo_array".
+             The intended replacement is output_type="coo_array".
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
              See the spmatrix to sparray migration guide for details.
              https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-             To silence this message, set to "coo_array" and wrap the return in coo_matrix().
+             To silence this message, set to "coo_array" and, if needed, wrap the
+             return in coo_matrix().
              """
-            prefixes = (os.path.dirname(__file__),)
-            warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+            warnings.filterwarnings("ignore", "coo_matrix is being repl")
             return res.coo_matrix(self.n, other.n)
         else:
             raise ValueError('Invalid output type')

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -8,6 +8,8 @@ from ._ckdtree import cKDTree, cKDTreeNode
 from .distance import minkowski
 from scipy._lib._array_api import xp_capabilities
 
+from scipy._lib.deprecation import _NoValue
+
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
            'distance_matrix',
            'Rectangle', 'KDTree']
@@ -884,7 +886,7 @@ class KDTree(cKDTree):
         return super().count_neighbors(other, r, p, weights, cumulative)
 
     def sparse_distance_matrix(
-            self, other, max_distance, p=2.0, output_type='dok_matrix'):
+            self, other, max_distance, p=2.0, output_type=_NoValue):
         """Compute a sparse distance matrix.
 
         Computes a distance matrix between two KDTrees, leaving as zero
@@ -913,7 +915,7 @@ class KDTree(cKDTree):
                `output_type` will be deprecated at v2.0 and switch from
                'dok_matrix' to 'dok_array' in v2.2.
                The values 'dok_matrix' and 'coo_matrix' continue
-               to work, but will go away eventually.
+               to work now, but will go away too.
 
             .. versionadded:: 1.6.0
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -957,6 +957,43 @@ class KDTree(cKDTree):
            [0.24617575, 0.29571802, 0.26836782, 0.57714465, 0.6473269 ]])
 
         """
+        def_msg = """The default value for `output_type` will become `dok_array` in v2.2.
+             That means the default return type will become a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set `output_type="dok_array"`.
+             """
+        dok_msg = f"""The keyword output_type="dok_matrix" will not be supported in v2.2
+             The intended replacement is output_type="dok_array".
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set to "dok_array" and, if needed, wrap the
+             return in dok_matrix().
+             """
+        coo_msg = f"""The keyword output_type="coo_matrix" will not be supported in v2.2
+             The intended replacement is output_type="coo_array".
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             To silence this message, set to "coo_array" and, if needed, wrap the
+             return in coo_matrix().
+             """
+        prefixes = (os.path.dirname(__file__),)
+        if output_type == _NoValue:
+            warnings.warn(def_msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            warnings.warn(dok_msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            output_type = "caught_dok_matrix"
+        elif output_type == "dok_matrix":
+            warnings.warn(dok_msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            output_type = "caught_dok_matrix"
+        elif output_type == "coo_matrix":
+            warnings.warn(coo_msg, DeprecationWarning, skip_file_prefixes=prefixes)
+            output_type = "caught_coo_matrix"
         return super().sparse_distance_matrix(other, max_distance, p, output_type)
 
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -957,7 +957,7 @@ class KDTree(cKDTree):
            [0.24617575, 0.29571802, 0.26836782, 0.57714465, 0.6473269 ]])
 
         """
-        def_msg = """The default value for `output_type` will become `dok_array` in v2.2.
+        def_msg = """The default value for `output_type` will become `dok_array` in v2.2
              That means the default return type will become a sparse array.
              Unless you use * instead of @, ** for matrix power, or you depend
              on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -965,7 +965,7 @@ class KDTree(cKDTree):
              https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
              To silence this message, set `output_type="dok_array"`.
              """
-        dok_msg = f"""The keyword output_type="dok_matrix" will not be supported in v2.2
+        dok_msg = """The keyword output_type="dok_matrix" will not be supported in v2.2
              The intended replacement is output_type="dok_array".
              Unless you use * instead of @, ** for matrix power, or you depend
              on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -974,7 +974,7 @@ class KDTree(cKDTree):
              To silence this message, set to "dok_array" and, if needed, wrap the
              return in dok_matrix().
              """
-        coo_msg = f"""The keyword output_type="coo_matrix" will not be supported in v2.2
+        coo_msg = """The keyword output_type="coo_matrix" will not be supported in v2.2
              The intended replacement is output_type="coo_array".
              Unless you use * instead of @, ** for matrix power, or you depend
              on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -721,23 +721,27 @@ class sparse_distance_matrix_consistency:
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
         assert isinstance(r, dok_array)
         # test return type 'dok_matrix'
-        r = self.T1.sparse_distance_matrix(self.T2, self.r,
-            output_type='dok_matrix')
-        assert_array_almost_equal(ref, r.toarray(), decimal=14)
-        assert isinstance(r, dok_matrix)
+        with pytest.deprecated_call(match="The keyword output_type="):
+            r = self.T1.sparse_distance_matrix(self.T2, self.r,
+                output_type='dok_matrix')
+            assert_array_almost_equal(ref, r.toarray(), decimal=14)
+            assert isinstance(r, dok_matrix)
         # test return type 'coo_array'
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='coo_array')
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
         assert isinstance(r, coo_array)
         # test return type 'coo_matrix'
-        r = self.T1.sparse_distance_matrix(self.T2, self.r,
-            output_type='coo_matrix')
-        assert_array_almost_equal(ref, r.toarray(), decimal=14)
-        assert isinstance(r, coo_matrix)
+        with pytest.deprecated_call(match="The keyword output_type="):
+            r = self.T1.sparse_distance_matrix(self.T2, self.r,
+                output_type='coo_matrix')
+            assert_array_almost_equal(ref, r.toarray(), decimal=14)
+            assert isinstance(r, coo_matrix)
         # test default return type 'dok_matrix'
-        r = self.T1.sparse_distance_matrix(self.T2, self.r)
-        assert isinstance(r, dok_matrix)
+        with pytest.deprecated_call(match="The keyword output_type="):
+            with pytest.deprecated_call(match="The default value for `output_type"):
+                r = self.T1.sparse_distance_matrix(self.T2, self.r)
+                assert isinstance(r, dok_matrix)
 
 
 @KDTreeTest

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -689,6 +689,20 @@ class sparse_distance_matrix_consistency:
         d = tree.sparse_distance_matrix(tree, 3, output_type='dok_array').toarray()
         assert_array_almost_equal(d, d.T, decimal=14)
 
+    def test_ckdtree_warnings(self):
+        tree = self.kdtree_type(np.array([[0.0, 0.0], [1.0, 1.0]]))
+        tree.sparse_distance_matrix(tree, 3, output_type="coo_array")
+        tree.sparse_distance_matrix(tree, 3, output_type="dok_array")
+        with pytest.deprecated_call(match='The keyword output_type="dok'):
+            with pytest.deprecated_call(match="dok_matrix is being repl"):
+                tree.sparse_distance_matrix(tree, 3, output_type="dok_matrix")
+        with pytest.deprecated_call(match='The keyword output_type="coo'):
+            with pytest.deprecated_call(match="coo_matrix is being repl"):
+                tree.sparse_distance_matrix(tree, 3, output_type="coo_matrix")
+        with pytest.deprecated_call(match="The default value for `out"):
+            with pytest.deprecated_call(match="dok_matrix is being repl"):
+                tree.sparse_distance_matrix(tree, 3)
+
     @pytest.mark.filterwarnings("ignore:.*_matrix is being repl:DeprecationWarning")
     def test_ckdtree_return_types(self):
         # brute-force reference
@@ -738,10 +752,9 @@ class sparse_distance_matrix_consistency:
             assert_array_almost_equal(ref, r.toarray(), decimal=14)
             assert isinstance(r, coo_matrix)
         # test default return type 'dok_matrix'
-        with pytest.deprecated_call(match="The keyword output_type="):
-            with pytest.deprecated_call(match="The default value for `output_type"):
-                r = self.T1.sparse_distance_matrix(self.T2, self.r)
-                assert isinstance(r, dok_matrix)
+        with pytest.deprecated_call(match="The default value for `out"):
+            r = self.T1.sparse_distance_matrix(self.T2, self.r)
+            assert isinstance(r, dok_matrix)
 
 
 @KDTreeTest

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -694,13 +694,11 @@ class sparse_distance_matrix_consistency:
         tree.sparse_distance_matrix(tree, 3, output_type="coo_array")
         tree.sparse_distance_matrix(tree, 3, output_type="dok_array")
         with pytest.deprecated_call(match='The keyword output_type="dok'):
-            with pytest.deprecated_call(match="dok_matrix is being repl"):
-                tree.sparse_distance_matrix(tree, 3, output_type="dok_matrix")
+            tree.sparse_distance_matrix(tree, 3, output_type="dok_matrix")
         with pytest.deprecated_call(match='The keyword output_type="coo'):
-            with pytest.deprecated_call(match="coo_matrix is being repl"):
-                tree.sparse_distance_matrix(tree, 3, output_type="coo_matrix")
-        with pytest.deprecated_call(match="The default value for `out"):
-            with pytest.deprecated_call(match="dok_matrix is being repl"):
+            tree.sparse_distance_matrix(tree, 3, output_type="coo_matrix")
+        with pytest.deprecated_call(match='The keyword output_type="dok'):
+            with pytest.deprecated_call(match="The default value for `out"):
                 tree.sparse_distance_matrix(tree, 3)
 
     @pytest.mark.filterwarnings("ignore:.*_matrix is being repl:DeprecationWarning")
@@ -735,7 +733,7 @@ class sparse_distance_matrix_consistency:
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
         assert isinstance(r, dok_array)
         # test return type 'dok_matrix'
-        with pytest.deprecated_call(match="The keyword output_type="):
+        with pytest.deprecated_call(match='The keyword output_type="dok'):
             r = self.T1.sparse_distance_matrix(self.T2, self.r,
                 output_type='dok_matrix')
             assert_array_almost_equal(ref, r.toarray(), decimal=14)
@@ -746,15 +744,16 @@ class sparse_distance_matrix_consistency:
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
         assert isinstance(r, coo_array)
         # test return type 'coo_matrix'
-        with pytest.deprecated_call(match="The keyword output_type="):
+        with pytest.deprecated_call(match='The keyword output_type="coo'):
             r = self.T1.sparse_distance_matrix(self.T2, self.r,
                 output_type='coo_matrix')
             assert_array_almost_equal(ref, r.toarray(), decimal=14)
             assert isinstance(r, coo_matrix)
         # test default return type 'dok_matrix'
         with pytest.deprecated_call(match="The default value for `out"):
-            r = self.T1.sparse_distance_matrix(self.T2, self.r)
-            assert isinstance(r, dok_matrix)
+            with pytest.deprecated_call(match='The keyword output_type="dok'):
+                r = self.T1.sparse_distance_matrix(self.T2, self.r)
+                assert isinstance(r, dok_matrix)
 
 
 @KDTreeTest


### PR DESCRIPTION
This PR adds deprecation warnings for both the default value and for the spmatrix values of the keyword `output_type` in the function sparse_distance_matrix.  The default value is changing from `dok_matrix` to `dok_array`. And the values `dok_matrix` and `coo_matrix` will not be supported when those classes are removed in ~2 releases.

This PR also adds tests of the deprecation warnings.

This is part of the deprecation process for spmatrix as laid out in #24802.