### PR TITLE
MAINT: fft: `fftfreq`/`rfftfreq` `device` argument supported by numpy >= 2.0.0

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -190,13 +190,9 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
 
     """
     xp = np if xp is None else xp
-    # numpy does not yet support the `device` keyword
-    # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
-    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+    if hasattr(xp, 'fft'):
         return xp.fft.fftfreq(n, d=d, device=device)
-    if device is not None:
-        raise ValueError('device parameter is not supported for input array type')
-    return np.fft.fftfreq(n, d=d)
+    return np.fft.fftfreq(n, d=d, device=device)
 
 
 @xp_capabilities()
@@ -250,13 +246,9 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
 
     """
     xp = np if xp is None else xp
-    # numpy does not yet support the `device` keyword
-    # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
-    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+    if hasattr(xp, 'fft'):
         return xp.fft.rfftfreq(n, d=d, device=device)
-    if device is not None:
-        raise ValueError('device parameter is not supported for input array type')
-    return np.fft.rfftfreq(n, d=d)
+    return np.fft.rfftfreq(n, d=d, device=device)
 
 
 @xp_capabilities()


### PR DESCRIPTION
#### Reference issue

None

#### What does this implement/fix?

Passes `device` to `numpy.fft.fftfreq` & `numpy.fft.rfftfreq` which is available in numpy >= 2.0.0 which is now the minimum supported numpy version.

#### Additional information

Allows code like `scipy.fft.fftfreq(1, device="cpu")` which would previously have raised an error.

The current tests don't catch this as the `xp` argument is only tested with `scipy._external.array_api_compat.numpy` and `array_api_strict` not `None` or `numpy`.

#### AI Generation Disclosure

No AI used.
