### PR TITLE
DOC: eval_sh_legendre, roots_sh_legendre: fix reference to Abramowitz

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -1380,7 +1380,7 @@ add_newdoc("eval_sh_legendre",
 
         P_n^*(x) = P_n(2x - 1)
 
-    where :math:`P_n` is a Legendre polynomial. See 2.2.11 in [AS]_
+    where :math:`P_n` is a Legendre polynomial. See 22.2.11 in [AS]_
     or [DLMF]_ for details.
 
     Parameters

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -3503,7 +3503,7 @@ def roots_sh_legendre(n, mu=False):
     shifted Legendre polynomial :math:`P^*_n(x)`. These sample points
     and weights correctly integrate polynomials of degree :math:`2n -
     1` or less over the interval :math:`[0, 1]` with weight function
-    :math:`w(x) = 1.0`. See 2.2.11 in [AS]_ for details.
+    :math:`w(x) = 1.0`. See 22.2.11 in [AS]_ for details.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
No issue was opened for this fix.

#### What does this implement/fix?
The documentation of `eval_sh_legendre` and `roots_sh_legendre` refers to equation 2.2.11 in AS which is clearly incorrect. Apparently, this is a typo and equation 22.2.11 was meant. While the orthogonality relation in 22.2.11 only indirectly provides the information needed in the docstrings, it is the best reference in AS for this purpose.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used
