### PR TITLE
TST: signal: remove JAX skips

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -274,8 +274,6 @@ class TestZpk2Tf:
         xp_assert_close(b, bp)
         xp_assert_close(a, ap)
 
-    @skip_xp_backends("jax.numpy",
-                      reason="zpk2tf not compatible with jax yet on multi-dim arrays")
     @skip_xp_backends("cupy",
                       reason="multi-dim arrays not supported yet on cupy")
     def test_zpk2tf_with_multi_dimensional_array(self, xp):
@@ -305,8 +303,6 @@ class TestZpk2Tf:
         xp_assert_close(b, b_ref, atol=1e-14)
         xp_assert_close(a, a_ref, atol=1e-14)
 
-    @skip_xp_backends("jax.numpy",
-                      reason="zpk2tf not compatible with jax yet on multi-dim arrays")
     @skip_xp_backends("cupy",
                       reason="multi-dim arrays not supported yet on cupy")
     def test_zpk2tf_complex_k_multi_dim_z(self, xp):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
It appears we can remove those JAX skips. Locally, it passes: let's see what CI says.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no AI