### PR TITLE
ENH: update boost to version 1.92

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -224,7 +224,7 @@ elif use_system_libraries.contains('auto')
   auto_system_libraries = true
 endif
 
-boost_version = '1.91.0'
+boost_version = '1.92.0'
 if all_system_libraries or use_system_libraries.contains('boost.math')
   boost_math_dep = dependency('boost', version : boost_version)
 elif auto_system_libraries

--- a/pixi.lock
+++ b/pixi.lock
@@ -9147,7 +9147,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm19_1_h6922315_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libamd-3.3.3-h5087772_7100102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-4_h51639a9_openblas.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.91.0-hce30654_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.92.0-hce30654_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbtf-2.3.2-h99b4a89_7100102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcamd-3.3.3-h99b4a89_7100102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-4_hb0561ab_openblas.conda
@@ -35328,14 +35328,15 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 18162
   timestamp: 1786058887392
-- conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.91.0-hce30654_0.conda
-  sha256: 3fee05bc086ef520e1f05ce4b9be48971ee504d9a78c433cd98e8d9b39316f20
-  md5: 7c364719d869c7e3e313b2bb618c1bec
+- conda: https://prefix.dev/conda-forge/osx-arm64/libboost-headers-1.92.0-hce30654_0.conda
+  sha256: 71a6bd4edd218128eb9d8bc9a9735f3ee7a655e673e2d961437527214ae26087
+  md5: ccded7d0f59edaa5a63e0a65efaa608a
   constrains:
   - boost-cpp <0.0a0
   license: BSL-1.0
-  size: 15154734
-  timestamp: 1776908824946
+  run_exports: {}
+  size: 15288467
+  timestamp: 1787650262259
 - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
   sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
   md5: 006e7ddd8a110771134fcc4e1e3a6ffa

--- a/pixi.toml
+++ b/pixi.toml
@@ -856,7 +856,7 @@ scikit-sparse = "*"
 
 [feature.system-libs.dependencies]
 # Pinned to match versions in `meson.build`
-libboost-headers = "==1.91.0"
+libboost-headers = "==1.92.0"
 qhull = "==2020.2"
 
 [feature.system-libs.activation.env]

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1810,6 +1810,18 @@ class TestBetaInc:
         res = special.betainc(a, b, x)
         assert_allclose(res, reference, rtol=rtol)
 
+    def test_gh24566(self):
+        # test that betainc does not return NaN for these specific inputs
+        # As neither Mathematica nor mpmath are able to compute the result,
+        # we simply test that the result is not NaN
+        # Boost contains a more elaborate test that checks the monotonicity
+        # in this region, see
+        # https://github.com/boostorg/math/blob/64a8d75df2d570ab5eddde4bc383c66675d68611/test/test_ibeta.hpp#L492
+        value = 0.010000000000005001
+        a = 3.1622776601699636e16
+        b = 3.130654883566682e18
+        assert not np.isnan(special.betainc(a, b, value))
+
 
 class TestCombinatorics:
     def test_comb(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -460,6 +460,17 @@ class TestBinom:
         res = stats.binom.pmf(3, 2000, 0.999)
         assert_allclose(res, 0, atol=1e-16)
 
+    def test_gh22622(self):
+        # check that gh-22622 is resolved:
+        # for extreme values of n and p the survival and inverse survival
+        # functions most pass a roundtrip test
+        k = 16
+        n = 10000
+        p = 4e-5
+        sf_res = stats.binom.sf(k, n, p)
+        isf_res = stats.binom.isf(sf_res, n, p)
+        assert_allclose(isf_res, k, rtol=1e-15)
+
 
 class TestArcsine:
 
@@ -3467,6 +3478,11 @@ class TestInvgauss:
         assert_allclose(dist.sf(x), dist0.sf(x))
         assert_allclose(dist.ppf(p), dist0.ppf(p))
         assert_allclose(dist.isf(p), dist0.isf(p))
+
+    def test_gh25096(self):
+        # Regression test for gh-25096: invgauss.ppf should not raise a warning
+        # for the given inputs
+        stats.invgauss.ppf(0.97969, 66.99652081)
 
 
 class TestLandau:

--- a/subprojects/boost_math/meson.build
+++ b/subprojects/boost_math/meson.build
@@ -1,5 +1,5 @@
 project('boost-math',
-  version : '1.91.0',
+  version : '1.92.0',
   meson_version: '>= 1.5.0',
 )
 


### PR DESCRIPTION
#### Reference issue
Closes #24566
Closes #22622
Closes #25096 
Towards #21966

#### What does this implement/fix?
Updates boost to version 1.92.

#### Additional information
Marking this as draft until boost 1.92 is available in conda forge (see https://github.com/conda-forge/boost-feedstock/pull/267). Until then all pixi jobs will fail.The second commit contains a typo, it refers to the wrong issue, will clean that up once conda forge catches up.

#### AI Generation Disclosure
No AI.
