### PR TITLE
BUG: sparse: fix broadcast-assigning a lower-dim sparse array into higher-dim COO

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1544,8 +1544,8 @@ def _get_sparse_data_and_coords(x, new_shape, dtype):
     if len_diff > 0:
         # prepend ones to shape of x to match ndim
         x_shape = [1] * len_diff + list(x_shape)
-        coord_zeros = np.zeroslike(x_coords[0])
-        x_coords = tuple([coord_zeros] * len_diff + x_coords)
+        coord_zeros = np.zeros_like(x_coords[0])
+        x_coords = [coord_zeros] * len_diff + x_coords
     # taking away axes (squeezing) is not part of broadcasting, but long
     # spmatrix history of using 2d vectors in 1d space, so we manually
     # squeeze the front and back axes here to be compatible

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1202,6 +1202,29 @@ def test_newaxis_set():
     assert_equal(A.toarray(), D)
 
 
+def test_setitem_sparse_rhs_broadcast_prepend_dim():
+    # gh-25965: assigning a lower-dimensional *sparse* array into a
+    # higher-dimensional target must broadcast by prepending leading axes.
+    # This path previously raised AttributeError ('np.zeroslike' typo) and,
+    # once that was fixed, TypeError from item-assigning a tuple.
+    for target_shape, src in [
+        ((2, 3), [1.0, 0.0, 2.0]),      # (3,) -> (2, 3), prepend one axis
+        ((2, 2, 3), [5.0, 0.0, 7.0]),   # (3,) -> (2, 2, 3), prepend two axes
+        ((3, 4, 5), np.arange(5.0)),    # (5,) -> (3, 4, 5), prepend two axes
+    ]:
+        src = np.asarray(src, dtype=float)
+        A = coo_array(target_shape, dtype=float)
+        A[...] = coo_array(src)
+        assert_equal(A.toarray(), np.broadcast_to(src, target_shape))
+
+    # partial slice with a sparse RHS broadcast over a prepended axis
+    A = coo_array((3, 3), dtype=float)
+    D = np.zeros((3, 3))
+    A[1:3, :] = coo_array(np.array([9.0, 0.0, 8.0]))
+    D[1:3, :] = np.array([9.0, 0.0, 8.0])
+    assert_equal(A.toarray(), D)
+
+
 def test_1d_coo_set():
     D = np.arange(9)
     A = coo_array(D)

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1208,9 +1208,9 @@ def test_setitem_sparse_rhs_broadcast_prepend_dim():
     # This path previously raised AttributeError ('np.zeroslike' typo) and,
     # once that was fixed, TypeError from item-assigning a tuple.
     for target_shape, src in [
-        ((2, 3), [1.0, 0.0, 2.0]),      # (3,) -> (2, 3), prepend one axis
-        ((2, 2, 3), [5.0, 0.0, 7.0]),   # (3,) -> (2, 2, 3), prepend two axes
-        ((3, 4, 5), np.arange(5.0)),    # (5,) -> (3, 4, 5), prepend two axes
+        ((2, 3), [1, 0, 2]),      # (3,) -> (2, 3), prepend one axis
+        ((2, 2, 3), [5, 0, 7]),   # (3,) -> (2, 2, 3), prepend two axes
+        ((3, 4, 5), np.arange(5)),    # (5,) -> (3, 4, 5), prepend two axes
     ]:
         src = np.asarray(src, dtype=float)
         A = coo_array(target_shape, dtype=float)
@@ -1220,9 +1220,12 @@ def test_setitem_sparse_rhs_broadcast_prepend_dim():
     # partial slice with a sparse RHS broadcast over a prepended axis
     A = coo_array((3, 3), dtype=float)
     D = np.zeros((3, 3))
-    A[1:3, :] = coo_array(np.array([9.0, 0.0, 8.0]))
-    D[1:3, :] = np.array([9.0, 0.0, 8.0])
+    A[1:3, :] = coo_array(np.array([9, 0, 8]))
+    D[1:3, :] = np.array([9, 0, 8])
+    # match numpy's broadcast result (moving target) ...
     assert_equal(A.toarray(), D)
+    # ... and a ground-truth check with the expected values written out
+    assert_equal(A.toarray(), [[0, 0, 0], [9, 0, 8], [9, 0, 8]])
 
 
 def test_1d_coo_set():


### PR DESCRIPTION
`coo_array.__setitem__` broadcasts a sparse right-hand side to the target region via `_get_sparse_data_and_coords`. When the RHS has fewer dimensions than the target (leading axes need prepending, `len_diff > 0`), two bugs on that code path made it always raise:

- `np.zeroslike` is a typo for `np.zeros_like`, raising `AttributeError`.
- After that is fixed, `x_coords` was rebuilt as a `tuple`, but the broadcasting loop below item-assigns `x_coords[i] = ...`, which raises `TypeError` on a tuple.

Both are fixed so sparse-RHS broadcast assignment with prepended axes works, matching NumPy broadcasting semantics. Adds a regression test covering (3,)→(2,3), (3,)→(2,2,3), (5,)→(3,4,5), and a partial-slice case.

Fixes #25965.

---
Disclosure: I used an AI tool to help investigate and draft this change. I reviewed, ran, and understand it.