### PR TITLE
ENH:optimize.root_scalar: avoid redundant `f` call in `newton`

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -308,6 +308,15 @@ def root_scalar(f, args=(), method=None, bracket=None,
             raise ValueError(f'x0 must not be None for {method}')
         if not fprime:
             # approximate fprime with finite differences
+            def f_newton(x, *args):
+                # record f0 for use in fprime
+                f_newton.x = x
+                f_newton.f0 = f(x, *args)
+                return f_newton.f0
+
+            # initialize attributes before fprime reads them
+            f_newton.x = None
+            f_newton.f0 = None
 
             def fprime(x, *args):
                 # `root_scalar` doesn't actually seem to support vectorized
@@ -319,11 +328,18 @@ def root_scalar(f, args=(), method=None, bracket=None,
                 # scalar input.
                 def f_wrapped(x, *args):
                     return f(x[0], *args)
-                return approx_derivative(f_wrapped, x, method='2-point', args=args)[0]
+                # if current x is same as last x, use the cached f0
+                # this saves one evaluation per iteration (gh-21165)
+                f0 = f_newton.f0 if x == f_newton.x else None
+                return approx_derivative(f_wrapped, x, method='2-point',
+                                         args=args, f0=f0)[0]
+        else:
+            # use the user-supplied f
+            f_newton = f
 
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')
-        r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=None,
+        r, sol = methodc(f_newton, x0, args=args, fprime=fprime, fprime2=None,
                          **kwargs)
     elif meth in ['halley']:
         if x0 is None:

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -485,6 +485,19 @@ class TestNewton(TestScalarRootFinders):
                 != res_newton_default.iterations
                 == res_newton_default.function_calls/2)  # newton 2-point diff
 
+    def test_gh21165_no_redundant_newton_fun_calls(self):
+        # 2x calls per iteration, previously 3x: the finite difference now
+        # reuses `newton`'s value of `f(x)` instead of recomputing it.
+
+        calls = []
+
+        def f(x):
+            calls.append(x)
+            return f1(x)
+
+        res = root_scalar(f, method='newton', x0=3, xtol=1e-6)
+        assert len(calls) == 2 * res.iterations
+
     @pytest.mark.parametrize('kwargs', [dict(), {'method': 'newton'}])
     def test_args_gh19090(self, kwargs):
         def f(x, a, b):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Addresses gh-21165 (removes extra function call at newton)

#### What does this implement/fix?
<!--Please explain your changes.-->

When `fprime` is not given, `root_scalar` uses finite differences to approximate the derivative. `approx_derivative` re-evaluated `f` at the point that `newton` had just evaluated. This resulted in 3 calls to `f` per iteration instead of 2. 

I cache the value from the most recent call to `f`, pass it as `f0` when the point matches.

#### Additional information
<!--Any additional information you think is important.-->

This only addresses newton since it uses finite differences. I haven't noticed a similar redundancy in other solvers.

`ScalarFunction` (suggested on the issue) casts `x0` to float64. That would break complex `x0` support in `newton`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Claude Code suggested fixes for my implementation of the caching structure and the test, and I adapted them. I was originally testing against `newton` directly instead of `root_scalar`, which was resulting in failing tests. I also used it for code review to check if existing memoization nearby could be used easily, but decided to go for the simpler patch.