### PR TITLE
BLD/CI: remove openblas requirements files, add them as dependency groups in pyproject.toml

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -432,9 +432,8 @@ jobs:
       - name: Install Python packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --group build --group dev-cli
+          python -m pip install --group build --group dev-cli --group openblas32
           python -m pip install --pre --upgrade --group coverage
-          python -m pip install -r requirements/openblas.txt
           python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Set up ccache
@@ -491,11 +490,10 @@ jobs:
             python3.12 -m venv test
             source test/bin/activate
             python -m pip install --upgrade pip
-            python -m pip install --group build --group dev-cli --group test-core
+            python -m pip install --group build --group dev-cli --group test-core --group openblas32
             # we want `mpmath` but cannot install `gmpy2` on 32-bit,
             # so cannot use `--group test-mp`
             python -m pip install mpmath
-            python -m pip install -r requirements/openblas.txt
             python -m pip install numpy==2.0.0 -Cbuild-dir=numpy-builddir
             python -c "import numpy as np; np.show_config()"
             spin build --with-scipy-openblas=32
@@ -604,8 +602,7 @@ jobs:
 
       - name: Setup Python build/test deps
         run: |
-          python -m pip install --group build --group test-core
-          python -m pip install -r requirements/openblas.txt
+          python -m pip install --group build --group test-core --group openblas32
           python -m pip install build
           # Remove `meson` from environment
           python -m pip uninstall meson --yes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,8 +81,7 @@ jobs:
       - name: pip-packages
         run: |
           # 2.0.0 is currently our oldest supported NumPy version
-          python -m pip install numpy==2.0.0 --group build --group dev-cli --group test-core
-          python -m pip install -r requirements/openblas.txt
+          python -m pip install numpy==2.0.0 --group build --group dev-cli --group test-core --group openblas32
           python -m pip install -r requirements/pkgconf.txt
 
       - name: Build
@@ -123,8 +122,7 @@ jobs:
       - name: pip-packages
         run: |
           # `numpy<2.4.3` pin is due to np.linalg.solve crash, see gh-24774
-          python -m pip install "numpy<2.4.3" --group build --group dev-cli --group test-core
-          python -m pip install -r requirements/openblas.txt
+          python -m pip install "numpy<2.4.3" --group build --group dev-cli --group test-core --group openblas32
           python -m pip install -r requirements/pkgconf.txt
 
       - name: Build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,12 @@ coverage = [
     { include-group = "test" },  # includes all optional test and runtime deps for maximum coverage
     "pytest-cov",
 ]
-
+openblas32 = [
+    scipy-openblas32==0.3.34.0.0
+]
+openblas64 = [
+    scipy-openblas64==0.3.34.0.0
+]
 bench = [
     # 0.6.6 regressed per-benchmark overhead ~7x, which pushes the CircleCI
     # benchmark job past its time limit; revisit when that is fixed upstream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,10 @@ coverage = [
     "pytest-cov",
 ]
 openblas32 = [
-    scipy-openblas32==0.3.34.0.0
+    "scipy-openblas32==0.3.34.0.0"
 ]
 openblas64 = [
-    scipy-openblas64==0.3.34.0.0
+    "scipy-openblas64==0.3.34.0.0"
 ]
 bench = [
     # 0.6.6 regressed per-benchmark overhead ~7x, which pushes the CircleCI

--- a/requirements/openblas.txt
+++ b/requirements/openblas.txt
@@ -1,1 +1,0 @@
-scipy-openblas32==0.3.34.0.0

--- a/requirements/openblas64.txt
+++ b/requirements/openblas64.txt
@@ -1,1 +1,0 @@
-scipy-openblas64==0.3.34.0.0

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -30,7 +30,7 @@ if [[ "$INSTALL_OPENBLAS" = "true" ]] ; then
     echo pkgconf_path is $pkgconf_path, OPENBLAS is ${OPENBLAS}
     rm -rf $pkgconf_path
     mkdir -p $pkgconf_path
-    python -m pip install -r $PROJECT_DIR/requirements/openblas.txt
+    python -m pip install --group openblas32
     python -c "import scipy_${OPENBLAS}; print(scipy_${OPENBLAS}.get_pkg_config())" > $pkgconf_path/scipy-openblas.pc
 
     # Copy scipy-openblas DLL's to a fixed location so we can point delvewheel


### PR DESCRIPTION
Removes openblas requirements files, adds them as a dependency group in pyproject.toml

@mattip, thoughts?

#### What does this implement/fix?
A step towards dependency pinning for scipy/scipy-release. It makes it easier to construct a lock-file if this information is in the pyproject.toml file. 

#### AI Generation Disclosure
No AI tools used.