### PR TITLE
BLD, MAINT: pythran bounds for `1.18.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ requires = [
     # (3.0.4 works at time of writing)
     "pybind11>=2.13.2,<3.1.0",
     # Pre-emptive upper bound on pythran
-    # (0.18.1 works at time of writing)
-    "pythran>=0.18.1,<0.19.0",
+    # (0.19.0 works at time of writing)
+    "pythran>=0.18.1,<0.20.0; python_version < '3.15'",
+    "pythran>=0.19.0,<0.20.0; python_version >= '3.15'",
     # NOTE: need numpy>=2.1.3 for free-threaded CPython support
     "numpy>=2.0.0,<2.8",
 ]


### PR DESCRIPTION
* For Python `3.15` support on the release branch/wheel builds, we need to adjust our dependency pinning for `pythran`. See related failures at: https://github.com/scipy/scipy-release/pull/38

#### AI Generation Disclosure
No AI tools used
