### PR TITLE
BUG: special: fix pbdv for large arguments

### DIFF
--- a/scipy/special/tests/test_pcf.py
+++ b/scipy/special/tests/test_pcf.py
@@ -22,3 +22,20 @@ def test_pbwa_nan():
     pts = [(-6, -6), (-6, 6), (6, -6), (6, 6)]
     for p in pts:
         assert_equal(sc.pbwa(*p), (np.nan, np.nan))
+
+
+def test_pbdv_near_integer_negative_argument():
+    # Values generated with mpmath 1.3.0 at 80 digits.
+    v = np.nextafter(50.0, 0.0)
+    x = [-np.sqrt(500.0), -v]
+    expected = [
+        [3.1429284557854132e37, -2.7008764338749622e38],
+        [5.6977287669133012e235, -1.3650529001419031e237],
+    ]
+    assert_allclose([sc.pbdv(v, xi) for xi in x], expected, rtol=5e-13)
+
+
+def test_pbdv_large_positive_argument_no_premature_underflow():
+    # Values generated with mpmath 1.3.0 at 80 digits.
+    expected = [7.3587705514938545e-274, -1.8411632169283370e-272]
+    assert_allclose(sc.pbdv(-1.0, 50.0), expected, rtol=5e-13, atol=0)


### PR DESCRIPTION
Depends on scipy/xsf#255.

## Summary

- fix `pbdv` near positive integer orders at large negative arguments by using an accurately evaluated connection formula where the forward recurrence is unstable
- prevent premature underflow when normalizing the backward recurrence for negative orders at large positive arguments
- add mpmath-based regression coverage for the reported values and derivatives

Closes #25814.

## Tests

- `pixi run tests` in XSF: 410 passed
- `pixi run format-dry-error` in XSF
- `pixi run -e test spin test --no-build scipy/special/tests/test_pcf.py`: 4 passed
- `pixi run -e test spin test --no-build -s special`: 8,769 passed

## AI disclosure

I used AI assistance to understand the repository structure and generate an initial draft of the potential fix and regression tests.
The initial drafts of parts of the XSF implementation, `scipy/special/tests/test_pcf.py` were AI-assisted.
I reproduced the reported failures, traced the two numerical root causes, revised the implementation based on my own understanding, verified the reference values against mpmath, and ran the full test and formatting checks.
I reviewed the final code and take responsibility for it.