### PR TITLE
MAINT: linalg: correct zero-size batch dtypes when rules are nonstandard

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1140,7 +1140,7 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
     # (i, i)->(i, i),bool(i) becomes (i, i)->(i, i),(booli).
     # But then we can still separate the two outputs by splitting at ),(.
     # TODO: use regular expression for more efficient, elegant parsing.
-    signature_dtypes = ['int32', 'bool', 'int', 'float', 'complex']
+    signature_dtypes = ['bool', 'int', 'float', 'complex']
     for signature_dtype in signature_dtypes:
         outputs = outputs.replace(f"{signature_dtype}(", f"({signature_dtype}")
     outputs = outputs.lstrip("(").rstrip(")").split("),(")
@@ -1148,9 +1148,8 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
         output_dtype = dtype
         for signature_dtype in signature_dtypes:
             if signature_dtype in output:
-                output_dtypes = {'int32': xp.int32,
-                                 'bool': xp.bool,
-                                 'int': xp.result_type(int(1)),
+                output_dtypes = {'bool': xp.bool,
+                                 'int': xp.result_type(1),
                                  'float': xp.real(xp.asarray(1, dtype=dtype)).dtype,
                                  'complex': xp.result_type(complex(1), dtype)}
                 output_dtype = output_dtypes[signature_dtype]

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1136,12 +1136,29 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
                 letter_to_length[l] = length
 
     results = []
+    # This is a hack to avoid having to rethink the parsing strategy, e.g.
+    # (i, i)->(i, i),bool(i) becomes (i, i)->(i, i),(booli).
+    # But then we can still separate the two outputs by splitting at ),(.
+    # TODO: use regular expression for more efficient, elegant parsing.
+    signature_dtypes = ['int32', 'bool', 'int', 'float', 'complex']
+    for signature_dtype in signature_dtypes:
+        outputs = outputs.replace(f"{signature_dtype}(", f"({signature_dtype}")
     outputs = outputs.lstrip("(").rstrip(")").split("),(")
     for output in outputs:
+        output_dtype = dtype
+        for signature_dtype in signature_dtypes:
+            if signature_dtype in output:
+                output_dtypes = {'int32': xp.int32,
+                                 'bool': xp.bool,
+                                 'int': xp.result_type(int(1)),
+                                 'float': xp.real(xp.asarray(1, dtype=dtype)).dtype,
+                                 'complex': xp.result_type(complex(1), dtype)}
+                output_dtype = output_dtypes[signature_dtype]
+                output = output.replace(signature_dtype, "")
         out_core_shape = tuple([eval(l, letter_to_length)
                                 for l in output.split(',') if l])
         results.append(xp.empty(batch_shape + out_core_shape,
-                                dtype=dtype, device=device))
+                                dtype=output_dtype, device=device))
     return results[0] if len(results) == 1 else tuple(results)
 
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1151,7 +1151,7 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
                 output_dtypes = {'bool': xp.bool,
                                  'int': xp.result_type(1),
                                  'float': xp.real(xp.asarray(1, dtype=dtype,
-                                                  device=device).dtype,
+                                                  device=device)).dtype,
                                  'complex': xp.result_type(complex(1), dtype)}
                 output_dtype = output_dtypes[signature_dtype]
                 output = output.replace(signature_dtype, "")

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1150,7 +1150,8 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
             if signature_dtype in output:
                 output_dtypes = {'bool': xp.bool,
                                  'int': xp.result_type(1),
-                                 'float': xp.real(xp.asarray(1, dtype=dtype)).dtype,
+                                 'float': xp.real(xp.asarray(1, dtype=dtype,
+                                                  device=xp_device(x))).dtype,
                                  'complex': xp.result_type(complex(1), dtype)}
                 output_dtype = output_dtypes[signature_dtype]
                 output = output.replace(signature_dtype, "")

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1151,7 +1151,7 @@ def output_from_signature(arrays, batch_shape, core_shapes, signature):
                 output_dtypes = {'bool': xp.bool,
                                  'int': xp.result_type(1),
                                  'float': xp.real(xp.asarray(1, dtype=dtype,
-                                                  device=xp_device(x))).dtype,
+                                                  device=device).dtype,
                                  'complex': xp.result_type(complex(1), dtype)}
                 output_dtype = output_dtypes[signature_dtype]
                 output = output.replace(signature_dtype, "")

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1469,7 +1469,7 @@ lstsq.default_lapack_driver = 'gelsd'  # pyrefly:ignore[missing-attribute]
 
 
 def _pinv_signature(*args, **kwargs):
-    return "(i,j)->(i,j),()" if kwargs.get('return_rank') else "(i,j)->(i,j)"
+    return "(i,j)->(i,j),int()" if kwargs.get('return_rank') else "(i,j)->(i,j)"
 
 
 @_apply_over_batch(('a', 2), signature=_pinv_signature)
@@ -1706,7 +1706,8 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
 
 
 def _matrix_balance_signature(*args, **kwargs):
-    return "(i,i)->(i,i),(2,i)" if kwargs.get('separate') else "(i,i)->(i,i)"
+    return ("(i,i)->(i,i),(2,i)" if kwargs.get('separate')
+            else "(i,i)->(i,i),(i,i)")
 
 
 @_apply_over_batch(('A', 2), signature=_matrix_balance_signature)

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -36,7 +36,7 @@ cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noe
 # ============================================================================
 
 
-@_apply_over_batch(('a', 2), signature="(i,i)->()")
+@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
 @cython.embedsignature(True)
 def issymmetric(a, atol=None, rtol=None):
     """Check if a square 2D array is symmetric.
@@ -167,7 +167,7 @@ cdef inline bint is_sym_her_real_noncontig_internal(const np_numeric_t[:, :]A) n
     return True
 
 
-@_apply_over_batch(('a', 2), signature="(i,i)->()")
+@_apply_over_batch(('a', 2), signature="(i,i)->bool()")
 @cython.embedsignature(True)
 def ishermitian(a, atol=None, rtol=None):
     """Check if a square 2D array is Hermitian.

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -645,7 +645,7 @@ def _check_select(select, select_range, max_ev, max_len):
 def _eig_banded_signature(a_band, lower=False, eigvals_only=False,
                           overwrite_a_band=False, select='a', select_range=None,
                           max_ev=0, check_finite=True):
-    return "(i,j)->(j,)" if eigvals_only else "(i,j)->(j,),(j,j)"
+    return "(i,j)->float(j,)" if eigvals_only else "(i,j)->float(j,),(j,j)"
 
 
 @_apply_over_batch(('a_band', 2), signature=_eig_banded_signature)
@@ -1051,7 +1051,7 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
                 driver=driver)
 
 
-@_apply_over_batch(('a_band', 2), signature='(i,j)->(j,)')
+@_apply_over_batch(('a_band', 2), signature='(i,j)->float(j,)')
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                    select='a', select_range=None, check_finite=True):
     """

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -12,7 +12,7 @@ from .lapack import get_lapack_funcs, _compute_lwork
 __all__ = ['ldl']
 
 
-@_apply_over_batch(('A', 2), signature="(i,i)->(i,i),(i,i),(i)")
+@_apply_over_batch(('A', 2), signature="(i,i)->(i,i),(i,i),int(i)")
 def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     """ Computes the LDLt or Bunch-Kaufman factorization of a symmetric/
     hermitian matrix.

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -19,7 +19,7 @@ __all__ = ['lu', 'lu_solve', 'lu_factor']
 def _luf_signature(a, *args, **kwargs):
     m, n = a.shape[-2:]
     k = min(m, n)
-    return f"(i,j)->(i,j),int32({k})"
+    return f"(i,j)->(i,j),int({k})"
 
 
 @_apply_over_batch(('a', 2), signature=_luf_signature)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -19,7 +19,7 @@ __all__ = ['lu', 'lu_solve', 'lu_factor']
 def _luf_signature(a, *args, **kwargs):
     m, n = a.shape[-2:]
     k = min(m, n)
-    return f"(i,j)->(i,j),({k})"
+    return f"(i,j)->(i,j),int32({k})"
 
 
 @_apply_over_batch(('a', 2), signature=_luf_signature)

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -341,7 +341,7 @@ def qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
 
 
 @_apply_over_batch(('A', 2), ('B', 2),
-                   signature="(i,i),(i,i)->(i,i),(i,i),(i),(i),(i,i),(i,i)")
+                   signature="(i,i),(i,i)->(i,i),(i,i),complex(i),(i),(i,i),(i,i)")
 def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
           overwrite_b=False, check_finite=True):
     """QZ decomposition for a pair of matrices with reordering.

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -275,7 +275,8 @@ def _castCopy(type, *arrays):
         return cast_arrays
 
 
-@_apply_over_batch(('T', 2), ('Z', 2), signature='(i,i),(i,i)->(i,i),(i,i)')
+@_apply_over_batch(('T', 2), ('Z', 2),
+                   signature='(i,i),(i,i)->complex(i,i),complex(i,i)')
 def rsf2csf(T, Z, check_finite=True):
     """
     Convert real Schur form to complex Schur form.

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -487,13 +487,13 @@ def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
     return Q
 
 
-def _subspace_angles_formula(A, B):
+def _subspace_angles_signature(A, B):
     _, n = A.shape[-2:]
     _, k = B.shape[-2:]
-    return f"(i,j),(i,k)->({min(n,k)},)"
+    return f"(i,j),(i,k)->float({min(n,k)},)"
 
 
-@_apply_over_batch(('A', 2), ('B', 2), signature=_subspace_angles_formula)
+@_apply_over_batch(('A', 2), ('B', 2), signature=_subspace_angles_signature)
 def subspace_angles(A, B):
     r"""
     Compute the subspace angles between two matrices.

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -357,7 +357,7 @@ def expm_frechet_kronform(A, method=None, check_finite=True):
     return np.vstack(cols).T
 
 
-@_apply_over_batch(('A', 2), signature="(i,i)->()")
+@_apply_over_batch(('A', 2), signature="(i,i)->float()")
 def expm_cond(A, check_finite=True):
     """
     Relative condition number of the matrix exponential in the Frobenius norm.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -95,7 +95,7 @@ def _maybe_real(A, B, tol=None):
 # Matrix functions.
 
 
-@_apply_over_batch(('A', 2), signature='(i,i)->(i,i)')
+@_apply_over_batch(('A', 2), signature='(i,i)->complex(i,i)')
 def fractional_matrix_power(A, t):
     """
     Compute the fractional power of a matrix.

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -15,7 +15,7 @@ __all__ = ['orthogonal_procrustes']
     jax_jit=False,
     skip_backends=[("dask.array", "full_matrices=True is not supported by dask")],
 )
-@_apply_over_batch(('A', 2), ('B', 2), signature="(i,j),(i,j)->(j,j),()")
+@_apply_over_batch(('A', 2), ('B', 2), signature="(i,j),(i,j)->(j,j),float()")
 def orthogonal_procrustes(A, B, check_finite=True):
     """
     Compute the matrix solution of the orthogonal (or unitary) Procrustes problem.

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -30,7 +30,8 @@ class TestBatch:
     # Test batch support for most linalg functions
 
     def batch_test(self, fun, arrays, *, core_dim=2, n_out=1, kwargs=None, dtype=None,
-                   broadcast=True, check_kwargs=True, test_zero_size=True):
+                   broadcast=True, check_kwargs=True, test_zero_size_shape=True,
+                   test_zero_size_dtype=True):
         # Check that all outputs of batched call `fun(A, **kwargs)` are the same
         # as if we loop over the separate vectors/matrices in `A`. Also check
         # that `fun` accepts `A` by position or keyword and that results are
@@ -76,14 +77,15 @@ class TestBatch:
         n_batch = len(batch_shape)
         zero_size_in = [np.empty((0,) + array.shape[n_batch:], dtype=array.dtype)
                         for array in arrays]
-        if test_zero_size is True:
+        if test_zero_size_shape is True:
             zero_size_out = fun(*zero_size_in, **kwargs)
             zero_size_out = (zero_size_out,) if n_out == 1 else zero_size_out
             for res_k, ref_k in zip(zero_size_out, ref):
                 ref_k = np.empty((0,) + ref_k.shape, dtype=ref_k.dtype)
                 np.testing.assert_equal(res_k, ref_k)
-                # assert res_k.dtype == ref_k.dtype
-        elif test_zero_size is False:
+                if test_zero_size_dtype:
+                    assert res_k.dtype == ref_k.dtype
+        elif test_zero_size_shape is False:
             fun_name = fun.__name__.lstrip('_')
             message = f"`{fun_name}` does not support zero-size batches."
             with pytest.raises(ValueError, match=message):
@@ -95,7 +97,7 @@ class TestBatch:
     def test_expm_cond(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = rng.random((5, 3, 4, 4)).astype(dtype)
-        self.batch_test(linalg.expm_cond, A)
+        self.batch_test(linalg.expm_cond, A, test_zero_size_dtype=False)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_issymmetric(self, dtype):
@@ -156,7 +158,8 @@ class TestBatch:
     def test_fractional_matrix_power(self, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
-        res1 = self.batch_test(linalg.fractional_matrix_power, A, kwargs={'t':1.5})
+        res1 = self.batch_test(linalg.fractional_matrix_power, A, kwargs={'t':1.5},
+                               test_zero_size_dtype=False)
         # test that `t` can be passed by position
         res2 = linalg.fractional_matrix_power(A, 1.5)
         np.testing.assert_equal(res1, res2)
@@ -184,7 +187,8 @@ class TestBatch:
     def test_matrix_balance(self, dtype, kwargs):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.matrix_balance, A, n_out=2, kwargs=kwargs)
+        self.batch_test(linalg.matrix_balance, A, n_out=2, kwargs=kwargs,
+                        test_zero_size_dtype=False)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_bandwidth(self, dtype):
@@ -378,7 +382,8 @@ class TestBatch:
         args = (A, B) if include_B else (A,)
         kwargs = dict(left=left, right=right, homogeneous_eigvals=homogeneous_eigvals)
         n_out = 1 + left + right
-        self.batch_test(linalg.eig, args, n_out=n_out, kwargs=kwargs)
+        self.batch_test(linalg.eig, args, n_out=n_out, kwargs=kwargs,
+                        test_zero_size_dtype=False)
 
     @pytest.mark.parametrize('two_in', [False, True])
     @pytest.mark.parametrize('fun_n_nout', [(linalg.eigh, 1), (linalg.eigh, 2),
@@ -402,7 +407,8 @@ class TestBatch:
         E = get_random((2, 1, 4, 4), dtype=dtype, rng=rng)
         n_out = 2 if compute_expm else 1
         self.batch_test(linalg.expm_frechet, (A, E), n_out=n_out,
-                        kwargs=dict(compute_expm=compute_expm))
+                        kwargs=dict(compute_expm=compute_expm),
+                        test_zero_size_dtype=False)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_subspace_angles(self, dtype):
@@ -435,7 +441,9 @@ class TestBatch:
         fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(fun, (A, B), n_out=n_out)
+        test_zero_size_dtype = False if fun == linalg.solve_discrete_lyapunov else True
+        self.batch_test(fun, (A, B), n_out=n_out,
+                        test_zero_size_dtype=test_zero_size_dtype)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_cossin(self, dtype):
@@ -694,7 +702,8 @@ class TestBatch:
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
         self.batch_test(linalg.clarkson_woodruff_transform, A,
-                        kwargs=dict(sketch_size=3, rng=311224))
+                        kwargs=dict(sketch_size=3, rng=311224),
+                        test_zero_size_dtype=False)
 
     def test_clarkson_woodruff_transform_sparse(self):
         rng = np.random.default_rng(8342310302941288912051)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -343,7 +343,8 @@ class TestBatch:
     def test_schur_lu(self, fun, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(fun, A, n_out=2)
+        test_zero_size_dtype = fun != linalg.lu_factor
+        self.batch_test(fun, A, n_out=2, test_zero_size_dtype=test_zero_size_dtype)
 
     @pytest.mark.parametrize('calc_q', [False, True])
     @pytest.mark.parametrize('dtype', floating)
@@ -441,7 +442,7 @@ class TestBatch:
         fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
-        test_zero_size_dtype = False if fun == linalg.solve_discrete_lyapunov else True
+        test_zero_size_dtype = fun != linalg.solve_discrete_lyapunov
         self.batch_test(fun, (A, B), n_out=n_out,
                         test_zero_size_dtype=test_zero_size_dtype)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-24148

#### What does this implement/fix?
gh-24158, gh-25940, and gh-25946 corrected the shape of linalg function output arrays when inputs had zero size. It assumed that the output dtype would be the result dtype of the input dtypes, but this is not always the case. This PR extends the NEP 5 syntax to specify nonstandard output dtypes.

#### Additional information
I've added a `test_zero_size_dtype` keyword to allow skipping the dtype test for functions affected by gh-25964.

#### AI Generation Disclosure
No AI