### PR TITLE
ENH: stats.anderson: add dist='gauss' for the standard normal

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2255,6 +2255,9 @@ def _swilk(y, *, xp):
 
 # Values from [8]
 _Avals_norm = array([0.561, 0.631, 0.752, 0.873, 1.035])
+# Case 0: mean and variance known, so no parameters are estimated. Quantiles of
+# the asymptotic A^2 distribution, from [9].
+_Avals_gauss = array([1.62123854, 1.93295783, 2.49236716, 3.07746418, 3.87812502])
 _Avals_expon = array([0.916, 1.062, 1.321, 1.591, 1.959])
 # From Stephens, M A, "Goodness of Fit for the Extreme Value Distribution",
 #             Biometrika, Vol. 64, Issue 3, Dec. 1977, pp 583-588.
@@ -2374,17 +2377,22 @@ def anderson(x, dist='norm', *, method=None):
     drawn from a population that follows a particular distribution.
     For the Anderson-Darling test, the critical values depend on
     which distribution is being tested against.  This function works
-    for normal, exponential, logistic, weibull_min, or Gumbel (Extreme Value
-    Type I) distributions.
+    for normal, standard normal, exponential, logistic, weibull_min, or Gumbel
+    (Extreme Value Type I) distributions.
 
     Parameters
     ----------
     x : array_like
         Array of sample data.
-    dist : {'norm', 'expon', 'logistic', 'gumbel', 'gumbel_l', 'gumbel_r', 'extreme1', 'weibull_min'}, optional
+    dist : {'norm', 'gauss', 'expon', 'logistic', 'gumbel', 'gumbel_l', 'gumbel_r', 'extreme1', 'weibull_min'}, optional
         The type of distribution to test against.  The default is 'norm'.
         The names 'extreme1', 'gumbel_l' and 'gumbel' are synonyms for the
-        same distribution.
+        same distribution.  'norm' estimates the mean and standard deviation
+        from the data; 'gauss' tests against the standard normal, holding the
+        mean at 0 and the standard deviation at 1.
+
+        .. versionadded:: 2.0.0
+            The ``'gauss'`` option.
     method : str or instance of `MonteCarloMethod`
         Defines the method used to compute the p-value.
         If `method` is ``"interpolated"``, the p-value is interpolated from
@@ -2444,7 +2452,7 @@ def anderson(x, dist='norm', *, method=None):
     Critical values provided when `method` is unspecified are for the following
     significance levels:
 
-    normal/exponential
+    normal/standard normal/exponential
         15%, 10%, 5%, 2.5%, 1%
     logistic
         25%, 10%, 5%, 2.5%, 1%, 0.5%
@@ -2493,6 +2501,9 @@ def anderson(x, dist='norm', *, method=None):
            In: Goodness-of-Fit Techniques. Ed. by Ralph B. D'Agostino and
            Michael A. Stephens. New York: Marcel Dekker, pp. 122-141. ISBN:
            0-8247-7487-6.
+    .. [9] Marsaglia, G., & Marsaglia, J. (2004). Evaluating the
+           Anderson-Darling Distribution. Journal of Statistical Software,
+           9(2), 1-5. :doi:`10.18637/jss.v009.i02`
 
     Examples
     --------
@@ -2516,7 +2527,7 @@ def anderson(x, dist='norm', *, method=None):
     dist = dist.lower()
     if dist in {'extreme1', 'gumbel'}:
         dist = 'gumbel_l'
-    dists = {'norm', 'expon', 'gumbel_l',
+    dists = {'norm', 'gauss', 'expon', 'gumbel_l',
              'gumbel_r', 'logistic', 'weibull_min'}
 
     if dist not in dists:
@@ -2532,6 +2543,13 @@ def anderson(x, dist='norm', *, method=None):
         logsf = distributions.norm.logsf(w)
         sig = array([15, 10, 5, 2.5, 1])
         critical = around(_Avals_norm / (1.0 + 0.75/N + 2.25/N/N), 3)
+    elif dist == 'gauss':
+        w = y
+        fit_params = 0.0, 1.0
+        logcdf = distributions.norm.logcdf(w)
+        logsf = distributions.norm.logsf(w)
+        sig = array([15, 10, 5, 2.5, 1])
+        critical = _Avals_gauss
     elif dist == 'expon':
         w = y / xbar
         fit_params = 0, xbar
@@ -2599,7 +2617,8 @@ def anderson(x, dist='norm', *, method=None):
     message = '`anderson` successfully fit the distribution to the data.'
     res = optimize.OptimizeResult(success=True, message=message)
     res.x = np.array(fit_params)
-    fit_result = FitResult(getattr(distributions, dist), y,
+    fit_dist = 'norm' if dist == 'gauss' else dist
+    fit_result = FitResult(getattr(distributions, fit_dist), y,
                            discrete=False, res=res)
 
     if method is None:
@@ -2630,6 +2649,8 @@ def _anderson_simulate_pvalue(x, dist, method):
     method['n_mc_samples'] = method.pop('n_resamples')
 
     kwargs= {'known_params': {'loc': 0}} if dist == 'expon' else {}
+    if dist == 'gauss':
+        kwargs, dist = {'known_params': {'loc': 0, 'scale': 1}}, 'norm'
     dist = getattr(stats, dist)
     res = stats.goodness_of_fit(dist, x, statistic='ad', **kwargs, **method)
     return res.pvalue

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -277,6 +277,33 @@ class TestAnderson:
         #   3.208057
         assert_allclose(A, 3.208057)
 
+    def test_gauss(self):
+        # dist='gauss' holds the mean at 0 and the standard deviation at 1, so
+        # standardising a sample by its own mean and standard deviation must
+        # reproduce the statistic dist='norm' computes by fitting them.
+        rs = RandomState(1234567890)
+        for scale, loc in [(1.0, 0.0), (2.5, -1.0), (0.4, 3.0)]:
+            x = scale * rs.standard_normal(size=200) + loc
+            z = (x - x.mean()) / x.std(ddof=1)
+            assert_allclose(stats.anderson(z, 'gauss').statistic,
+                            stats.anderson(x, 'norm').statistic)
+
+        # Fixing the scale makes the test sensitive to it, unlike 'norm'.
+        y = 1.5 * rs.standard_normal(size=1000)
+        assert stats.anderson(y, 'gauss').statistic > 10
+        assert stats.anderson(y, 'norm').statistic < 1
+
+        # No parameters are estimated, so the critical values do not depend on
+        # the sample size and the fitted parameters are exactly (0, 1).
+        res_small = stats.anderson(rs.standard_normal(size=20), 'gauss')
+        res_large = stats.anderson(rs.standard_normal(size=2000), 'gauss')
+        assert_allclose(res_small.critical_values, res_large.critical_values)
+        assert_allclose(res_small.critical_values,
+                        [1.62123854, 1.93295783, 2.49236716,
+                         3.07746418, 3.87812502])
+        assert_array_equal(res_small.significance_level, [15, 10, 5, 2.5, 1])
+        assert_allclose(res_small.fit_result.params, (0, 1))
+
     def test_expon(self):
         rs = RandomState(1234567890)
         x1 = rs.standard_exponential(size=50)


### PR DESCRIPTION

#### What does this implement/fix?
Implements a standard normal or Gaussian distribution in the Anderson-Darling statistic.

#### Additional information
`dist='norm'` estimates the mean and standard deviation from the sample, so it cannot test whether data follow N(0, 1) specifically. `dist='gauss'` holds them at 0 and 1 and uses the case-0 critical values, which apply when no parameters are fitted, taken from Marsaglia & Marsaglia (2004).

#### AI Generation Disclosure
Claude Opus 5 was used to review, write the required `test_gauss()` function covering this added feature, and check this PR against the PR checklist. The checklist review added the `.. versionadded:: 2.0.0` text in a doc string
