### PR TITLE
ENH: fft: optional `dtype` argument for `fftfreq` & `rfftfreq`

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -147,7 +147,7 @@ prev_fast_len.__signature__ = _sig_prev_fast_len
 
 
 @xp_capabilities()
-def fftfreq(n, d=1.0, *, xp=None, device=None):
+def fftfreq(n, d=1.0, *, xp=None, device=None, dtype=None):
     """Return the Discrete Fourier Transform sample frequencies.
 
     The returned float array `f` contains the frequency bin centers in cycles
@@ -170,6 +170,10 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
     device : device, optional
         The device for the return array.
         Only valid when `xp.fft.fftfreq` implements the device parameter.
+    dtype : dtype, optional
+        The dtype of the return array. Must be an inexact type.
+        Only valid when `xp.fft.fftfreq` implements the dtype parameter or when
+        `xp` is NumPy.
 
     Returns
     -------
@@ -190,13 +194,19 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
 
     """
     xp = np if xp is None else xp
-    if hasattr(xp, 'fft'):
-        return xp.fft.fftfreq(n, d=d, device=device)
-    return np.fft.fftfreq(n, d=d, device=device)
+    # numpy does not yet support the `dtype` keyword
+    # `xp.__name__ != 'numpy'` and `.astype(dtype, copy=False)`
+    # should be removed when numpy is compatible
+    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+        return xp.fft.fftfreq(n, d=d, device=device, dtype=dtype)
+    dtype = np.result_type(d, np.float64) if dtype is None else dtype
+    if not np.isdtype(dtype, ("real floating", "complex floating")):
+        raise ValueError(f"`dtype` must be an inexact type. Got {dtype=}")
+    return np.fft.fftfreq(n, d=d, device=device).astype(dtype, copy=False)
 
 
 @xp_capabilities()
-def rfftfreq(n, d=1.0, *, xp=None, device=None):
+def rfftfreq(n, d=1.0, *, xp=None, device=None, dtype=None):
     """Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).
 
@@ -223,6 +233,10 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
     device : device, optional
         The device for the return array.
         Only valid when `xp.fft.rfftfreq` implements the device parameter.
+    dtype : dtype, optional
+        The dtype of the return array. Must be an inexact type.
+        Only valid when `xp.fft.rfftfreq` implements the dtype parameter or when
+        `xp` is NumPy.
 
     Returns
     -------
@@ -246,9 +260,15 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
 
     """
     xp = np if xp is None else xp
-    if hasattr(xp, 'fft'):
-        return xp.fft.rfftfreq(n, d=d, device=device)
-    return np.fft.rfftfreq(n, d=d, device=device)
+    # numpy does not yet support the `dtype` keyword
+    # `xp.__name__ != 'numpy'` and `.astype(dtype, copy=False)`
+    # should be removed when numpy is compatible
+    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+        return xp.fft.rfftfreq(n, d=d, device=device, dtype=dtype)
+    dtype = np.result_type(d, np.float64) if dtype is None else dtype
+    if not np.isdtype(dtype, ("real floating", "complex floating")):
+        raise ValueError(f"`dtype` must be an inexact type. Got {dtype=}")
+    return np.fft.rfftfreq(n, d=d, device=device).astype(dtype, copy=False)
 
 
 @xp_capabilities()

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -531,6 +531,10 @@ class TestFFTFreq:
             x = xp.empty(0, device=d)
             assert xp_device(y) == xp_device(x)
 
+    def test_dtype(self, xp):
+        for dtype in (xp.float32, xp.float64):
+            assert fft.fftfreq(9, xp=xp, dtype=dtype).dtype == dtype
+
 
 @make_xp_test_case(fft.rfftfreq)
 class TestRFFTFreq:
@@ -558,3 +562,7 @@ class TestRFFTFreq:
             y = fft.rfftfreq(9, xp=xp, device=d)
             x = xp.empty(0, device=d)
             assert xp_device(y) == xp_device(x)
+    
+    def test_dtype(self, xp):
+        for dtype in (xp.float32, xp.float64):
+            assert fft.rfftfreq(9, xp=xp, dtype=dtype).dtype == dtype

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -562,7 +562,7 @@ class TestRFFTFreq:
             y = fft.rfftfreq(9, xp=xp, device=d)
             x = xp.empty(0, device=d)
             assert xp_device(y) == xp_device(x)
-    
+
     def test_dtype(self, xp):
         for dtype in (xp.float32, xp.float64):
             assert fft.rfftfreq(9, xp=xp, dtype=dtype).dtype == dtype


### PR DESCRIPTION
#### Reference issue

Closes https://github.com/scipy/scipy/issues/25997

#### What does this implement/fix?

Adds an optional `dtype` argument to `fftfreq` and `rfftfreq`.

#### Additional information

This allows `dtype` to be complex floating which is not included in the Array API specification.
I did this as it was the simplest way I could think to allow a dtype argument whilst preserving backwards compatibility with passing complex `d`.

JAX: has a `dtype` argument and allows it to be a complex type, but doesn't allow `d` to be complex.
PyTorch: has a `dtype` argument and doesn't allow it to be a complex type, but also doesn't allow `d` to be complex.
CuPy: doesn't yet have a `dtype` argument and allows `d` to be complex

#### AI Generation Disclosure

No AI used.
