### PR TITLE
MAINT: ndimage: more fixes and tests for resolving writeback on output arrays

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -2010,10 +2010,13 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         # if algorithmic fixes are found.
         lim2 = input.size - ((footprint.size - 1) // 2 - origin)
         if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
-            if input.dtype in (np.int64, np.float64, np.float32):
+            # Dispatch on `dtype.type` so that non-native byte order takes the
+            # same route as native; the C code converts to native order.
+            input_type = input.dtype.type
+            if input_type in (np.int64, np.float64, np.float32):
                 x = input
                 x_out = output
-            elif input.dtype == np.float16:
+            elif input_type == np.float16:
                 x = input.astype('float32')
                 x_out = np.empty(x.shape, dtype='float32')
             elif np.result_type(input, np.int64) == np.int64:
@@ -2028,7 +2031,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
             cval = x.dtype.type(cval)
             _rank_filter_1d.rank_filter(x, rank, footprint.size, x_out, mode, cval,
                                         origin)
-            if input.dtype not in (np.int64, np.float64, np.float32):
+            if input_type not in (np.int64, np.float64, np.float32):
                 np.copyto(output, x_out, casting='unsafe')
         else:
             _nd_image.rank_filter(input, rank, footprint, output, mode, cval, origins)

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -289,8 +289,10 @@ static PyObject *rank_filter(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  PyArrayObject *in_arr = (PyArrayObject *)PyArray_FROM_OTF(
-      in_arr_obj, NPY_NOTYPE, NPY_ARRAY_IN_ARRAY);
+  // The filter dereferences the buffers directly, so the input must be in
+  // native byte order.
+  PyArrayObject *in_arr = (PyArrayObject *)PyArray_FROM_OF(
+      in_arr_obj, NPY_ARRAY_IN_ARRAY | NPY_ARRAY_NOTSWAPPED);
   if (in_arr == NULL) {
     return NULL;
   }

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -294,8 +294,13 @@ static PyObject *rank_filter(PyObject *self, PyObject *args) {
   if (in_arr == NULL) {
     return NULL;
   }
+  // Both buffers are reinterpreted as PyArray_TYPE(in_arr) below, so the output
+  // must have that dtype too; otherwise we would write doubles into, say, a
+  // float32 buffer and run off the end of it. NumPy supplies a correctly typed
+  // temporary and casts the results back on writeback.
   PyArrayObject *out_arr = (PyArrayObject *)PyArray_FROM_OTF(
-      out_arr_obj, NPY_NOTYPE, NPY_ARRAY_INOUT_ARRAY2);
+      out_arr_obj, PyArray_TYPE(in_arr),
+      NPY_ARRAY_INOUT_ARRAY2 | NPY_ARRAY_FORCECAST);
   if (out_arr == NULL) {
     Py_DECREF(in_arr);
     return NULL;

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -336,6 +336,14 @@ static PyObject *rank_filter(PyObject *self, PyObject *args) {
   if (rank_filter_status == -1) {
     PyErr_SetString(PyExc_MemoryError, "failed to allocate memory for rank filter");
   }
+  // NPY_ARRAY_INOUT_ARRAY2 implies NPY_ARRAY_WRITEBACKIFCOPY, so any temporary
+  // copy has to be flushed back explicitly. No-ops if no copy was made.
+  if (PyErr_Occurred()) {
+    PyArray_DiscardWritebackIfCopy(out_arr);
+  }
+  else {
+    PyArray_ResolveWritebackIfCopy(out_arr);
+  }
   Py_DECREF(in_arr);
   Py_DECREF(out_arr);
   if (PyErr_Occurred()) {

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -120,9 +120,12 @@ NI_ObjectToOutputArray(PyObject *object, PyArrayObject **array)
      * If the input array is not aligned or is byteswapped, this call
      * will create a new aligned, native byte order array, and copy the
      * contents of object into it. For an output array, the copy is
-     * unnecessary, so this could be optimized. It is very easy to not
-     * do NPY_ARRAY_UPDATEIFCOPY right, so we let NumPy do it for us
-     * and pay the performance price.
+     * unnecessary, so this could be optimized.
+     *
+     * Callers must then call PyArray_ResolveWritebackIfCopy() on the result
+     * (or PyArray_DiscardWritebackIfCopy() on error) before dropping their
+     * reference; see gh-25641. Both accept NULL and are no-ops if no copy
+     * was made.
      */
     *array = (PyArrayObject *)PyArray_CheckFromAny(object, NULL, 0, 0, flags,
                                                    NULL);
@@ -1181,6 +1184,7 @@ static PyObject *Py_DistanceTransformBruteForce(PyObject *obj,
 
     NI_DistanceTransformBruteForce(input, metric, sampling, output, features);
     PyArray_ResolveWritebackIfCopy(output);
+    PyArray_ResolveWritebackIfCopy(features);
 
 exit:
     Py_XDECREF(input);
@@ -1316,9 +1320,13 @@ static PyObject *Py_BinaryErosion2(PyObject *obj, PyObject *args)
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "cannot convert CObject");
+        goto exit;
     }
     PyArray_ResolveWritebackIfCopy(array);
 exit:
+    if (PyErr_Occurred()) {
+        PyArray_DiscardWritebackIfCopy(array);
+    }
     Py_XDECREF(array);
     Py_XDECREF(strct);
     Py_XDECREF(mask);

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3384,3 +3384,44 @@ def test_median_filter_lim2():
     expected = np.ones(8)
     filtered_samples = ndimage.median_filter(sample_array, size=19, mode="reflect")
     xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
+
+
+# The rank filter tests below are NumPy only: contiguity, alignment, byte order
+# and NPY_ARRAY_WRITEBACKIFCOPY have no equivalent in the array API standard.
+def _noncontiguous_output(size, dtype):
+    """Output array that is not C contiguous, so NumPy has to copy it."""
+    out = np.zeros(2 * size, dtype=dtype)[::2]
+    assert not out.flags.c_contiguous
+    return out
+
+
+def _misaligned_output(size, dtype):
+    """Output array that is not aligned, so NumPy has to copy it."""
+    dtype = np.dtype(dtype)
+    buf = np.zeros(size * dtype.itemsize + 1, dtype=np.uint8)
+    out = np.ndarray(size, dtype=dtype, buffer=buf.data, offset=1)
+    assert not out.flags.aligned
+    return out
+
+
+@pytest.mark.parametrize('make_output',
+                         [_noncontiguous_output, _misaligned_output],
+                         ids=['noncontiguous', 'misaligned'])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.int64])
+def test_rank_filter_1d_output_writeback(make_output, dtype):
+    # output= is converted with NPY_ARRAY_INOUT_ARRAY2, so a non-contiguous or
+    # misaligned output array is substituted by a temporary that has to be
+    # written back explicitly. Same class of bug as gh-25641.
+    data = np.asarray([3, 1, 4, 1, 5, 9, 2, 6, 5, 3], dtype=dtype)
+    reference = ndimage.median_filter(data, size=3)
+
+    out = make_output(data.size, dtype)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        ndimage.median_filter(data, size=3, output=out)
+    unresolved = [str(w.message) for w in rec
+                  if issubclass(w.category, RuntimeWarning)
+                  and 'WRITEBACKIFCOPY' in str(w.message)]
+    assert unresolved == []
+
+    xp_assert_equal(np.ascontiguousarray(out), reference)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3425,3 +3425,27 @@ def test_rank_filter_1d_output_writeback(make_output, dtype):
     assert unresolved == []
 
     xp_assert_equal(np.ascontiguousarray(out), reference)
+
+
+@pytest.mark.parametrize('in_dtype, out_dtype', [
+    (np.float64, np.float32),   # output itemsize smaller than the input's
+    (np.float32, np.float64),   # output itemsize larger than the input's
+    (np.float64, np.int64),     # same itemsize, different kind
+    (np.int64, np.float64),
+])
+def test_rank_filter_1d_output_dtype(in_dtype, out_dtype):
+    # The 1-D fast path reinterprets the output buffer using the input's dtype,
+    # so a differing output dtype must be converted rather than reinterpreted.
+    # Results must match the n-dimensional code path.
+    data = np.asarray([3, 1, 4, 1, 5, 9, 2, 6, 5, 3], dtype=in_dtype)
+
+    # reference: the same filter forced through the n-dimensional code path
+    expected = np.zeros((1, data.size), dtype=out_dtype)
+    ndimage.median_filter(data[np.newaxis, :], size=(1, 3), output=expected)
+    expected = expected[0]
+
+    out = np.zeros(data.size, dtype=out_dtype)
+    result = ndimage.median_filter(data, size=3, output=out)
+
+    assert result is out
+    xp_assert_equal(out, expected)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3449,3 +3449,26 @@ def test_rank_filter_1d_output_dtype(in_dtype, out_dtype):
 
     assert result is out
     xp_assert_equal(out, expected)
+
+
+@pytest.mark.parametrize('dtype', [np.float64, np.float32, np.int64,
+                                   np.int32, np.uint16])
+@pytest.mark.parametrize('swap_input, swap_output',
+                         [(True, False), (False, True), (True, True)],
+                         ids=['input', 'output', 'both'])
+def test_rank_filter_1d_byte_order(dtype, swap_input, swap_output):
+    # The 1-D fast path dereferences the buffers directly, so non-native byte
+    # order has to be converted rather than reinterpreted.
+    native = np.dtype(dtype)
+    swapped = native.newbyteorder()
+
+    values = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3]
+    data = np.asarray(values, dtype=swapped if swap_input else native)
+    expected = ndimage.median_filter(np.asarray(values, dtype=native), size=3)
+
+    out = np.zeros(len(values), dtype=swapped if swap_output else native)
+    ndimage.median_filter(data, size=3, output=out)
+    xp_assert_equal(out.astype(native), expected)
+
+    # ... and the same without an explicit output array
+    xp_assert_equal(ndimage.median_filter(data, size=3).astype(native), expected)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -3108,34 +3108,64 @@ def test_distance_transform_cdt_invalid_metric(xp):
                                        metric="garbage")
 
 
-# NumPy-only because byte order is numpy-specific
-def _swapped_int32(shape):
-    return np.zeros(shape, dtype=np.dtype(np.int32).newbyteorder())
+def _byteswapped_output(shape, dtype):
+    """Output array with non-native byte order, so NumPy has to copy it."""
+    return np.zeros(shape, dtype=np.dtype(dtype).newbyteorder())
 
 
-@pytest.mark.parametrize('call', [
+def _misaligned_output(shape, dtype):
+    """Output array that is not aligned, so NumPy has to copy it."""
+    dtype = np.dtype(dtype)
+    nbytes = np.prod(shape, dtype=np.intp) * dtype.itemsize
+    buf = np.zeros(nbytes + 1, dtype=np.uint8)
+    out = np.ndarray(shape, dtype=dtype, buffer=buf.data, offset=1)
+    assert not out.flags.aligned
+    return out
+
+
+# Multi-byte output dtypes on purpose: a 1-byte dtype (the bool that
+# `binary_erosion` normally produces) is always aligned and has no byte order,
+# so it never triggers the copy these cases are about. Shapes match `data` below.
+_WRITEBACK_CASES = [
     pytest.param(
-        lambda a: ndimage.distance_transform_cdt(
-            a, distances=_swapped_int32((5, 5))),
-        id='distance_transform_cdt'),
+        lambda data, out: ndimage.distance_transform_bf(data, distances=out),
+        (7, 7), np.float64, id='distance_transform_bf'),
     pytest.param(
-        lambda a: ndimage.distance_transform_edt(
-            a, return_indices=True, indices=_swapped_int32((2, 5, 5))),
-        id='distance_transform_edt'),
+        lambda data, out: ndimage.distance_transform_cdt(data, distances=out),
+        (7, 7), np.int32, id='distance_transform_cdt'),
     pytest.param(
-        lambda a: ndimage.binary_erosion(
-            a, output=_swapped_int32((5, 5)), iterations=2),
-        id='binary_erosion'),
-])
-def test_byte_order_output_writeback(call):
-    """Regression test for gh-25641: an output array that NumPy has to copy
-    (here, because of non-native byte order) must be written back by the
-    C code rather than left for NumPy to clean up during deallocation.
-    """
-    data = np.zeros((5, 5), dtype=np.uint8)
+        lambda data, out: ndimage.distance_transform_edt(
+            data, return_indices=True, indices=out),
+        (2, 7, 7), np.int32, id='distance_transform_edt'),
+    pytest.param(
+        lambda data, out: ndimage.binary_erosion(data, output=out, iterations=2),
+        (7, 7), np.int32, id='binary_erosion'),
+]
+
+
+# NumPy only: byte order, alignment and NPY_ARRAY_WRITEBACKIFCOPY have no
+# equivalent in the array API standard.
+@pytest.mark.parametrize('make_output',
+                         [_byteswapped_output, _misaligned_output],
+                         ids=['byteswapped', 'misaligned'])
+@pytest.mark.parametrize('call, shape, dtype', _WRITEBACK_CASES)
+def test_output_writeback(call, shape, dtype, make_output):
+    # gh-25641: an output array that NumPy has to copy must be written back by
+    # the C code itself, rather than left to NumPy's deallocation fallback.
+    data = np.zeros((7, 7), dtype=np.uint8)
+    data[1:6, 1:6] = 1
+
+    reference = np.zeros(shape, dtype=dtype)
+    call(data, reference)
+
+    out = make_output(shape, dtype)
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
-        call(data)
-    leaked = [str(w.message) for w in rec
-              if issubclass(w.category, RuntimeWarning)]
-    assert leaked == []
+        call(data, out)
+    unresolved = [str(w.message) for w in rec
+                  if issubclass(w.category, RuntimeWarning)
+                  and 'WRITEBACKIFCOPY' in str(w.message)]
+    assert unresolved == []
+
+    # the results must actually have made it back into the caller's array
+    xp_assert_equal(np.asarray(out, dtype=dtype), reference)


### PR DESCRIPTION
This is a follow-up to gh-25646, which fixed most of the problems related to `NPY_ARRAY_WRITEBACKIFCOPY`, but not all of them. It also expands the tests to (a) cover misaligned, byteswapped and non-contiguous inputs, and (b) ensure the data is valid rather than only checking that numpy doesn't emit a warning.


#### AI Generation Disclosure

I used Claude Opus 5.0 for this, with manual polishing and review of what it produced after some steering.
