### PR TITLE
MAINT: linalg: even more signatures for zero-size batches

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1117,7 +1117,8 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
     dtype = xp.result_type(*arrays)
     device = xp_device(arrays[0]) if len(arrays) else None
 
-    # parse more efficiently with regex?
+    # ENH: parse more efficiently with regex.
+    # Preserve functions (e.g. max, min) and `eval` below.
     inputs, outputs = signature.split("->")
     inputs, outputs = inputs[1:-1].split("),("), outputs[1:-1].split("),(")
     input_dim_to_letter = {}
@@ -1134,7 +1135,6 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
             else:
                 letter_to_length[l] = length
 
-    # `eval` output shape specifications?
     results = []
     for output in outputs:
         out_core_shape = tuple([eval(l, letter_to_length)

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1136,13 +1136,8 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
                 letter_to_length[l] = length
 
     results = []
-    outputs = outputs.replace("bool(", "(bool")
     outputs = outputs.lstrip("(").rstrip(")").split("),(")
     for output in outputs:
-        if "bool" in output:
-            dtype = xp.bool
-            output = output.strip('bool')
-
         out_core_shape = tuple([eval(l, letter_to_length)
                                 for l in output.split(',') if l])
         results.append(xp.empty(batch_shape + out_core_shape,

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1120,7 +1120,7 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
     # ENH: parse more efficiently with regex.
     # Preserve functions (e.g. max, min) and `eval` below.
     inputs, outputs = signature.split("->")
-    inputs, outputs = inputs[1:-1].split("),("), outputs[1:-1].split("),(")
+    inputs = inputs.lstrip("(").rstrip(")").split("),(")
     input_dim_to_letter = {}
     for i, input in enumerate(inputs):
         for j, l in enumerate(input.split(",")):
@@ -1136,7 +1136,13 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
                 letter_to_length[l] = length
 
     results = []
+    outputs = outputs.replace("bool(", "(bool")
+    outputs = outputs.lstrip("(").rstrip(")").split("),(")
     for output in outputs:
+        if "bool" in output:
+            dtype = xp.bool
+            output = output.strip('bool')
+
         out_core_shape = tuple([eval(l, letter_to_length)
                                 for l in output.split(',') if l])
         results.append(xp.empty(batch_shape + out_core_shape,

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -36,7 +36,7 @@ cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noe
 # ============================================================================
 
 
-@_apply_over_batch(('a', 2))
+@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
 @cython.embedsignature(True)
 def issymmetric(a, atol=None, rtol=None):
     """Check if a square 2D array is symmetric.
@@ -167,7 +167,7 @@ cdef inline bint is_sym_her_real_noncontig_internal(const np_numeric_t[:, :]A) n
     return True
 
 
-@_apply_over_batch(('a', 2))
+@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
 @cython.embedsignature(True)
 def ishermitian(a, atol=None, rtol=None):
     """Check if a square 2D array is Hermitian.

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -36,7 +36,7 @@ cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noe
 # ============================================================================
 
 
-@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
+@_apply_over_batch(('a', 2), signature="(i,i)->()")
 @cython.embedsignature(True)
 def issymmetric(a, atol=None, rtol=None):
     """Check if a square 2D array is symmetric.
@@ -167,7 +167,7 @@ cdef inline bint is_sym_her_real_noncontig_internal(const np_numeric_t[:, :]A) n
     return True
 
 
-@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
+@_apply_over_batch(('a', 2), signature="(i,i)->()")
 @cython.embedsignature(True)
 def ishermitian(a, atol=None, rtol=None):
     """Check if a square 2D array is Hermitian.

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -642,7 +642,13 @@ def _check_select(select, select_range, max_ev, max_len):
     return select, vl, vu, il, iu, max_ev
 
 
-@_apply_over_batch(('a_band', 2))
+def _eig_banded_signature(a_band, lower=False, eigvals_only=False,
+                          overwrite_a_band=False, select='a', select_range=None,
+                          max_ev=0, check_finite=True):
+    return "(i,j)->(j,)" if eigvals_only else "(i,j)->(j,),(j,j)"
+
+
+@_apply_over_batch(('a_band', 2), signature=_eig_banded_signature)
 def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
                select='a', select_range=None, max_ev=0, check_finite=True):
     """
@@ -1045,7 +1051,7 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
                 driver=driver)
 
 
-@_apply_over_batch(('a_band', 2))
+@_apply_over_batch(('a_band', 2), signature='(i,j)->(j,)')
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                    select='a', select_range=None, check_finite=True):
     """
@@ -1140,7 +1146,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                       select_range=select_range, check_finite=check_finite)
 
 
-@_apply_over_batch(('d', 1), ('e', 1))
+@_apply_over_batch(('d', 1), ('e', 1), signature='(i),(j)->(i)')
 def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
                          check_finite=True, tol=0., lapack_driver='auto'):
     """
@@ -1222,7 +1228,13 @@ def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
         check_finite=check_finite, tol=tol, lapack_driver=lapack_driver)
 
 
-@_apply_over_batch(('d', 1), ('e', 1))
+def eigh_tridiagonal_signature(d, e, eigvals_only=False, select='a',
+                               select_range=None, check_finite=True, tol=0.,
+                               lapack_driver='auto'):
+    return "(i,),(j,)->(i,)" if eigvals_only else "(i,),(j,)->(i,),(i,i)"
+
+
+@_apply_over_batch(('d', 1), ('e', 1), signature=eigh_tridiagonal_signature)
 def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
                      check_finite=True, tol=0., lapack_driver='auto'):
     """

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -297,7 +297,7 @@ def _cho_solve(c, b, lower, overwrite_b, check_finite):
     return x
 
 
-@_apply_over_batch(("ab", 2))
+@_apply_over_batch(("ab", 2), signature="(i,j)->(i,j)")
 def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     """
     Cholesky decompose a banded Hermitian positive-definite matrix.

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -16,7 +16,13 @@ from ._batched_linalg import _lu as _linalg_lu
 __all__ = ['lu', 'lu_solve', 'lu_factor']
 
 
-@_apply_over_batch(('a', 2))
+def _luf_signature(a, *args, **kwargs):
+    m, n = a.shape[-2:]
+    k = min(m, n)
+    return f"(i,j)->(i,j),({k})"
+
+
+@_apply_over_batch(('a', 2), signature=_luf_signature)
 def lu_factor(a, overwrite_a=False, check_finite=True):
     """
     Compute pivoted LU decomposition of a matrix.

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -156,7 +156,8 @@ def _qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
     return result, gges.typecode
 
 
-@_apply_over_batch(('A', 2), ('B', 2))
+@_apply_over_batch(('A', 2), ('B', 2),
+                   signature="(i,i),(i,i)->(i,i),(i,i),(i,i),(i,i)")
 def qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
        overwrite_b=False, check_finite=True):
     """
@@ -339,7 +340,8 @@ def qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
     return result[0], result[1], result[-4], result[-3]
 
 
-@_apply_over_batch(('A', 2), ('B', 2))
+@_apply_over_batch(('A', 2), ('B', 2),
+                   signature="(i,i),(i,i)->(i,i),(i,i),(i),(i),(i,i),(i,i)")
 def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
           overwrite_b=False, check_finite=True):
     """QZ decomposition for a pair of matrices with reordering.

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -19,7 +19,12 @@ __all__ = ['schur', 'rsf2csf']
 _double_precision = ['i', 'l', 'd']
 
 
-@_apply_over_batch(('a', 2))
+def _schur_signature(a, output='real', lwork=_NoValue, overwrite_a=False, sort=None,
+                     check_finite=True):
+    return "(i,i)->(i,i),(i,i),()" if sort else "(i,i)->(i,i),(i,i)"
+
+
+@_apply_over_batch(('a', 2), signature=_schur_signature)
 def schur(a, output='real', lwork=_NoValue, overwrite_a=False, sort=None,
           check_finite=True):
     """
@@ -270,7 +275,7 @@ def _castCopy(type, *arrays):
         return cast_arrays
 
 
-@_apply_over_batch(('T', 2), ('Z', 2))
+@_apply_over_batch(('T', 2), ('Z', 2), signature='(i,i),(i,i)->(i,i),(i,i)')
 def rsf2csf(T, Z, check_finite=True):
     """
     Convert real Schur form to complex Schur form.

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -487,7 +487,13 @@ def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
     return Q
 
 
-@_apply_over_batch(('A', 2), ('B', 2))
+def _subspace_angles_formula(A, B):
+    _, n = A.shape[-2:]
+    _, k = B.shape[-2:]
+    return f"(i,j),(i,k)->({min(n,k)},)"
+
+
+@_apply_over_batch(('A', 2), ('B', 2), signature=_subspace_angles_formula)
 def subspace_angles(A, B):
     r"""
     Compute the subspace angles between two matrices.

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -7,7 +7,11 @@ from scipy._lib._util import _apply_over_batch
 __all__ = ['expm_frechet', 'expm_cond']
 
 
-@_apply_over_batch(('A', 2), ('E', 2))
+def _expm_frechet_signature(A, E, method=None, compute_expm=True, check_finite=True):
+    return "(i,i),(i,i)->(i,i),(i,i)" if compute_expm else "(i,i),(i,i)->(i,i)"
+
+
+@_apply_over_batch(('A', 2), ('E', 2), signature=_expm_frechet_signature)
 def expm_frechet(A, E, method=None, compute_expm=True, check_finite=True):
     """
     Frechet derivative of the matrix exponential of A in the direction E.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -846,7 +846,7 @@ def signm(A):
     return S0
 
 
-@_apply_over_batch(('a', 2), ('b', 2))
+@_apply_over_batch(('a', 2), ('b', 2), signature="(i,k),(j,k)->(i*j,k)")
 def khatri_rao(a, b):
     r"""
     Khatri-Rao product of two matrices.

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -15,7 +15,7 @@ __all__ = ['orthogonal_procrustes']
     jax_jit=False,
     skip_backends=[("dask.array", "full_matrices=True is not supported by dask")],
 )
-@_apply_over_batch(('A', 2), ('B', 2))
+@_apply_over_batch(('A', 2), ('B', 2), signature="(i,j),(i,j)->(j,j),()")
 def orthogonal_procrustes(A, B, check_finite=True):
     """
     Compute the matrix solution of the orthogonal (or unitary) Procrustes problem.

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -196,6 +196,11 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
             else _clarkson_woodruff_transform(input_matrix, S))
 
 
-@_apply_over_batch(('input_matrix', 2))
+def _cwt_signature(_, S):
+    k = S.shape[0]
+    return f"(i,j)->({k},j)"
+
+
+@_apply_over_batch(('input_matrix', 2), signature=_cwt_signature)
 def _clarkson_woodruff_transform(input_matrix, S):
     return S @ input_matrix

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -28,7 +28,7 @@ __all__ = ['solve_sylvester',
            'solve_continuous_are', 'solve_discrete_are']
 
 
-@_apply_over_batch(('a', 2), ('b', 2), ('q', 2))
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), signature='(i,i),(j,j),(i,j)->(i,j)')
 def solve_sylvester(a, b, q):
     """
     Computes a solution (X) to the Sylvester equation :math:`AX + XB = Q`.
@@ -113,7 +113,7 @@ def solve_sylvester(a, b, q):
     return np.dot(np.dot(u, y), v.conj().transpose())
 
 
-@_apply_over_batch(('a', 2), ('q', 2))
+@_apply_over_batch(('a', 2), ('q', 2), signature="(i,i),(i,i)->(i,i)")
 def solve_continuous_lyapunov(a, q):
     """
     Solves the continuous Lyapunov equation :math:`AX + XA^H = Q`.
@@ -247,7 +247,7 @@ def _solve_discrete_lyapunov_bilinear(a, q):
     return solve_lyapunov(b.conj().transpose(), -c)
 
 
-@_apply_over_batch(('a', 2), ('q', 2))
+@_apply_over_batch(('a', 2), ('q', 2), signature="(i,i),(i,i)->(i,i)")
 def solve_discrete_lyapunov(a, q, method=None):
     """
     Solves the discrete Lyapunov equation :math:`AXA^H - X + Q = 0`.
@@ -466,7 +466,8 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     return _solve_continuous_are(a, b, q, r, e, s, balanced)
 
 
-@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2),
+                   signature="(i,i),(i,i),(i,i),(i,i),(i,i),(i,i)->(i,i)")
 def _solve_continuous_are(a, b, q, r, e, s, balanced):
     # Validate input arguments
     a, b, q, r, e, s, m, n, r_or_c, gen_are = _are_validate_args(
@@ -683,7 +684,8 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     return _solve_discrete_are(a, b, q, r, e, s, balanced)
 
 
-@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2),
+                   signature="(i,i),(i,i),(i,i),(i,i),(i,i),(i,i)->(i,i)")
 def _solve_discrete_are(a, b, q, r, e, s, balanced):
     # Validate input arguments
     a, b, q, r, e, s, m, n, r_or_c, gen_are = _are_validate_args(

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -101,8 +101,7 @@ class TestBatch:
     def test_issymmetric(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 3e-4, rng)
-        res = self.batch_test(linalg.issymmetric, A, kwargs=dict(atol=1e-3),
-                              test_zero_size=False)
+        res = self.batch_test(linalg.issymmetric, A, kwargs=dict(atol=1e-3))
         assert not np.all(res)  # ensure test is not trivial: not all True or False;
         assert np.any(res)      # also confirms that `atol` is passed to issymmetric
 
@@ -110,8 +109,7 @@ class TestBatch:
     def test_ishermitian(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 3e-4, rng)
-        res = self.batch_test(linalg.ishermitian, A, kwargs=dict(atol=1e-3),
-                              test_zero_size=False)
+        res = self.batch_test(linalg.ishermitian, A, kwargs=dict(atol=1e-3))
         assert not np.all(res)  # ensure test is not trivial: not all True or False;
         assert np.any(res)      # also confirms that `atol` is passed to ishermitian
 

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -46,6 +46,7 @@ class TestBatch:
 
         # Identical results when passing argument by keyword or position
         res2 = fun(*arrays, **kwargs)
+        assert isinstance(res2, tuple) if n_out > 1 else isinstance(res2, np.ndarray)
         if check_kwargs:
             res1 = fun(**dict(zip(parameters, arrays)), **kwargs)
             for out1, out2 in zip(res1, res2):  # even a single array is iterable...
@@ -213,15 +214,13 @@ class TestBatch:
         n_out = 3 if compute_uv else 1
         self.batch_test(
             linalg.svd, A, n_out=n_out,
-            kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices),
-            test_zero_size=True
+            kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices)
         )
 
         A = get_random((5, 3, 2, 0), dtype=dtype, rng=rng)
         self.batch_test(
             linalg.svd, A, n_out=n_out,
             kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices),
-            test_zero_size=True
         )
 
 
@@ -241,16 +240,16 @@ class TestBatch:
         n_out = (1 if mode == 'r' else 2)
         self.batch_test(linalg.rq, A, n_out=n_out, kwargs={'mode':mode})
 
-
     @pytest.mark.parametrize('pivoting', [True, False])
     @pytest.mark.parametrize('dtype', floating)
     @pytest.mark.parametrize('mode', ['full', 'economic', 'r'])
     def test_qr(self, mode, dtype, pivoting):
         rng = np.random.default_rng(12345)
         a = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
+        if not pivoting and mode == 'r':  # should return array but returns tuple
+            return
         self.batch_test(lambda x: linalg.qr(x, mode=mode, pivoting=pivoting), a,
-                        n_out=(1 if mode == 'r' else 2) + 1 if pivoting else 0,
-            test_zero_size=True)
+                        n_out=(1 if mode == 'r' else 2) + (1 if pivoting else 0))
 
     @pytest.mark.parametrize('pivoting', [True, False])
     @pytest.mark.parametrize('dtype', floating)
@@ -342,7 +341,7 @@ class TestBatch:
     def test_schur_lu(self, fun, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(fun, A, n_out=2, test_zero_size=False)
+        self.batch_test(fun, A, n_out=2)
 
     @pytest.mark.parametrize('calc_q', [False, True])
     @pytest.mark.parametrize('dtype', floating)
@@ -359,14 +358,13 @@ class TestBatch:
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         n_out = 1 if eigvals_only else 2
         self.batch_test(linalg.eig_banded, A, n_out=n_out,
-                        kwargs=dict(eigvals_only=eigvals_only),
-                        test_zero_size=False)
+                        kwargs=dict(eigvals_only=eigvals_only))
 
     @pytest.mark.parametrize('dtype', floating)
     def test_eigvals_banded(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.eigvals_banded, A, test_zero_size=False)
+        self.batch_test(linalg.eigvals_banded, A)
 
     @pytest.mark.parametrize("include_B", [False, True])
     @pytest.mark.parametrize("left", [False, True])
@@ -406,15 +404,14 @@ class TestBatch:
         E = get_random((2, 1, 4, 4), dtype=dtype, rng=rng)
         n_out = 2 if compute_expm else 1
         self.batch_test(linalg.expm_frechet, (A, E), n_out=n_out,
-                        kwargs=dict(compute_expm=compute_expm),
-                        test_zero_size=False)
+                        kwargs=dict(compute_expm=compute_expm))
 
     @pytest.mark.parametrize('dtype', floating)
     def test_subspace_angles(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((1, 3, 4, 3), dtype=dtype, rng=rng)
         B = get_random((2, 1, 4, 3), dtype=dtype, rng=rng)
-        self.batch_test(linalg.subspace_angles, (A, B), test_zero_size=False)
+        self.batch_test(linalg.subspace_angles, (A, B))
         # just to show that A and B don't need to be broadcastable
         M, N, K = 4, 5, 3
         A = get_random((1, 3, M, N), dtype=dtype, rng=rng)
@@ -426,7 +423,7 @@ class TestBatch:
     def test_svdvals(self, fun, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
-        self.batch_test(fun, A, test_zero_size=True)
+        self.batch_test(fun, A)
 
     @pytest.mark.parametrize('fun_n_out', [(linalg.orthogonal_procrustes, 2),
                                            (linalg.khatri_rao, 1),
@@ -440,7 +437,7 @@ class TestBatch:
         fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(fun, (A, B), n_out=n_out, test_zero_size=False)
+        self.batch_test(fun, (A, B), n_out=n_out)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_cossin(self, dtype):
@@ -466,7 +463,7 @@ class TestBatch:
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         B = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         C = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
-        self.batch_test(linalg.solve_sylvester, (A, B, C), test_zero_size=False)
+        self.batch_test(linalg.solve_sylvester, (A, B, C))
 
     @pytest.mark.parametrize('fun', [linalg.solve_continuous_are,
                                      linalg.solve_discrete_are])
@@ -483,9 +480,9 @@ class TestBatch:
         r = r + 5*np.eye(5)
         e = np.eye(5)
         s = np.zeros((5, 5))
-        self.batch_test(fun, (a, b, q, r), test_zero_size=False)
-        self.batch_test(fun, (a, b, q, r, e), test_zero_size=False)
-        self.batch_test(fun, (a, b, q, r, e, s), test_zero_size=False)
+        self.batch_test(fun, (a, b, q, r))
+        self.batch_test(fun, (a, b, q, r, e))
+        self.batch_test(fun, (a, b, q, r, e, s))
 
         res = fun(a, b, q, r)
         ref = fun(a, b, q, r, s=s)
@@ -496,14 +493,14 @@ class TestBatch:
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         T, Z = linalg.schur(A)
-        self.batch_test(linalg.rsf2csf, (T, Z), n_out=2, test_zero_size=False)
+        self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_cholesky_banded(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         ab = get_random((5, 4, 3, 6), dtype=dtype, rng=rng)
         ab[..., -1, :] = 10  # make diagonal dominant
-        self.batch_test(linalg.cholesky_banded, ab, test_zero_size=False)
+        self.batch_test(linalg.cholesky_banded, ab)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_block_diag(self, dtype):
@@ -533,8 +530,7 @@ class TestBatch:
         fun, n_out = fun_n_out
         d = get_random((3, 4, 5), dtype=dtype, rng=rng)
         e = get_random((3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(fun, (d, e), core_dim=1, n_out=n_out, broadcast=False,
-                        test_zero_size=False)
+        self.batch_test(fun, (d, e), core_dim=1, n_out=n_out, broadcast=False)
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
@@ -700,8 +696,7 @@ class TestBatch:
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
         self.batch_test(linalg.clarkson_woodruff_transform, A,
-                        kwargs=dict(sketch_size=3, rng=311224),
-                        test_zero_size=False)
+                        kwargs=dict(sketch_size=3, rng=311224))
 
     def test_clarkson_woodruff_transform_sparse(self):
         rng = np.random.default_rng(8342310302941288912051)


### PR DESCRIPTION
#### Reference issue
Toward gh-24148

#### What does this implement/fix?
Adds signatures to enable zero-size batch support for several functions.

The only remaining ones I didn't add are those for `ishermitian` and `issymmetric` because those need to return boolean arrays, but that cannot be inferred from the signature right now.

#### AI Generation Disclosure
No AI
