### PR TITLE
TST: stats - bump some tolerances

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2995,7 +2995,7 @@ class TestBoxcoxNormmax(NormmaxTest):
 
         res = stats.boxcox_normmax(x, method='all', nan_policy='omit')
         ref = stats.boxcox_normmax(x[~np.isnan(x)], method='all')
-        np.testing.assert_allclose(res, ref)
+        np.testing.assert_allclose(res, ref, rtol=2e-7)
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -765,7 +765,7 @@ class TestPearsonr:
         y = rng.random(10)
         res = stats.pearsonr(x, y, axis=1)
         ref = stats.pearsonr(x, y, axis=-1)
-        assert_equal(res.statistic, ref.statistic)
+        assert_equal(res.statistic, ref.statistic, rtol=3e-16)
 
     @pytest.mark.parametrize('axis', [0, 1, None])
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -765,7 +765,7 @@ class TestPearsonr:
         y = rng.random(10)
         res = stats.pearsonr(x, y, axis=1)
         ref = stats.pearsonr(x, y, axis=-1)
-        assert_equal(res.statistic, ref.statistic, rtol=3e-16)
+        assert_allclose(res.statistic, ref.statistic, rtol=3e-16)
 
     @pytest.mark.parametrize('axis', [0, 1, None])
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])


### PR DESCRIPTION
Bumps some test tolerances in stats.

#### Reference issue
should fix the fails in 
https://github.com/scipy/scipy-release/actions/runs/32099350455/job/95596733265?pr=33

#### AI Generation Disclosure
None