### PR TITLE
ENH: stats.median_test: add array API support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 import numpy as np
 from numpy import (isscalar, log, around, arange, sort, amin, amax, sqrt, array,
-                   pi, exp, ravel, count_nonzero)
+                   pi, exp, ravel)
 
 from scipy import optimize, special, interpolate, stats
 from scipy._lib._bunch import _make_tuple_bunch
@@ -4163,7 +4163,7 @@ MedianTestResult = _make_tuple_bunch(
 )
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(skip_backends=[("dask.array", "untested")], jax_jit=False)
 def median_test(*samples, ties='below', correction=True, lambda_=1,
                 nan_policy='propagate'):
     """Perform a Mood's median test.
@@ -4317,48 +4317,52 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
         raise ValueError(f"invalid 'ties' option '{ties}'; 'ties' must be one "
                          f"of: {str(ties_options)[1:-1]}")
 
-    data = _broadcast_arrays(samples, axis=-1, xp=np)
-    data = xp_promote(*data, force_floating=True, xp=np)
-    batch_shape, dtype = data[0].shape[:-1], data[0].dtype
+    xp = array_namespace(*samples)
+    data = _broadcast_arrays(samples, axis=-1, xp=xp)
+    data = xp_promote(*data, force_floating=True, xp=xp)
+    batch_shape, dtype, device = data[0].shape[:-1], data[0].dtype, xp_device(data[0])
 
-    cdata = np.concat(data, axis=-1)
+    cdata = xp.concat(data, axis=-1)
     contains_nan = _contains_nan(cdata, nan_policy)
 
     if cdata.shape[-1] == 0:
         # If all samples are empty, there's nothing we can calculate. Return now.
         warnings.warn(too_small_nd_not_omit, SmallSampleWarning, stacklevel=2)
-        nan = np.full(batch_shape, np.nan, dtype=dtype)
-        zeros = np.zeros(batch_shape + (2, n_samples), dtype=dtype)
+        nan = xp.full(batch_shape, xp.nan, dtype=dtype, device=device)
+        zeros = xp.zeros(batch_shape + (2, n_samples), dtype=dtype, device=device)
+        nan = nan[()] if nan.ndim == 0 else nan
+        zeros = zeros[()] if zeros.ndim == 0 else zeros
         return MedianTestResult(nan, nan, nan, zeros)
 
     if nan_policy == 'omit' and contains_nan:
-        grand_median = np.nanmedian(cdata, axis=-1, keepdims=True)
+        grand_median = stats.quantile(cdata, 0.5, axis=-1, keepdims=True,
+                                      nan_policy='omit')
     else:
-        grand_median = np.median(cdata, axis=-1, keepdims=True)
+        grand_median = stats.quantile(cdata, 0.5, axis=-1, keepdims=True)
 
     # Create the contingency table.
-    table = np.zeros(batch_shape + (2, n_samples), dtype=np.int64)
+    table = xp.zeros(batch_shape + (2, n_samples), dtype=xp.int64, device=device)
     for k, sample in enumerate(data):
-        nnan = count_nonzero(np.isnan(sample), axis=-1)
-        nabove = count_nonzero(sample > grand_median, axis=-1)
-        nbelow = count_nonzero(sample < grand_median, axis=-1)
+        nnan = xp.count_nonzero(xp.isnan(sample), axis=-1)
+        nabove = xp.count_nonzero(sample > grand_median, axis=-1)
+        nbelow = xp.count_nonzero(sample < grand_median, axis=-1)
         nequal = (sample.shape[-1] - (nabove + nbelow + nnan) if nan_policy=='omit'
-                  else count_nonzero(sample == grand_median, axis=-1))
-        table[..., 0, k] += nabove
-        table[..., 1, k] += nbelow
+                  else xp.count_nonzero(sample == grand_median, axis=-1))
+        table = xpx.at(table)[..., 0, k].add(nabove)
+        table = xpx.at(table)[..., 1, k].add(nbelow)
         if ties == "below":
-            table[..., 1, k] += nequal
+            table = xpx.at(table)[..., 1, k].add(nequal)
         elif ties == "above":
-            table[..., 0, k] += nequal
+            table = xpx.at(table)[..., 0, k].add(nequal)
 
-    grand_median = np.squeeze(grand_median, axis=-1)
+    grand_median = xp.squeeze(grand_median, axis=-1)
 
     # Check that no row or column of the table is all zero.
     # Such a table will result in NaN statistic and p-value.
-    rowsums = table.sum(axis=-1)
-    if batch_shape == () and not np.isnan(grand_median) and rowsums[0] == 0:
+    rowsums = xp.sum(table, axis=-1)
+    if batch_shape == () and not xp.isnan(grand_median) and rowsums[0] == 0:
         raise ValueError(f"All values are below the grand median ({grand_median}).")
-    if batch_shape == () and not np.isnan(grand_median) and rowsums[1] == 0:
+    if batch_shape == () and not xp.isnan(grand_median) and rowsums[1] == 0:
         raise ValueError(f"All values are above the grand median ({grand_median}).")
 
     if batch_shape == () and (ties == "ignore" or nan_policy == 'omit'):
@@ -4367,8 +4371,8 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
         # is "ignore", that would result in a column of zeros in `table`.
         # Similarly, observations in a sample could be omitted NaNs.
         # We check for these cases here.
-        zero_cols = np.nonzero((table == 0).all(axis=0))[0]
-        if len(zero_cols) > 0:
+        zero_cols = xp.nonzero(xp.all((table == 0), axis=0))[0]
+        if xp_size(zero_cols):
             raise ValueError(
                 f"All values in sample {zero_cols[0] + 1} are equal to the grand "
                 f"median ({grand_median!r}), so they are ignored, resulting in an "
@@ -4379,12 +4383,16 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
         # if only some samples are empty, we have the grand_median and `table`,
         # but `_chi2_contingency_2d` would make noise, so return now.
         warnings.warn(too_small_nd_not_omit, SmallSampleWarning, stacklevel=2)
-        nan = np.full(batch_shape, np.nan, dtype=dtype)
-        return MedianTestResult(nan, nan, grand_median[()], table[()])
+        nan = xp.full(batch_shape, xp.nan, dtype=dtype, device=device)
+        nan = nan[()] if nan.ndim == 0 else nan
+        grand_median = grand_median[()] if grand_median.ndim == 0 else grand_median
+        return MedianTestResult(nan, nan, grand_median, table)
 
     stat, p = stats.contingency._chi2_contingency_2d(
         table, lambda_=lambda_, correction=correction)
-    return MedianTestResult(stat[()], p[()], grand_median[()], table[()])
+    if stat.ndim == 0:
+        stat, p, grand_median = stat[()], p[()], grand_median[()]
+    return MedianTestResult(stat, p, grand_median, table)
 
 
 def _circfuncs_common(samples, period, xp=None):

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4163,7 +4163,7 @@ MedianTestResult = _make_tuple_bunch(
 )
 
 
-@xp_capabilities(skip_backends=[("dask.array", "untested")], jax_jit=False)
+@xp_capabilities(skip_backends=[("dask.array", "untested")])
 def median_test(*samples, ties='below', correction=True, lambda_=1,
                 nan_policy='propagate'):
     """Perform a Mood's median test.
@@ -4360,24 +4360,25 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
     # Check that no row or column of the table is all zero.
     # Such a table will result in NaN statistic and p-value.
     rowsums = xp.sum(table, axis=-1)
-    if batch_shape == () and not xp.isnan(grand_median) and rowsums[0] == 0:
-        raise ValueError(f"All values are below the grand median ({grand_median}).")
-    if batch_shape == () and not xp.isnan(grand_median) and rowsums[1] == 0:
-        raise ValueError(f"All values are above the grand median ({grand_median}).")
+    if not is_lazy_array(grand_median):
+        if batch_shape == () and not xp.isnan(grand_median) and rowsums[0] == 0:
+            raise ValueError(f"All values are below the grand median ({grand_median}).")
+        if batch_shape == () and not xp.isnan(grand_median) and rowsums[1] == 0:
+            raise ValueError(f"All values are above the grand median ({grand_median}).")
 
-    if batch_shape == () and (ties == "ignore" or nan_policy == 'omit'):
-        # We already checked that each sample has at least one value, but it
-        # is possible that all those values equal the grand median.  If `ties`
-        # is "ignore", that would result in a column of zeros in `table`.
-        # Similarly, observations in a sample could be omitted NaNs.
-        # We check for these cases here.
-        zero_cols = xp.nonzero(xp.all((table == 0), axis=0))[0]
-        if xp_size(zero_cols):
-            raise ValueError(
-                f"All values in sample {zero_cols[0] + 1} are equal to the grand "
-                f"median ({grand_median!r}), so they are ignored, resulting in an "
-                f"empty sample."
-            )
+        if batch_shape == () and (ties == "ignore" or nan_policy == 'omit'):
+            # We already checked that each sample has at least one value, but it
+            # is possible that all those values equal the grand median.  If `ties`
+            # is "ignore", that would result in a column of zeros in `table`.
+            # Similarly, observations in a sample could be omitted NaNs.
+            # We check for these cases here.
+            zero_cols = xp.nonzero(xp.all((table == 0), axis=0))[0]
+            if xp_size(zero_cols):
+                raise ValueError(
+                    f"All values in sample {zero_cols[0] + 1} are equal to the grand "
+                    f"median ({grand_median!r}), so they are ignored, resulting in an "
+                    f"empty sample."
+                )
 
     if any(array.shape[-1] == 0 for array in data):
         # if only some samples are empty, we have the grand_median and `table`,

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -28,7 +28,7 @@ from ._stats_py import power_divergence, _untabulate, Power_divergenceResult
 from ._relative_risk import relative_risk
 from ._crosstab import crosstab
 from ._odds_ratio import odds_ratio
-from scipy._lib._array_api import (array_namespace, xp_capabilities, xp_result_type,
+from scipy._lib._array_api import (array_namespace, xp_capabilities, xp_promote,
                                    xp_size, xp_device)
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
@@ -428,7 +428,8 @@ def _chi2_contingency_2d(observed, *, correction=True, lambda_=1, xp=None):
     # vectorized implementation of chi2_contingency for batches of 2D tables
     # (chi2_contingency works for ND tables, so it can't be vectorized)
     xp = array_namespace(observed) if xp is None else xp
-    dtype = xp_result_type(observed.dtype, force_floating=True, xp=xp)
+    observed = xp_promote(observed, force_floating=True, xp=xp)
+    dtype = observed.dtype
     device = xp_device(observed)
     batch_shape = observed.shape[:-2]
     table_shape = observed.shape[-2:]

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3564,152 +3564,165 @@ class TestCircFuncsNanPolicy:
         assert_raises(ValueError, test_func, x, high=360, nan_policy='foobar')
 
 
+@make_xp_test_case(stats.median_test)
 class TestMedianTest:
 
-    def test_bad_n_samples(self):
+    def test_bad_n_samples(self, xp):
         message = "median_test requires two or more samples."
         with pytest.raises(ValueError, match=message):
-            stats.median_test([1, 2, 3])
+            stats.median_test(xp.asarray([1, 2, 3]))
 
-    def test_empty_sample(self):
+    def test_empty_sample(self, xp):
         # Each sample must contain at least one value.
         message = "All axis-slices of one or more sample arguments..."
+        x = xp.asarray([])
+        y = xp.asarray([1, 2, 3])
         with pytest.warns(SmallSampleWarning, match=message):
-            res = stats.median_test([], [1, 2, 3])
-        assert_equal(res.statistic, np.nan)
-        assert_equal(res.pvalue, np.nan)
+            res = stats.median_test(x, y)
+        nan = xp.asarray(xp.nan, dtype=x.dtype)
+        xp_assert_equal(res.statistic, nan)
+        xp_assert_equal(res.pvalue, xp.asarray(np.nan))
 
-    def test_empty_when_ties_ignored(self):
+    def test_empty_when_ties_ignored(self, xp):
         # The grand median is 1, and all values in the first argument are
         # equal to the grand median.  With ties="ignore", those values are
         # ignored, which results in the first sample being (in effect) empty.
         # This should raise a ValueError.
-        assert_raises(ValueError, stats.median_test,
-                      [1, 1, 1, 1], [2, 0, 1], [2, 0], ties="ignore")
+        x = xp.asarray([1, 1, 1, 1])
+        y = xp.asarray([2, 0, 1])
+        z = xp.asarray([2, 0])
+        with pytest.raises(ValueError, match="All values in sample..."):
+            stats.median_test(x, y, z, ties="ignore")
 
-    def test_empty_contingency_row(self):
+    @pytest.mark.parametrize("ties", ['below', 'above'])
+    def test_empty_contingency_row(self, ties, xp):
         # The grand median is 1, and with the default ties="below", all the
         # values in the samples are counted as being below the grand median.
         # This would result a row of zeros in the contingency table, which is
         # an error.
-        assert_raises(ValueError, stats.median_test, [1, 1, 1], [1, 1, 1])
+        x = xp.ones(3)
+        with pytest.raises(match=f"All values are {ties} the grand median"):
+            stats.median_test(x, x, ties=ties)
 
-        # With ties="above", all the values are counted as above the
-        # grand median.
-        assert_raises(ValueError, stats.median_test, [1, 1, 1], [1, 1, 1],
-                      ties="above")
-
-    def test_bad_ties(self):
+    def test_bad_ties_nan_policy(self, xp):
+        x, y = xp.asarray([1, 2, 3]), xp.asarray([4, 5])
         message = "invalid 'ties' option 'foo'..."
-        with pytest.raises(ValueError, match=message):
-            stats.median_test([1, 2, 3], [4, 5], ties="foo")
 
-    def test_bad_nan_policy(self):
+        with pytest.raises(ValueError, match=message):
+            stats.median_test(x, y, ties="foo")
+
         message = "nan_policy must be one of..."
         with pytest.raises(ValueError, match=message):
-            stats.median_test([1, 2, 3], [4, 5], nan_policy="foobar")
+            stats.median_test(x, y, nan_policy="foobar")
 
-    def test_simple(self):
-        x = [1, 2, 3]
-        y = [1, 2, 3]
+    def test_simple(self, xp):
+        x = xp.asarray([1., 2., 3.])
+        y = xp.asarray([1., 2., 3.])
         stat, p, med, tbl = stats.median_test(x, y)
 
         # The median is floating point, but this equality test should be safe.
-        assert_equal(med, 2.0)
+        xp_assert_equal(med, xp.asarray(2.0))
 
-        assert_array_equal(tbl, [[1, 1], [2, 2]])
+        xp_assert_equal(tbl, xp.asarray([[1, 1], [2, 2]]))
 
         # The expected values of the contingency table equal the contingency
         # table, so the statistic should be 0 and the p-value should be 1.
-        assert_equal(stat, 0)
-        assert_equal(p, 1)
+        xp_assert_equal(stat, xp.asarray(0.))
+        xp_assert_equal(p, xp.asarray(1.))
 
-    def test_ties_options(self):
+    def test_ties_options(self, xp):
         # Test the contingency table calculation.
-        x = [1, 2, 3, 4]
-        y = [5, 6]
-        z = [7, 8, 9]
+        x = xp.asarray([1., 2., 3., 4.])
+        y = xp.asarray([5., 6.])
+        z = xp.asarray([7., 8., 9.])
         # grand median is 5.
 
         # Default 'ties' option is "below".
         stat, p, m, tbl = stats.median_test(x, y, z)
-        assert_equal(m, 5)
-        assert_equal(tbl, [[0, 1, 3], [4, 1, 0]])
+        xp_assert_equal(m, xp.asarray(5.))
+        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 1, 0]]))
 
         stat, p, m, tbl = stats.median_test(x, y, z, ties="ignore")
-        assert_equal(m, 5)
-        assert_equal(tbl, [[0, 1, 3], [4, 0, 0]])
+        xp_assert_equal(m, xp.asarray(5.))
+        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 0, 0]]))
 
         stat, p, m, tbl = stats.median_test(x, y, z, ties="above")
-        assert_equal(m, 5)
-        assert_equal(tbl, [[0, 2, 3], [4, 0, 0]])
+        xp_assert_equal(m, xp.asarray(5.))
+        xp_assert_equal(tbl, xp.asarray([[0, 2, 3], [4, 0, 0]]))
 
-    def test_nan_policy_options(self):
-        x = [1, 2, np.nan]
-        y = [4, 5, 6]
-        mt1 = stats.median_test(x, y, nan_policy='propagate')
+    def test_nan_policy_options(self, xp):
+        x = xp.asarray([1., 2., np.nan])
+        y = xp.asarray([4., 5., 6.])
+
+        s, p, m, t = stats.median_test(x, y, nan_policy='propagate')
+        nan = xp.asarray(xp.nan)
+        xp_assert_equal(s, nan)
+        xp_assert_equal(p, nan)
+        xp_assert_equal(m, nan)
+        xp_assert_equal(t, xp.asarray([[0, 0], [0, 0]]))
+
+        if is_lazy_array(x):
+            message = "nan_policy='omit' is not supported for lazy arrays."
+            with pytest.raises(TypeError, match=message):
+                stats.median_test(x, y, nan_policy='omit')
+
+            message = "nan_policy='raise' is not supported for lazy arrays."
+            with pytest.raises(TypeError, match=message):
+                stats.median_test(x, y, nan_policy='raise')
+
+            return
+
         s, p, m, t = stats.median_test(x, y, nan_policy='omit')
-
-        assert_equal(mt1, (np.nan, np.nan, np.nan, np.zeros((2, 2))))
-        assert_allclose(s, 0.31250000000000006)
-        assert_allclose(p, 0.57615012203057869)
-        assert_equal(m, 4.0)
-        assert_equal(t, np.array([[0, 2], [2, 1]]))
+        xp_assert_close(s, xp.asarray(0.31250000000000006))
+        xp_assert_close(p, xp.asarray(0.57615012203057869))
+        xp_assert_equal(m, xp.asarray(4.0))
+        xp_assert_equal(t, xp.asarray([[0, 2], [2, 1]]))
 
         message = "The input contains nan values"
         with pytest.raises(ValueError, match=message):
             stats.median_test(x, y, nan_policy='raise')
 
-    def test_basic(self):
+    @pytest.mark.parametrize('kwargs', [{}, {'lambda_': 0}, {'correction': False}])
+    def test_basic(self, kwargs, xp):
         # median_test calls chi2_contingency to compute the test statistic
         # and p-value.  Make sure it hasn't screwed up the call...
 
-        x = [1, 2, 3, 4, 5]
-        y = [2, 4, 6, 8]
+        x = xp.asarray([1., 2., 3., 4., 5.])
+        y = xp.asarray([2., 4., 6., 8.])
 
-        stat, p, m, tbl = stats.median_test(x, y)
-        assert_equal(m, 4)
-        assert_equal(tbl, [[1, 2], [4, 2]])
-
-        exp_stat, exp_p, dof, e = stats.chi2_contingency(tbl)
-        assert_allclose(stat, exp_stat)
-        assert_allclose(p, exp_p)
-
-        stat, p, m, tbl = stats.median_test(x, y, lambda_=0)
-        assert_equal(m, 4)
-        assert_equal(tbl, [[1, 2], [4, 2]])
-
-        exp_stat, exp_p, dof, e = stats.chi2_contingency(tbl, lambda_=0)
-        assert_allclose(stat, exp_stat)
-        assert_allclose(p, exp_p)
-
-        stat, p, m, tbl = stats.median_test(x, y, correction=False)
-        assert_equal(m, 4)
-        assert_equal(tbl, [[1, 2], [4, 2]])
-
-        exp_stat, exp_p, dof, e = stats.chi2_contingency(tbl, correction=False)
-        assert_allclose(stat, exp_stat)
-        assert_allclose(p, exp_p)
+        stat, p, m, tbl = stats.median_test(x, y, **kwargs)
+        exp_stat, exp_p, dof, e = stats.chi2_contingency(tbl, **kwargs)
+        xp_assert_equal(m, xp.asarray(4.))
+        xp_assert_equal(tbl, xp.asarray([[1, 2], [4, 2]]))
+        xp_assert_close(stat, exp_stat)
+        xp_assert_close(p, exp_p)
 
     @pytest.mark.parametrize("correction", [False, True])
-    def test_result(self, correction):
-        x = [1, 2, 3]
-        y = [1, 2, 3]
+    def test_result(self, correction, xp):
+        x = xp.asarray([1, 2, 3])
+        res = stats.median_test(x, x, correction=correction)
+        assert res.statistic is res[0]
+        assert res.pvalue is res[1]
+        assert res.median is res[2]
+        assert res.table is res[3]
 
-        res = stats.median_test(x, y, correction=correction)
-        assert_equal((res.statistic, res.pvalue, res.median, res.table), res)
-
-    def test_multidimensional(self):
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_multidimensional(self, dtype, xp):
+        dtype = xpx.default_dtype(xp) if dtype is None else getattr(xp, dtype)
         rng = np.random.default_rng(723482348929883)
         x = rng.random((3, 15))
         y = rng.random(16)
+        x = xp.asarray(x, dtype=dtype)
+        y = xp.asarray(y, dtype=dtype)
+
         res = stats.median_test(x, y)
-        for i, xi in enumerate(x):
+        for i in range(3):
+            xi = x[i, ...]
             ref = stats.median_test(xi, y)
-            assert_equal(res.statistic[i, ...], ref.statistic)
-            assert_equal(res.pvalue[i, ...], ref.pvalue)
-            assert_equal(res.median[i, ...], ref.median)
-            assert_equal(res.table[i, ...], ref.table)
+            xp_assert_close(res.statistic[i], ref.statistic)
+            xp_assert_close(res.pvalue[i], ref.pvalue)
+            xp_assert_close(res.median[i], ref.median)
+            xp_assert_equal(res.table[i, ...], ref.table)
 
 
 @make_xp_test_case(stats.directional_stats)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3626,7 +3626,7 @@ class TestMedianTest:
         # The median is floating point, but this equality test should be safe.
         xp_assert_equal(med, xp.asarray(2.0))
 
-        xp_assert_equal(tbl, xp.asarray([[1, 1], [2, 2]]))
+        xp_assert_equal(tbl, xp.asarray([[1, 1], [2, 2]], dtype=xp.int64))
 
         # The expected values of the contingency table equal the contingency
         # table, so the statistic should be 0 and the p-value should be 1.
@@ -3643,15 +3643,15 @@ class TestMedianTest:
         # Default 'ties' option is "below".
         stat, p, m, tbl = stats.median_test(x, y, z)
         xp_assert_equal(m, xp.asarray(5.))
-        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 1, 0]]))
+        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 1, 0]], dtype=xp.int64))
 
         stat, p, m, tbl = stats.median_test(x, y, z, ties="ignore")
         xp_assert_equal(m, xp.asarray(5.))
-        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 0, 0]]))
+        xp_assert_equal(tbl, xp.asarray([[0, 1, 3], [4, 0, 0]], dtype=xp.int64))
 
         stat, p, m, tbl = stats.median_test(x, y, z, ties="above")
         xp_assert_equal(m, xp.asarray(5.))
-        xp_assert_equal(tbl, xp.asarray([[0, 2, 3], [4, 0, 0]]))
+        xp_assert_equal(tbl, xp.asarray([[0, 2, 3], [4, 0, 0]], dtype=xp.int64))
 
     def test_nan_policy_options(self, xp):
         x = xp.asarray([1., 2., np.nan])
@@ -3662,7 +3662,7 @@ class TestMedianTest:
         xp_assert_equal(s, nan)
         xp_assert_equal(p, nan)
         xp_assert_equal(m, nan)
-        xp_assert_equal(t, xp.asarray([[0, 0], [0, 0]]))
+        xp_assert_equal(t, xp.asarray([[0, 0], [0, 0]], dtype=xp.int64))
 
         if is_lazy_array(x):
             message = "nan_policy='omit' is not supported for lazy arrays."
@@ -3679,7 +3679,7 @@ class TestMedianTest:
         xp_assert_close(s, xp.asarray(0.31250000000000006))
         xp_assert_close(p, xp.asarray(0.57615012203057869))
         xp_assert_equal(m, xp.asarray(4.0))
-        xp_assert_equal(t, xp.asarray([[0, 2], [2, 1]]))
+        xp_assert_equal(t, xp.asarray([[0, 2], [2, 1]], dtype=xp.int64))
 
         message = "The input contains nan values"
         with pytest.raises(ValueError, match=message):
@@ -3696,7 +3696,7 @@ class TestMedianTest:
         stat, p, m, tbl = stats.median_test(x, y, **kwargs)
         exp_stat, exp_p = _chi2_contingency_2d(tbl, **kwargs)
         xp_assert_equal(m, xp.asarray(4.))
-        xp_assert_equal(tbl, xp.asarray([[1, 2], [4, 2]]))
+        xp_assert_equal(tbl, xp.asarray([[1, 2], [4, 2]], dtype=xp.int64))
         xp_assert_close(stat, exp_stat)
         xp_assert_close(p, exp_p)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -21,6 +21,7 @@ from scipy.stats._morestats import (_abw_state, _get_As_weibull, _Avals_weibull,
                                     _yeojohnson_transform)
 from .common_tests import check_named_results
 from .._hypotests import _get_wilcoxon_distr, _get_wilcoxon_distr2
+from scipy.stats.contingency import _chi2_contingency_2d
 from scipy.stats._ansari_swilk_statistics import swilk
 from scipy.stats._binomtest import _binary_search_for_binom_tst
 from scipy.stats._distr_params import distcont
@@ -3693,7 +3694,7 @@ class TestMedianTest:
         y = xp.asarray([2., 4., 6., 8.])
 
         stat, p, m, tbl = stats.median_test(x, y, **kwargs)
-        exp_stat, exp_p, dof, e = stats.chi2_contingency(tbl, **kwargs)
+        exp_stat, exp_p = _chi2_contingency_2d(tbl, **kwargs)
         xp_assert_equal(m, xp.asarray(4.))
         xp_assert_equal(tbl, xp.asarray([[1, 2], [4, 2]]))
         xp_assert_close(stat, exp_stat)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3583,6 +3583,7 @@ class TestMedianTest:
         xp_assert_equal(res.statistic, nan)
         xp_assert_equal(res.pvalue, xp.asarray(np.nan))
 
+    @skip_xp_backends("jax.numpy", reason="JAX can't branch based on array values")
     def test_empty_when_ties_ignored(self, xp):
         # The grand median is 1, and all values in the first argument are
         # equal to the grand median.  With ties="ignore", those values are
@@ -3594,6 +3595,7 @@ class TestMedianTest:
         with pytest.raises(ValueError, match="All values in sample..."):
             stats.median_test(x, y, z, ties="ignore")
 
+    @skip_xp_backends("jax.numpy", reason="JAX can't branch based on array values")
     @pytest.mark.parametrize("ties", ['below', 'above'])
     def test_empty_contingency_row(self, ties, xp):
         # The grand median is 1, and with the default ties="below", all the


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `stats.median_test`.

#### AI Generation Disclosure
No AI