### PR TITLE
DOC: spatial.transform.Rotation/RigidTransform: fix some doc rendering issues

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1744,12 +1744,12 @@ class RigidTransform:
         If the original frame transforms to the final frame by this transform,
         then its application to a vector can be seen in two ways:
 
-            - As a projection of vector components expressed in the final frame
-              to the original frame.
-            - As the physical transformation of a vector being glued to the
-              original frame as it transforms. In this case the vector
-              components are expressed in the original frame before and after
-              the transformation.
+        - As a projection of vector components expressed in the final frame
+          to the original frame.
+        - As the physical transformation of a vector being glued to the
+          original frame as it transforms. In this case the vector
+          components are expressed in the original frame before and after
+          the transformation.
 
         In terms of the rotation matrix and translation,
         this application is the same as

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -834,8 +834,8 @@ class Rotation:
         ``axis3``). For Euler angles, there is an additional relationship
         between ``axis1`` or ``axis3``, with two possibilities:
 
-            - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
-            - ``axis1 == axis3`` (symmetric sequence)
+        - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
+        - ``axis1 == axis3`` (symmetric sequence)
 
         For Davenport angles, this last relationship is relaxed [2]_, and only
         the consecutive orthogonal axes requirement is maintained.
@@ -1265,9 +1265,8 @@ class Rotation:
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to:
 
-                - [-90, 90] degrees if all axes are different (like xyz)
-                - [0, 180] degrees if first and third axes are the same
-                  (like zxz)
+              - [-90, 90] degrees if all axes are different (like xyz)
+              - [0, 180] degrees if first and third axes are the same (like zxz)
 
         References
         ----------
@@ -1338,8 +1337,8 @@ class Rotation:
         ``axis3``). For Euler angles, there is an additional relationship
         between ``axis1`` or ``axis3``, with two possibilities:
 
-            - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
-            - ``axis1 == axis3`` (symmetric sequence)
+        - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
+        - ``axis1 == axis3`` (symmetric sequence)
 
         For Davenport angles, this last relationship is relaxed [1]_, and only
         the consecutive orthogonal axes requirement is maintained.
@@ -1577,11 +1576,11 @@ class Rotation:
         If the original frame rotates to the final frame by this rotation, then
         its application to a vector can be seen in two ways:
 
-            - As a projection of vector components expressed in the final frame
-              to the original frame.
-            - As the physical rotation of a vector being glued to the original
-              frame as it rotates. In this case the vector components are
-              expressed in the original frame before and after the rotation.
+        - As a projection of vector components expressed in the final frame
+          to the original frame.
+        - As the physical rotation of a vector being glued to the original
+          frame as it rotates. In this case the vector components are
+          expressed in the original frame before and after the rotation.
 
         In terms of rotation matrices, this application is the same as
         ``(self.as_matrix() @ vectors[..., np.newaxis])[..., 0]``.
@@ -1776,6 +1775,7 @@ class Rotation:
                [ 0.33721128, -0.26362477,  0.26362477,  0.86446082]])
 
         Broadcasting rules apply:
+
         >>> p = R.from_quat(np.tile(np.array([0, 0, 1, 1]), (5, 1, 1)))
         >>> q = R.from_quat(np.tile(np.array([1, 0, 0, 1]), (1, 6, 1)))
         >>> p.shape, q.shape
@@ -2116,11 +2116,11 @@ class Rotation:
             The name of the group. Must be one of 'I', 'O', 'T', 'Dn', 'Cn',
             where `n` is a positive integer. The groups are:
 
-                * I: Icosahedral group
-                * O: Octahedral group
-                * T: Tetrahedral group
-                * D: Dicyclic group
-                * C: Cyclic group
+            * I: Icosahedral group
+            * O: Octahedral group
+            * T: Tetrahedral group
+            * D: Dicyclic group
+            * C: Cyclic group
 
         axis : int
             The cyclic rotation axis. Must be one of ['X', 'Y', 'Z'] (or


### PR DESCRIPTION
[docs only]

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Mostly accidental block quotes and missing white space in an example
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai