### PR TITLE
DOC: link XSF roadmap from special roadmap

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -411,6 +411,10 @@ math implement by a few of the metrics.
 
 special
 ```````
+Development of many special function implementations takes place in the
+`XSF project <https://github.com/scipy/xsf>`__. See the
+`XSF roadmap <https://github.com/scipy/xsf/issues/220>`__ for planned work.
+
 Though there are still a lot of functions that need improvements in precision,
 probably the only show-stoppers are hypergeometric functions, parabolic cylinder
 functions, and spheroidal wave functions. Three possible ways to handle this:


### PR DESCRIPTION
#### Reference issue

Closes gh-25820.

#### What does this implement/fix?

Links the XSF project and its roadmap from the `scipy.special` section of SciPy's detailed roadmap so contributors can find the current implementation plans.

#### Additional information

Validation performed:

- `python3 tools/linting/lint.py --diff-against upstream/main`
- `rstcheck --report-level WARNING doc/source/dev/roadmap-detailed.rst`
- `git diff --check`
- Both added links return successful HTTP responses.

#### AI Generation Disclosure

OpenAI Codex was used to locate the relevant roadmap section, draft the four-line documentation addition, and run validation. The contributor reviewed the final text and link targets.
