### PR TITLE
BUG: sparse: fix zeroslike typo in COO assignment broadcast

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1544,8 +1544,8 @@ def _get_sparse_data_and_coords(x, new_shape, dtype):
     if len_diff > 0:
         # prepend ones to shape of x to match ndim
         x_shape = [1] * len_diff + list(x_shape)
-        coord_zeros = np.zeroslike(x_coords[0])
-        x_coords = tuple([coord_zeros] * len_diff + x_coords)
+        coord_zeros = np.zeros_like(x_coords[0])
+        x_coords = [coord_zeros] * len_diff + x_coords
     # taking away axes (squeezing) is not part of broadcasting, but long
     # spmatrix history of using 2d vectors in 1d space, so we manually
     # squeeze the front and back axes here to be compatible

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1202,6 +1202,16 @@ def test_newaxis_set():
     assert_equal(A.toarray(), D)
 
 
+def test_nd_setitem_broadcast_sparse_rhs():
+    # Regression: np.zeroslike typo in _get_sparse_data_and_coords when
+    # broadcasting a lower-ndim sparse RHS. https://github.com/scipy/scipy/issues/25965
+    A = coo_array((2, 3, 4), dtype=float)
+    x = coo_array(np.arange(12, dtype=float).reshape(3, 4))
+    A[:] = x
+    expected = np.broadcast_to(x.toarray(), (2, 3, 4))
+    assert_equal(A.toarray(), expected)
+
+
 def test_1d_coo_set():
     D = np.arange(9)
     A = coo_array(D)


### PR DESCRIPTION
﻿Closes #25965.

## Root cause
`_get_sparse_data_and_coords` used `np.zeroslike` (not a NumPy API) when broadcasting a lower-ndim sparse RHS into an n-D `coo_array`. That assignment path raised `AttributeError`. After correcting the name, coords were wrapped in a `tuple`, but the following expansion writes `x_coords[i] = ...` and requires a list.

## Fix
- `np.zeros_like`
- prepend axes with a list, not a tuple

## Tests
`test_nd_setitem_broadcast_sparse_rhs`: `A[:] = x` for 3-D empty COO and 2-D sparse `x`.

## Results (SciPy 1.17.1, Python 3.11, Windows)
- Unpatched: `AttributeError: module 'numpy' has no attribute 'zeroslike'`
- Overlay of this patch: assignment matches `np.broadcast_to`; overlay reverted
- Full clone pytest not run here (installed vs `main` tree). CI should run `scipy/sparse/tests/test_coo.py`.
