### PR TITLE
BUG: fix zeros_like typo in sparse COO assignment

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1544,7 +1544,7 @@ def _get_sparse_data_and_coords(x, new_shape, dtype):
     if len_diff > 0:
         # prepend ones to shape of x to match ndim
         x_shape = [1] * len_diff + list(x_shape)
-        coord_zeros = np.zeroslike(x_coords[0])
+        coord_zeros = np.zeros_like(x_coords[0])
         x_coords = tuple([coord_zeros] * len_diff + x_coords)
     # taking away axes (squeezing) is not part of broadcasting, but long
     # spmatrix history of using 2d vectors in 1d space, so we manually

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1202,6 +1202,15 @@ def test_newaxis_set():
     assert_equal(A.toarray(), D)
 
 
+def test_nd_coo_set_sparse_broadcast():
+    A = coo_array((2, 3, 3), dtype=int)
+    x = coo_array([1, 0, 2])
+
+    A[...] = x
+
+    assert_equal(A.toarray(), np.broadcast_to(x.toarray(), A.shape))
+
+
 def test_1d_coo_set():
     D = np.arange(9)
     A = coo_array(D)


### PR DESCRIPTION
Fixes #25965.

Correct `np.zeroslike` to `np.zeros_like` in the sparse COO assignment path and add a regression test covering low-dimensional COO to higher-dimensional COO broadcasting assignment.

Validation:
- `git diff --check` passed
- `py_compile` passed
- The targeted pytest suite could not be run in the preparation environment because `pytest` and `numpy` were unavailable; the code and test changes are intentionally minimal.
