### PR TITLE
CI: add editable Linux CI job and limit sudo apt runtime

### DIFF
--- a/.github/apt-get/action.yml
+++ b/.github/apt-get/action.yml
@@ -20,6 +20,7 @@ runs:
         PACKAGES: ${{ inputs.packages }}
         REPOSITORY: ${{ inputs.repository }}
       run: |
+        set -euo pipefail
         opts=(
           -o Acquire::Retries=3
           -o Acquire::http::Timeout=30
@@ -33,8 +34,10 @@ runs:
         sudo timeout 5m apt-get update "${opts[@]}"
         if [[ -n "$REPOSITORY" ]]; then
           install software-properties-common
-          sudo add-apt-repository -y "$REPOSITORY"
+          sudo DEBIAN_FRONTEND=noninteractive timeout 5m add-apt-repository -y "$REPOSITORY"
           sudo timeout 5m apt-get update "${opts[@]}"
         fi
-        read -ra packages <<< "$PACKAGES"
+        # Fold newlines into spaces first: `read` stops at the first newline, so a
+        # caller using a `|` block scalar would otherwise lose packages silently.
+        read -ra packages <<< "${PACKAGES//$'\n'/ }"
         install "${packages[@]}"

--- a/.github/apt-get/action.yml
+++ b/.github/apt-get/action.yml
@@ -33,8 +33,10 @@ runs:
         }
         # GitHub-hosted Ubuntu runners default to an Azure geo-mirror that is
         # frequently unreachable; go straight to the canonical mirror instead of
-        # burning the update timeout on retries against a dead host.
-        for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+        # burning the update timeout on retries against a dead host. The actual
+        # mirror lives in apt-mirrors.txt - ubuntu.sources just points at it via
+        # a `mirror+file:` URI, so patching only the .sources files is a no-op.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/apt-mirrors.txt; do
           [[ -f "$f" ]] && sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' "$f"
         done
         sudo timeout 5m apt-get update "${opts[@]}"

--- a/.github/apt-get/action.yml
+++ b/.github/apt-get/action.yml
@@ -31,6 +31,12 @@ runs:
         install() {
           sudo DEBIAN_FRONTEND=noninteractive timeout 10m apt-get install -y "${opts[@]}" "$@"
         }
+        # GitHub-hosted Ubuntu runners default to an Azure geo-mirror that is
+        # frequently unreachable; go straight to the canonical mirror instead of
+        # burning the update timeout on retries against a dead host.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+          [[ -f "$f" ]] && sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' "$f"
+        done
         sudo timeout 5m apt-get update "${opts[@]}"
         if [[ -n "$REPOSITORY" ]]; then
           install software-properties-common

--- a/.github/apt-get/action.yml
+++ b/.github/apt-get/action.yml
@@ -1,0 +1,40 @@
+name: Install apt packages
+description: >
+  `apt-get update && install` with retries and timeouts, so a stalled mirror
+  or a dpkg lock held by unattended-upgrades fails fast instead of hanging CI
+  for hours.
+inputs:
+  packages:
+    description: Packages to install, whitespace-separated
+    required: true
+  repository:
+    description: "Optional PPA to add before installing, e.g. ppa:deadsnakes/ppa"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        REPOSITORY: ${{ inputs.repository }}
+      run: |
+        opts=(
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
+          -o DPkg::Lock::Timeout=120  # wait out unattended-upgrades rather than erroring
+          -o Dpkg::Options::=--force-unsafe-io  # no fsync; the runner is ephemeral
+        )
+        install() {
+          sudo DEBIAN_FRONTEND=noninteractive timeout 10m apt-get install -y "${opts[@]}" "$@"
+        }
+        sudo timeout 5m apt-get update "${opts[@]}"
+        if [[ -n "$REPOSITORY" ]]; then
+          install software-properties-common
+          sudo add-apt-repository -y "$REPOSITORY"
+          sudo timeout 5m apt-get update "${opts[@]}"
+        fi
+        read -ra packages <<< "$PACKAGES"
+        install "${packages[@]}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,12 +84,20 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
-      name: Install dependencies and build SciPy
+      name: Checkout submodules
+      shell: bash
+      run: git submodule update --init
+
+    - if: matrix.build-mode == 'manual'
+      name: Install Ubuntu dependencies
+      uses: ./.github/apt-get
+      with:
+        packages: gcc g++ libopenblas-dev liblapack-dev pkg-config python3-pip python3-dev
+
+    - if: matrix.build-mode == 'manual'
+      name: Build SciPy
       shell: bash
       run: |
-        git submodule update --init
-        sudo apt update
-        sudo apt install -y gcc g++ libopenblas-dev liblapack-dev pkg-config python3-pip python3-dev
         python -m pip install --upgrade pip
         python -m pip install --group build --group dev-cli
         spin build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -243,28 +243,40 @@ jobs:
         run: |
           spin install
 
-      - name: Ccache performance
-        shell: bash -l {0}
-        run: |
-          ccache --evict-older-than 1d
-          ccache -s
-
       - name: Check import
         # Run from outside the source tree, then check that `scipy` still
         # resolves back to it - that's the point of an editable install.
         run: |
           python -c "
-          import pathlib, scipy, scipy.linalg
-          expected = pathlib.Path(r'$EXPECTED_SCIPY_DIR')
+          import os, pathlib, scipy, scipy.linalg
+          expected = pathlib.Path(os.environ['EXPECTED_SCIPY_DIR'])
           assert pathlib.Path(scipy.__file__).parent == expected, \
               f'{scipy.__file__=} not from {expected}'"
         working-directory: ${{ runner.temp }}
         env:
           EXPECTED_SCIPY_DIR: ${{ github.workspace }}/scipy
 
-      - name: Test SciPy
+      - name: Check rebuild on import
+        # meson-python reruns ninja on every import of an editable install. Touch a
+        # .pyx so that hook has actual work to do; nothing else in CI exercises it.
         run: |
-          spin test -j3 -- --durations 10 --timeout=60
+          touch "$GITHUB_WORKSPACE/scipy/linalg/_cythonized_array_utils.pyx"
+          python -c "import numpy as np, scipy.linalg; print(scipy.linalg.bandwidth(np.eye(3)))"
+        working-directory: ${{ runner.temp }}
+
+      - name: Ccache performance
+        # After the imports above, since those can trigger a rebuild
+        shell: bash -l {0}
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s
+
+      - name: Test SciPy
+        # `-t scipy` is required: with extra args after `--`, spin does not add a
+        # collection target of its own, and for an editable install it also leaves
+        # pytest's cwd at the repo root - so pytest would collect the whole checkout.
+        run: |
+          spin test -j3 -t scipy -- --durations 10 --timeout=60
 
   #################################################################################
   python_debug:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -201,6 +201,71 @@ jobs:
           ccache -s
 
   #################################################################################
+  test_editable_install:
+    # Editable installs hit corner cases that regular installs don't, e.g., gh-25892
+    name: Editable install, fast, py3.12/npAny, spin
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Ubuntu dependencies
+        run: |
+          # apt OpenBLAS rather than the scipy-openblas wheel, because
+          # `--with-scipy-openblas` is a `spin build` flag with no `spin install` equivalent
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config ccache
+
+      - name: Install Python packages
+        run: |
+          python -m pip install --group build --group dev-cli --group test-core --group optional-runtime-deps
+
+      - name: Set up ccache
+        uses: ./.github/ccache
+        with:
+          workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
+
+      - name: Editable install
+        # `spin install` defaults to `pip install -e . --no-build-isolation`
+        run: |
+          spin install
+
+      - name: Ccache performance
+        shell: bash -l {0}
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s
+
+      - name: Check import
+        # Run from outside the source tree, then check that `scipy` still
+        # resolves back to it - that's the point of an editable install.
+        run: |
+          python -c "
+          import pathlib, scipy, scipy.linalg
+          expected = pathlib.Path(r'$EXPECTED_SCIPY_DIR')
+          assert pathlib.Path(scipy.__file__).parent == expected, \
+              f'{scipy.__file__=} not from {expected}'"
+        working-directory: ${{ runner.temp }}
+        env:
+          EXPECTED_SCIPY_DIR: ${{ github.workspace }}/scipy
+
+      - name: Test SciPy
+        run: |
+          spin test -j3 -- --durations 10 --timeout=60
+
+  #################################################################################
   python_debug:
     # also uses the vcs->sdist->wheel route.
     name: Python-debug & ATLAS & sdist+wheel, fast, py3.12/npMin, pip+pytest
@@ -634,5 +699,4 @@ jobs:
 
       - name: Test SciPy
         run: |
-          export OMP_NUM_THREAD=2
           pixi run test-fail-slow

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -258,10 +258,25 @@ jobs:
 
       - name: Check rebuild on import
         # meson-python reruns ninja on every import of an editable install. Touch a
-        # .pyx so that hook has actual work to do; nothing else in CI exercises it.
+        # source file (Pythran-compiled here, rather than Cython, but the rebuild
+        # hook works the same way) so that hook has actual work to do, then check
+        # the compiled extension's mtime to prove a rebuild actually happened -
+        # not just that the (possibly stale) module still imports without error.
         run: |
-          touch "$GITHUB_WORKSPACE/scipy/linalg/_cythonized_array_utils.pyx"
-          python -c "import numpy as np, scipy.linalg; print(scipy.linalg.bandwidth(np.eye(3)))"
+          before=$(python -c "
+          import scipy.signal._max_len_seq_inner as m, os
+          print(os.stat(m.__file__).st_mtime_ns)")
+          sleep 1  # ensure a rebuilt file's mtime is unambiguously newer
+          touch "$GITHUB_WORKSPACE/scipy/signal/_max_len_seq_inner.py"
+          after=$(python -c "
+          import scipy.signal, scipy.signal._max_len_seq_inner as m, os
+          assert len(scipy.signal.max_len_seq(4)[0]) == 15
+          print(os.stat(m.__file__).st_mtime_ns)")
+          echo "extension mtime (ns): before=$before after=$after"
+          if [[ "$after" -le "$before" ]]; then
+            echo "::error::extension was not rebuilt on import (mtime unchanged)"
+            exit 1
+          fi
         working-directory: ${{ runner.temp }}
 
       - name: Ccache performance

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,10 +57,12 @@ jobs:
           allow-prereleases: true
 
       - name: Install Ubuntu dependencies
-        run: |
-          # NOTE: not the same OpenBLAS version as in upstream CI (I'm being lazy here)
-          sudo apt-get update
-          sudo apt-get install -y libopenblas-dev libatlas-base-dev liblapack-dev libgmp-dev libmpfr-dev libsuitesparse-dev ccache libmpc-dev
+        # NOTE: not the same OpenBLAS version as in upstream CI (I'm being lazy here)
+        uses: ./.github/apt-get
+        with:
+          packages: >-
+            libopenblas-dev libatlas-base-dev liblapack-dev libgmp-dev
+            libmpfr-dev libsuitesparse-dev ccache libmpc-dev
 
       - name: Install Python packages
         if: matrix.python-version == '3.12'
@@ -142,13 +144,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Ubuntu dependencies
-        run: |
-          # We're not running the full test suite here, only testing the install
-          # into a venv is working, so leave out optional dependencies. That's
-          # also why we can get away with an old version of OpenBLAS from Ubuntu
-          sudo apt-get update
-          sudo apt-get install -y python3-dev libopenblas-dev pkg-config \
-            ccache
+        # We're not running the full test suite here, only testing the install
+        # into a venv is working, so leave out optional dependencies. That's
+        # also why we can get away with an old version of OpenBLAS from Ubuntu
+        uses: ./.github/apt-get
+        with:
+          packages: python3-dev libopenblas-dev pkg-config ccache
 
       - name: Set up ccache
         uses: ./.github/ccache
@@ -221,11 +222,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install Ubuntu dependencies
-        run: |
-          # apt OpenBLAS rather than the scipy-openblas wheel, because
-          # `--with-scipy-openblas` is a `spin build` flag with no `spin install` equivalent
-          sudo apt-get update
-          sudo apt-get install -y libopenblas-dev pkg-config ccache
+        # apt OpenBLAS rather than the scipy-openblas wheel, because
+        # `--with-scipy-openblas` is a `spin build` flag with no `spin install` equivalent
+        uses: ./.github/apt-get
+        with:
+          packages: libopenblas-dev pkg-config ccache
 
       - name: Install Python packages
         run: |
@@ -281,10 +282,14 @@ jobs:
           persist-credentials: false
 
       - name: Configuring Test Environment
-        run: |
-          sudo apt-get update
-          sudo apt install python3-dbg python3-dev libatlas-base-dev liblapack-dev \
+        uses: ./.github/apt-get
+        with:
+          packages: >-
+            python3-dbg python3-dev libatlas-base-dev liblapack-dev
             libgmp-dev libmpfr-dev libmpc-dev
+
+      - name: Check python3-dbg
+        run: |
           python3-dbg --version # just to check
           python3-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
 
@@ -323,11 +328,11 @@ jobs:
           python-version: "3.12"
 
       - name: Setup system dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt install -y g++-10 gcc-10
-          sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
-            libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev ccache
+        uses: ./.github/apt-get
+        with:
+          packages: >-
+            g++-10 gcc-10 libatlas-base-dev liblapack-dev libgmp-dev
+            libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev ccache
 
       - name: Setup Python build deps
         run: pip install --group build
@@ -393,10 +398,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache \
-            lcov ccache
+        uses: ./.github/apt-get
+        with:
+          packages: libgmp-dev libmpfr-dev libmpc-dev ccache lcov
 
       - name: Install Python packages
         run: |
@@ -489,12 +493,11 @@ jobs:
           persist-credentials: false
 
       - name: Setup system dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt install software-properties-common
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt update -y
-          sudo apt install -y python3.12-dev ninja-build pkg-config libatlas-base-dev \
+        uses: ./.github/apt-get
+        with:
+          repository: ppa:deadsnakes/ppa
+          packages: >-
+            python3.12-dev ninja-build pkg-config libatlas-base-dev
             liblapack-dev ccache
 
       - name: Set up ccache
@@ -553,10 +556,9 @@ jobs:
           persist-credentials: false
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libopenblas-dev liblapack-dev \
-            ccache
+        uses: ./.github/apt-get
+        with:
+          packages: pkg-config libopenblas-dev liblapack-dev ccache
 
       - name: Set up ccache
         uses: ./.github/ccache

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,11 +1,20 @@
 [pytest]
 addopts = -l
 junit_family=xunit2
+# NOTE: this replaces pytest's built-in defaults rather than adding to them, hence
+# `build*`/`dist`/`venv`/`.*`/`*.egg` below - those are pytest's own defaults. They
+# matter for editable installs, where `spin test` runs pytest from the repo root
+# rather than from `build-install`.
 norecursedirs =
     benchmarks
     doc
     tools
     subprojects
+    build*
+    dist
+    venv
+    .*
+    *.egg
 
 filterwarnings =
     error

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 addopts = -l
 junit_family=xunit2
 norecursedirs =
+    benchmarks
     doc
     tools
     subprojects


### PR DESCRIPTION
#### Reference issue

@rgommers mentioned this possibility in: https://github.com/scipy/scipy/pull/25918#issuecomment-5325356484

#### What does this implement/fix?

Adds Linux editable CI run. Also removes a misspelled and unneeded (I think based on `conftest.py`?) `OMP_NUM_THREAD`.

I considered tacking this on to some existing job instead but I didn't see a good fit. `venv` was a possibility but it already does a couple envs now.

#### Additional information

N/A

#### AI Generation Disclosure

Drafted by Claude Opus 5 then revised by me.