### PR TITLE
BUG: signal: firwin_2d ignored pass_zero and scale

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1476,7 +1476,7 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
     ------
     ValueError
         - If `hsize` and `window` are not 2-element tuples or lists.
-        - If `cutoff` is None when `circular` is True.
+        - If `fc` is None.
         - If `cutoff` is outside the range [0, `fs`/2] and `circular` is ``False``.
         - If any of the elements in `window` are not recognized.
     RuntimeError
@@ -1543,7 +1543,8 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
 
         n_r = max(hsize[0], hsize[1]) * 8  # oversample 1d window by factor 8
 
-        win_r = firwin(n_r, cutoff=fc, window=window, fs=fs)
+        win_r = firwin(n_r, cutoff=fc, window=window, fs=fs,
+                       pass_zero=pass_zero, scale=scale)
 
         f1, f2 = np.meshgrid(np.linspace(-1, 1, hsize[0]), np.linspace(-1, 1, hsize[1]))
         r = np.sqrt(f1**2 + f2**2)
@@ -1551,10 +1552,16 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
         win_2d = np.interp(r, np.linspace(0, 1, n_r), win_r)
         return win_2d
 
+    if fc is None:
+        raise ValueError("Cutoff frequency `fc` must be provided when "
+                         "`circular` is False")
+
     if len(window) != 2:
         raise ValueError("window must be a 2-element tuple or list")
 
-    row_filter = firwin(hsize[0], cutoff=fc, window=window[0], fs=fs)
-    col_filter = firwin(hsize[1], cutoff=fc, window=window[1], fs=fs)
+    row_filter = firwin(hsize[0], cutoff=fc, window=window[0], fs=fs,
+                        pass_zero=pass_zero, scale=scale)
+    col_filter = firwin(hsize[1], cutoff=fc, window=window[1], fs=fs,
+                        pass_zero=pass_zero, scale=scale)
 
     return np.outer(row_filter, col_filter)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -796,6 +796,31 @@ class Testfirwin_2d:
                            match="window must be a 2-element tuple or list"):
             firwin_2d((51, 51), window="invalid_window", fc=0.5)
 
+        with pytest.raises(ValueError, match="`fc` must be provided"):
+            firwin_2d((11, 11), window=("hamming", "hamming"))
+
+    def test_pass_zero_and_scale_forwarded(self):
+        # Regression: these kwargs were documented as passed to firwin but ignored.
+        # https://github.com/scipy/scipy/issues/25986
+        kw = dict(hsize=(11, 11), window=("hamming", "hamming"), fc=0.3, fs=2)
+        base = firwin_2d(**kw)
+
+        hp = firwin_2d(**kw, pass_zero=False)
+        assert not np.allclose(hp, base)
+        expected_hp = np.outer(
+            firwin(11, cutoff=0.3, window="hamming", fs=2, pass_zero=False),
+            firwin(11, cutoff=0.3, window="hamming", fs=2, pass_zero=False),
+        )
+        xp_assert_close(hp, expected_hp)
+
+        unscaled = firwin_2d(**kw, scale=False)
+        assert not np.allclose(unscaled, base)
+        expected_unscaled = np.outer(
+            firwin(11, cutoff=0.3, window="hamming", fs=2, scale=False),
+            firwin(11, cutoff=0.3, window="hamming", fs=2, scale=False),
+        )
+        xp_assert_close(unscaled, expected_unscaled)
+
     def test_filter_design(self):
         hsize = (51, 51)
         window = (("kaiser", 8.0), ("kaiser", 8.0))


### PR DESCRIPTION
Closes #25986.

## Root cause
`firwin_2d` documents `pass_zero` and `scale` as passed through to `firwin` for each axis, but both call sites omitted them. Callers requesting a 2-D highpass (`pass_zero=False`) silently received a lowpass. Separately, omitting `fc` for a non-circular design forwarded `None` into `firwin` and returned an all-NaN array instead of raising.

## Fix
- Forward `pass_zero` and `scale` to both `firwin` calls (separable outer product and circular).
- Raise `ValueError` when `fc` is omitted and `circular` is False (circular already required `fc`).

## Tests
Added `Testfirwin_2d.test_pass_zero_and_scale_forwarded` and an `fc`-required check in `test_invalid_args`.

Results on this machine (installed SciPy 1.17.1, Python 3.11, Windows):
- **Unpatched 1.17.1:** `pass_zero=False` matches the default taps (delta 0); `fc=None` does not raise.
- **Same 1.17.1 with this logic overlaid:** new assertions plus existing 2-D design / impulse / frequency / symmetry / circular checks passed, then the overlay was reverted.
- Full `pytest` against the **clone** of `main` was not run here (import of `scipy._external` / conftest clash with the installed 1.17.1 tree). CI should run `scipy/signal/tests/test_fir_filter_design.py`.