### PR TITLE
Fix pythran warning in CIs

### DIFF
--- a/scipy/signal/_max_len_seq_inner.py
+++ b/scipy/signal/_max_len_seq_inner.py
@@ -20,6 +20,6 @@ def _max_len_seq_inner(taps, state, nbits, length, seq):
         state[idx] = feedback
         idx = (idx + 1) % nbits
     # state must be rolled s.t. next run, when idx==0, it's in the right place
-    # Avoid np.roll as pythran's generated code for it triggers a spurious
-    # GCC 13 -Werror=array-bounds warning on this fixed-size int8 array
+    # Avoid np.roll, pythran's generated code triggers a spurious warning:
+    # https://github.com/serge-sans-paille/pythran/issues/2472
     return np.concatenate((state[idx:], state[:idx]))

--- a/scipy/signal/_max_len_seq_inner.py
+++ b/scipy/signal/_max_len_seq_inner.py
@@ -20,4 +20,6 @@ def _max_len_seq_inner(taps, state, nbits, length, seq):
         state[idx] = feedback
         idx = (idx + 1) % nbits
     # state must be rolled s.t. next run, when idx==0, it's in the right place
-    return np.roll(state, -idx, axis=0)
+    # Avoid np.roll as pythran's generated code for it triggers a spurious
+    # GCC 13 -Werror=array-bounds warning on this fixed-size int8 array
+    return np.concatenate((state[idx:], state[:idx]))


### PR DESCRIPTION
#### Reference issue

None, recent PR CIs are failing e.g. in https://github.com/scipy/scipy/pull/25954 with [this](https://github.com/scipy/scipy/actions/runs/32076917144/job/95532013957?pr=25954):

<details>
<summary>traceback</summary>

```
  In file included from /usr/include/c++/13/bits/specfun.h:43,
                   from /usr/include/c++/13/cmath:3699,
                   from /usr/include/c++/13/complex:44,
                   from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/include/types/traits.hpp:4,
                   from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/include/types/combined.hpp:6,
                   from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/combined.hpp:4,
                   from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/core.hpp:48,
                   from scipy/signal/_max_len_seq_inner.cpython-312-x86_64-linux-gnu.so.p/_max_len_seq_inner.cpp:1:
  In static member function ‘static void std::__copy_move<false, false, std::random_access_iterator_tag>::__assign_one(_Tp*, _Up*) [with _Tp = signed char; _Up = const signed char]’,
      inlined from ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = const signed char; _Up = signed char; bool _IsMove = false]’ at /usr/include/c++/13/bits/stl_algobase.h:440:20,
      inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
      inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
      inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
      inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::types::ndarray<T, pS>::copy() const [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/ndarray.hpp:863:14,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::numpy::roll(const {anonymous}::pythonic::types::ndarray<T, pS>&, long int, long int) [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/numpy/roll.hpp:75:24:
  /usr/include/c++/13/bits/stl_algobase.h:398:17: error: array subscript 0 is outside array bounds of ‘signed char [0]’ [-Werror=array-bounds=]
    398 |         { *__to = *__from; }
        |           ~~~~~~^~~~~~~~~
  In file included from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/include/types/list.hpp:10,
                   from ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/include/types/ndarray.hpp:14,
                   from scipy/signal/_max_len_seq_inner.cpython-312-x86_64-linux-gnu.so.p/_max_len_seq_inner.cpp:12:
  In function ‘T* {anonymous}::pythonic::utils::allocate(size_t) [with T = signed char]’,
      inlined from ‘{anonymous}::pythonic::types::raw_array<T>::raw_array(size_t) [with T = signed char]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/raw_array.hpp:24:62,
      inlined from ‘{anonymous}::pythonic::utils::shared_ref<T>::memory::memory(Types&& ...) [with Types = {long int}; T = {anonymous}::pythonic::types::raw_array<signed char>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/utils/shared_ref.hpp:21:9,
      inlined from ‘{anonymous}::pythonic::utils::shared_ref<T>::shared_ref(Types&& ...) [with Types = {long int}; T = {anonymous}::pythonic::types::raw_array<signed char>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/utils/shared_ref.hpp:38:13,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS>::ndarray(const pS&, {anonymous}::pythonic::types::none_type) [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/ndarray.hpp:371:9,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::types::ndarray<T, pS>::copy() const [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/ndarray.hpp:862:20,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::numpy::roll(const {anonymous}::pythonic::types::ndarray<T, pS>&, long int, long int) [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/numpy/roll.hpp:75:24:
  ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/include/utils/allocate.hpp:30:23: note: object of size 0 allocated by ‘malloc’
     30 |     return (T *)malloc(sizeof(T) * nmemb);
        |                 ~~~~~~^~~~~~~~~~~~~~~~~~~
  In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = const signed char; _Up = signed char; bool _IsMove = false]’,
      inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
      inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
      inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
      inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = const signed char*; _OI = signed char*]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::types::ndarray<T, pS>::copy() const [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/types/ndarray.hpp:863:14,
      inlined from ‘{anonymous}::pythonic::types::ndarray<T, pS> {anonymous}::pythonic::numpy::roll(const {anonymous}::pythonic::types::ndarray<T, pS>&, long int, long int) [with T = signed char; pS = {anonymous}::pythonic::types::pshape<long int>]’ at ../../../../../../tmp/pip-build-env-dyyy7ohz/overlay/lib/python3.12/site-packages/pythran/pythonic/numpy/roll.hpp:75:24:
  /usr/include/c++/13/bits/stl_algobase.h:437:30: error: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ offset [0, 1] is out of the bounds [0, 0] [-Werror=array-bounds=]
    437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
        |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cc1plus: all warnings being treated as errors
  [1005/1139] Compiling C object scipy/signal/_sosfilt.cpython-312-x86_64-linux-gnu.so.p/meson-generated__sosfilt.c.o
  [1006/1139] Compiling C object scipy/signal/_peak_finding_utils.cpython-312-x86_64-linux-gnu.so.p/meson-generated__peak_finding_utils.c.o
  [1007/1139] Compiling C++ object scipy/spatial/distance/_distance_pybind.cpython-312-x86_64-linux-gnu.so.p/src_distance_pybind.cpp.o
  [1008/1139] Compiling C object scipy/signal/_upfirdn_apply.cpython-312-x86_64-linux-gnu.so.p/meson-generated__upfirdn_apply.c.o
  [1009/1139] Compiling C++ object scipy/optimize/_highspy/_core.cpython-312-x86_64-linux-gnu.so.p/.._.._.._subprojects_highs_highs_highs_bindings.cpp.o
  ninja: build stopped: subcommand failed.
```

</details>

#### What does this implement/fix?

Use something other than `np.roll` to avoid the warning.

An alternative would be to add the warning type to the global ignores. Can do that if we keep hitting this, but in the meantime a targeted fix seemed better.

#### Additional information

Not 100% sure the workaround will work but CIs will tell us (on macOS ATM so didn't check directly). If it doesn't, a global warning would work.

#### AI Generation Disclosure

I used Claude Sonnet to look into the issue and iterate (going from a global skip to a targeted workaround).