### PR TITLE
REL, MAINT: prepare for SciPy 1.18.2

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.18.2-notes
    release/1.18.1-notes
    release/1.18.0-notes
    release/1.17.1-notes

--- a/doc/source/release/1.18.2-notes.rst
+++ b/doc/source/release/1.18.2-notes.rst
@@ -1,0 +1,23 @@
+==========================
+SciPy 1.18.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.18.2 is a bug-fix release with no new features
+compared to 1.18.1.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+Issues closed for 1.18.2
+------------------------
+
+
+
+Pull requests for 1.18.2
+------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.18.1"
+version = "1.18.2.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Prepare for SciPy `1.18.2`.

* In related news, the backport label has been cleaned out, the `1.18.1` milestone closed, and the `1.18.2` milestone opened just in case.

[docs only]

#### AI Generation Disclosure
No AI tools used
