### PR TITLE
ENH: use Python raw memory allocators in code which includes Python.h

### DIFF
--- a/scipy/_lib/src/_test_ccallback.c
+++ b/scipy/_lib/src/_test_ccallback.c
@@ -348,7 +348,7 @@ static void data_capsule_destructor(PyObject *capsule)
 {
     void *data;
     data = PyCapsule_GetPointer(capsule, NULL);
-    free(data);
+    PyMem_RawFree(data);
 }
 
 static PyObject *test_get_data_capsule(PyObject *obj, PyObject *args)
@@ -359,7 +359,7 @@ static PyObject *test_get_data_capsule(PyObject *obj, PyObject *args)
         return NULL;
     }
 
-    data = (double *)malloc(sizeof(double));
+    data = (double *)PyMem_RawMalloc(sizeof(double));
     if (data == NULL) {
         return PyErr_NoMemory();
     }

--- a/scipy/integrate/__quadpack.h
+++ b/scipy/integrate/__quadpack.h
@@ -96,16 +96,16 @@ init_multivariate_data(ccallback_t *callback, int ndim, PyObject *extra_argument
 
     callback->info_p = NULL;
 
-    p = (double *)malloc(sizeof(double) * ndim);
+    p = (double *)PyMem_RawMalloc(sizeof(double) * ndim);
     if (p == NULL) {
-        free(p);
+        PyMem_RawFree(p);
         PyErr_SetString(PyExc_MemoryError, "failed to allocate memory");
         return -1;
     }
 
     size = PyTuple_Size(extra_arguments);
     if (size != ndim - 1) {
-        free(p);
+        PyMem_RawFree(p);
         PyErr_SetString(PyExc_ValueError, "extra arguments don't match ndim");
         return -1;
     }
@@ -117,7 +117,7 @@ init_multivariate_data(ccallback_t *callback, int ndim, PyObject *extra_argument
         item = PyTuple_GET_ITEM(extra_arguments, i);
         p[i+1] = PyFloat_AsDouble(item);
         if (PyErr_Occurred()) {
-            free(p);
+            PyMem_RawFree(p);
             return -1;
         }
     }
@@ -195,7 +195,7 @@ free_callback(ccallback_t *callback)
 {
     if (callback->signature && (callback->signature->value == CB_ND ||
                                 callback->signature->value == CB_ND_USER)) {
-        free(callback->info_p);
+        PyMem_RawFree(callback->info_p);
         callback->info_p = NULL;
     }
 

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -709,7 +709,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
         goto fail;
     }
 
-    if ((wa = (double *)calloc(lrw*sizeof(double) + liw*sizeof(CBLAS_INT), 1))==NULL) {
+    if ((wa = (double *)PyMem_RawCalloc(lrw*sizeof(double) + liw*sizeof(CBLAS_INT), 1))==NULL) {
         PyErr_NoMemory();
         goto fail;
     }
@@ -823,7 +823,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     Py_XDECREF(ap_tcrit);
     Py_DECREF(ap_y);
     Py_DECREF(ap_tout);
-    free(wa);
+    PyMem_RawFree(wa);
 
     // Full output
     if (full_output)
@@ -859,7 +859,7 @@ fail:
     Py_XDECREF(ap_tcrit);
     Py_XDECREF(ap_tout);
     Py_XDECREF(ap_yout);
-    if (allocated) { free(wa); }
+    if (allocated) { PyMem_RawFree(wa); }
 
     if (full_output)
     {

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -67,7 +67,7 @@ fitpack_bispeu(PyObject* Py_UNUSED(dummy), PyObject *args)
 
     /* Allocate work array: lwrk = kx + ky + 2 */
     lwrk = kx + ky + 2;
-    wrk = (double *)malloc(lwrk * sizeof(double));
+    wrk = (double *)PyMem_RawMalloc(lwrk * sizeof(double));
     if (wrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -76,7 +76,7 @@ fitpack_bispeu(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Call the C function */
     bispeu(tx, nx, ty, ny, c, kx, ky, x, y, z, m, wrk, lwrk, &ier);
 
-    free(wrk);
+    PyMem_RawFree(wrk);
     Py_DECREF(ap_tx);
     Py_DECREF(ap_ty);
     Py_DECREF(ap_c);
@@ -153,20 +153,20 @@ fitpack_bispev(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Allocate work arrays */
     lwrk = mx * (kx + 1) + my * (ky + 1);
     kwrk = mx + my;
-    wrk = (double *)malloc(lwrk * sizeof(double));
-    iwrk = (int *)malloc(kwrk * sizeof(int));
+    wrk = (double *)PyMem_RawMalloc(lwrk * sizeof(double));
+    iwrk = (int *)PyMem_RawMalloc(kwrk * sizeof(int));
     if (wrk == NULL || iwrk == NULL) {
         PyErr_NoMemory();
-        free(wrk);
-        free(iwrk);
+        PyMem_RawFree(wrk);
+        PyMem_RawFree(iwrk);
         goto fail;
     }
 
     /* Call the C function */
     bispev(tx, nx, ty, ny, c, kx, ky, x, mx, y, my, z, wrk, lwrk, iwrk, kwrk, &ier);
 
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
     Py_DECREF(ap_tx);
     Py_DECREF(ap_ty);
     Py_DECREF(ap_c);
@@ -311,7 +311,7 @@ fitpack_splder(PyObject* Py_UNUSED(dummy), PyObject *args)
     }
     y = (double *)PyArray_DATA(ap_y);
 
-    wrk = (double *)malloc(n * sizeof(double));
+    wrk = (double *)PyMem_RawMalloc(n * sizeof(double));
     if (wrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -320,7 +320,7 @@ fitpack_splder(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Call the C function */
     splder(t, n, c, nc, k, nu, x, y, m, e, wrk, &ier);
 
-    free(wrk);
+    PyMem_RawFree(wrk);
     Py_DECREF(ap_t);
     Py_DECREF(ap_c);
     Py_DECREF(ap_x);
@@ -370,7 +370,7 @@ fitpack_splint(PyObject* Py_UNUSED(dummy), PyObject *args)
     }
 
     /* Allocate work array */
-    wrk = (double *)malloc(n * sizeof(double));
+    wrk = (double *)PyMem_RawMalloc(n * sizeof(double));
     if (wrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -379,7 +379,7 @@ fitpack_splint(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Call the C function */
     aint = splint(t, n, c, nc, k, a, b, wrk);
 
-    free(wrk);
+    PyMem_RawFree(wrk);
     Py_DECREF(ap_t);
     Py_DECREF(ap_c);
 
@@ -619,20 +619,20 @@ fitpack_parder(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Allocate work arrays */
     lwrk = (nx * ny) + (kx + 1) * mx + (ky + 1) * my;
     kwrk = mx + my;
-    wrk = (double *)malloc(lwrk * sizeof(double));
-    iwrk = (int *)malloc(kwrk * sizeof(int));
+    wrk = (double *)PyMem_RawMalloc(lwrk * sizeof(double));
+    iwrk = (int *)PyMem_RawMalloc(kwrk * sizeof(int));
     if (wrk == NULL || iwrk == NULL) {
         PyErr_NoMemory();
-        free(wrk);
-        free(iwrk);
+        PyMem_RawFree(wrk);
+        PyMem_RawFree(iwrk);
         goto fail;
     }
 
     /* Call the C function */
     parder(tx, nx, ty, ny, c, kx, ky, nux, nuy, x, mx, y, my, z, wrk, lwrk, iwrk, kwrk, &ier);
 
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
     Py_DECREF(ap_tx);
     Py_DECREF(ap_ty);
     Py_DECREF(ap_c);
@@ -785,8 +785,8 @@ fitpack_pardeu(PyObject* Py_UNUSED(dummy), PyObject *args)
     /* Allocate work arrays */
     lwrk = (nx * ny) + (kx + 1) * m + (ky + 1) * m;
     kwrk = m + m;
-    wrk = malloc(lwrk * sizeof(double));
-    iwrk = malloc(kwrk * sizeof(int));
+    wrk = PyMem_RawMalloc(lwrk * sizeof(double));
+    iwrk = PyMem_RawMalloc(kwrk * sizeof(int));
     if (wrk == NULL || iwrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -801,8 +801,8 @@ fitpack_pardeu(PyObject* Py_UNUSED(dummy), PyObject *args)
            (double *)PyArray_DATA(ap_z), m,
            wrk, lwrk, iwrk, kwrk, &ier);
 
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
     Py_DECREF(ap_tx);
     Py_DECREF(ap_ty);
     Py_DECREF(ap_c);
@@ -812,8 +812,8 @@ fitpack_pardeu(PyObject* Py_UNUSED(dummy), PyObject *args)
     return Py_BuildValue(("Ni"), PyArray_Return(ap_z), ier);
 
 fail:
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
     Py_XDECREF(ap_tx);
     Py_XDECREF(ap_ty);
     Py_XDECREF(ap_c);
@@ -857,7 +857,7 @@ fitpack_dblint(PyObject* Py_UNUSED(dummy), PyObject *args)
 
     /* Allocate work array */
     wrk_size = nx + ny - kx - ky - 2;
-    wrk = malloc(wrk_size * sizeof(double));
+    wrk = PyMem_RawMalloc(wrk_size * sizeof(double));
     if (wrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -869,7 +869,7 @@ fitpack_dblint(PyObject* Py_UNUSED(dummy), PyObject *args)
            (double *)PyArray_DATA(ap_c), kx, ky,
            xb, xe, yb, ye, wrk);
 
-    free(wrk);
+    PyMem_RawFree(wrk);
     Py_DECREF(ap_tx);
     Py_DECREF(ap_ty);
     Py_DECREF(ap_c);
@@ -877,7 +877,7 @@ fitpack_dblint(PyObject* Py_UNUSED(dummy), PyObject *args)
     return Py_BuildValue("d", result);
 
 fail:
-    free(wrk);
+    PyMem_RawFree(wrk);
     Py_XDECREF(ap_tx);
     Py_XDECREF(ap_ty);
     Py_XDECREF(ap_c);
@@ -1215,9 +1215,9 @@ fitpack_surfit_lsq(PyObject* Py_UNUSED(dummy), PyObject *args)
         }
     }
 
-    wrk1 = (double *)malloc((size_t)lwrk1 * sizeof(double));
-    wrk2 = (double *)malloc((size_t)lwrk2 * sizeof(double));
-    iwrk = (int *)malloc((size_t)kwrk * sizeof(int));
+    wrk1 = (double *)PyMem_RawMalloc((size_t)lwrk1 * sizeof(double));
+    wrk2 = (double *)PyMem_RawMalloc((size_t)lwrk2 * sizeof(double));
+    iwrk = (int *)PyMem_RawMalloc((size_t)kwrk * sizeof(int));
     if (wrk1 == NULL || wrk2 == NULL || iwrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -1244,21 +1244,21 @@ fitpack_surfit_lsq(PyObject* Py_UNUSED(dummy), PyObject *args)
            wrk2, lwrk2,
            iwrk, kwrk, &ier);
 
-    free(wrk1);
-    free(wrk2);
-    free(iwrk);
+    PyMem_RawFree(wrk1);
+    PyMem_RawFree(wrk2);
+    PyMem_RawFree(iwrk);
 
     return Py_BuildValue("Ndi", PyArray_Return(ap_c), fp, ier);
 
 fail:
     if (wrk1 != NULL) {
-        free(wrk1);
+        PyMem_RawFree(wrk1);
     }
     if (wrk2 != NULL) {
-        free(wrk2);
+        PyMem_RawFree(wrk2);
     }
     if (iwrk != NULL) {
-        free(iwrk);
+        PyMem_RawFree(iwrk);
     }
     return NULL;
 }
@@ -1353,9 +1353,9 @@ fitpack_surfit_smth(PyObject* Py_UNUSED(dummy), PyObject *args)
         }
     }
 
-    wrk1 = (double *)malloc((size_t)lwrk1 * sizeof(double));
-    wrk2 = (double *)malloc((size_t)lwrk2 * sizeof(double));
-    iwrk = (int *)malloc((size_t)kwrk * sizeof(int));
+    wrk1 = (double *)PyMem_RawMalloc((size_t)lwrk1 * sizeof(double));
+    wrk2 = (double *)PyMem_RawMalloc((size_t)lwrk2 * sizeof(double));
+    iwrk = (int *)PyMem_RawMalloc((size_t)kwrk * sizeof(int));
     if (wrk1 == NULL || wrk2 == NULL || iwrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -1395,21 +1395,21 @@ fitpack_surfit_smth(PyObject* Py_UNUSED(dummy), PyObject *args)
            wrk2, lwrk2,
            iwrk, kwrk, &ier);
 
-    free(wrk1);
-    free(wrk2);
-    free(iwrk);
+    PyMem_RawFree(wrk1);
+    PyMem_RawFree(wrk2);
+    PyMem_RawFree(iwrk);
 
     return Py_BuildValue("iNiNNdi", nx, PyArray_Return(ap_tx), ny, PyArray_Return(ap_ty), PyArray_Return(ap_c), fp, ier);
 
 fail:
     if (wrk1 != NULL) {
-        free(wrk1);
+        PyMem_RawFree(wrk1);
     }
     if (wrk2 != NULL) {
-        free(wrk2);
+        PyMem_RawFree(wrk2);
     }
     if (iwrk != NULL) {
-        free(iwrk);
+        PyMem_RawFree(iwrk);
     }
     Py_XDECREF(ap_tx);
     Py_XDECREF(ap_ty);
@@ -1511,9 +1511,9 @@ fitpack_surfit(PyObject* Py_UNUSED(dummy), PyObject *args)
         }
     }
 
-    wrk1 = (double *)malloc((size_t)lwrk1 * sizeof(double));
-    wrk2 = (double *)malloc((size_t)lwrk2 * sizeof(double));
-    iwrk = (int *)malloc((size_t)kwrk * sizeof(int));
+    wrk1 = (double *)PyMem_RawMalloc((size_t)lwrk1 * sizeof(double));
+    wrk2 = (double *)PyMem_RawMalloc((size_t)lwrk2 * sizeof(double));
+    iwrk = (int *)PyMem_RawMalloc((size_t)kwrk * sizeof(int));
     if (wrk1 == NULL || wrk2 == NULL || iwrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -1575,11 +1575,11 @@ fitpack_surfit(PyObject* Py_UNUSED(dummy), PyObject *args)
     }
     memcpy(PyArray_DATA(ap_wrk_out), wrk1, (size_t)nc * sizeof(double));
 
-    free(wrk1);
+    PyMem_RawFree(wrk1);
     wrk1 = NULL;
-    free(wrk2);
+    PyMem_RawFree(wrk2);
     wrk2 = NULL;
-    free(iwrk);
+    PyMem_RawFree(iwrk);
     iwrk = NULL;
 
     /* Slice tx, ty to actual sizes nx, ny for return. */
@@ -1611,13 +1611,13 @@ fitpack_surfit(PyObject* Py_UNUSED(dummy), PyObject *args)
 
 fail:
     if (wrk1 != NULL) {
-        free(wrk1);
+        PyMem_RawFree(wrk1);
     }
     if (wrk2 != NULL) {
-        free(wrk2);
+        PyMem_RawFree(wrk2);
     }
     if (iwrk != NULL) {
-        free(iwrk);
+        PyMem_RawFree(iwrk);
     }
     Py_XDECREF(ap_tx);
     Py_XDECREF(ap_ty);
@@ -1918,8 +1918,8 @@ fitpack_spgrid(PyObject* Py_UNUSED(dummy), PyObject *args)
     kwrk = 5 + mu + mv + nuest + nvest;
 
     /* Allocate workspace arrays */
-    wrk = malloc(lwrk * sizeof(double));
-    iwrk = malloc(kwrk * sizeof(int));
+    wrk = PyMem_RawMalloc(lwrk * sizeof(double));
+    iwrk = PyMem_RawMalloc(kwrk * sizeof(int));
     if (wrk == NULL || iwrk == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -1955,8 +1955,8 @@ fitpack_spgrid(PyObject* Py_UNUSED(dummy), PyObject *args)
             (double *)PyArray_DATA(ap_c_full), &fp,
            wrk, lwrk, iwrk, kwrk, &ier);
 
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
 
     /* Check for errors before creating sliced arrays */
     if (ier == 10) {
@@ -2015,8 +2015,8 @@ fitpack_spgrid(PyObject* Py_UNUSED(dummy), PyObject *args)
                          PyArray_Return(ap_c), fp, ier);
 
 fail:
-    free(wrk);
-    free(iwrk);
+    PyMem_RawFree(wrk);
+    PyMem_RawFree(iwrk);
     Py_XDECREF(ap_tu_full);
     Py_XDECREF(ap_tv_full);
     Py_XDECREF(ap_c);
@@ -2341,8 +2341,8 @@ fitpack_insert(PyObject* Py_UNUSED(dummy), PyObject *args)
         /* Allocate temporary buffer (needed for m > 1) */
         if (t2 == t_in) {
             if (t_buf == NULL) {
-                t_buf = calloc(nest, sizeof(double));
-                c_buf = calloc(nest, sizeof(double));
+                t_buf = PyMem_RawCalloc(nest, sizeof(double));
+                c_buf = PyMem_RawCalloc(nest, sizeof(double));
                 if (t_buf == NULL || c_buf == NULL) {
                     PyErr_NoMemory();
                     Py_DECREF(ap_t);
@@ -2351,8 +2351,8 @@ fitpack_insert(PyObject* Py_UNUSED(dummy), PyObject *args)
                     Py_DECREF(ap_c_pad);
                     Py_XDECREF(ap_tt);
                     Py_XDECREF(ap_cc);
-                    free(t_buf);
-                    free(c_buf);
+                    PyMem_RawFree(t_buf);
+                    PyMem_RawFree(c_buf);
                     return NULL;
                 }
             }
@@ -2374,8 +2374,8 @@ fitpack_insert(PyObject* Py_UNUSED(dummy), PyObject *args)
         memcpy(c_out, c2, nest * sizeof(double));
     }
 
-    free(t_buf);
-    free(c_buf);
+    PyMem_RawFree(t_buf);
+    PyMem_RawFree(c_buf);
     Py_DECREF(ap_t);
     Py_DECREF(ap_c);
     Py_DECREF(ap_t_pad);

--- a/scipy/linalg/_matfuncsmodule.c
+++ b/scipy/linalg/_matfuncsmodule.c
@@ -19,7 +19,7 @@ static PyObject* matfuncs_error;
 static void
 capsule_destructor(PyObject *capsule) {
     void *ptr = PyCapsule_GetPointer(capsule, NULL);
-    free(ptr);
+    PyMem_RawFree(ptr);
 }
 
 
@@ -87,26 +87,26 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
 
     if (PyArray_TYPE(ap_Am) == NPY_FLOAT32)
     {
-        mem_ret = malloc(ret_dims*sizeof(float));
+        mem_ret = PyMem_RawMalloc(ret_dims*sizeof(float));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Memory allocation failed."); }
         matrix_squareroot_s(ap_Am, (float*)mem_ret, &isIllconditioned, &isSingular, &info, &isComplex);
 
     } else if (PyArray_TYPE(ap_Am) == NPY_FLOAT64) {
 
-        mem_ret = malloc(ret_dims*sizeof(double));
+        mem_ret = PyMem_RawMalloc(ret_dims*sizeof(double));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Memory allocation failed."); }
         matrix_squareroot_d(ap_Am, (double*)mem_ret, &isIllconditioned, &isSingular, &info, &isComplex);
 
     } else if (PyArray_TYPE(ap_Am) == NPY_COMPLEX64) {
 
-        mem_ret = malloc(ret_dims*sizeof(SCIPY_C));
+        mem_ret = PyMem_RawMalloc(ret_dims*sizeof(SCIPY_C));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Memory allocation failed."); }
         matrix_squareroot_c(ap_Am, (SCIPY_C*)mem_ret, &isIllconditioned, &isSingular, &info, &isComplex);
         isComplex = 1;
 
     } else if (PyArray_TYPE(ap_Am) == NPY_COMPLEX128) {
 
-        mem_ret = malloc(ret_dims*sizeof(SCIPY_Z));
+        mem_ret = PyMem_RawMalloc(ret_dims*sizeof(SCIPY_Z));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Memory allocation failed."); }
         matrix_squareroot_z(ap_Am, (SCIPY_Z*)mem_ret, &isIllconditioned, &isSingular, &info, &isComplex);
         isComplex = 1;
@@ -118,7 +118,7 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
     if (info < 0)
     {
         // Internal failure memory or LAPACK error, fail and return the error code in info
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         Py_INCREF(Py_None);
         return Py_BuildValue(
             "Niin", Py_None, isIllconditioned,
@@ -130,16 +130,16 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
     {
         // Input and output is real, truncate the extra space at the end
         npy_intp new_size = (ret_dims/2)*(input_type == NPY_FLOAT32 ? sizeof(float) : sizeof(double));
-        void* new_ret = realloc(mem_ret, new_size);
+        void* new_ret = PyMem_RawRealloc(mem_ret, new_size);
         // Quite unlikely but still allowed to fail
         if (!new_ret) {
-            free(mem_ret);
+            PyMem_RawFree(mem_ret);
             PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Memory reallocation failed.");
         }
         mem_ret = new_ret;
         ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(ndim, shape, input_type, mem_ret);
         if (ap_ret == NULL) {
-            free(mem_ret);
+            PyMem_RawFree(mem_ret);
             PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Failed to create numpy array from data.");
         }
     } else if ((input_type == NPY_FLOAT32) || (input_type == NPY_FLOAT64)) {
@@ -147,14 +147,14 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
         int new_type = (PyArray_TYPE(ap_Am) == NPY_FLOAT32 ? NPY_COMPLEX64 : NPY_COMPLEX128);
         ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(ndim, shape, new_type, mem_ret);
         if (ap_ret == NULL) {
-            free(mem_ret);
+            PyMem_RawFree(mem_ret);
             PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Failed to create numpy array from data.");
         }
     } else {
         // Input was complex, result is complex, only reshape
         ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(ndim, shape, PyArray_TYPE(ap_Am), mem_ret);
         if (ap_ret == NULL) {
-            free(mem_ret);
+            PyMem_RawFree(mem_ret);
             PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Failed to create numpy array from data.");
         }
     }
@@ -163,7 +163,7 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
     PyObject* capsule = PyCapsule_New(mem_ret, NULL, capsule_destructor);
     if (capsule == NULL) {
         Py_DECREF(ap_ret);
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         PYERR(matfuncs_error, "scipy.linalg._matfuncs:sqrtm: Failed to create capsule.");
     }
     // For ref counting of the memory
@@ -215,25 +215,25 @@ matrix_exponential(PyObject* Py_UNUSED(dummy), PyObject *args) {
 
     if (PyArray_TYPE(ap_a) == NPY_FLOAT32)
     {
-        mem_ret = calloc(ret_dims, sizeof(float));
+        mem_ret = PyMem_RawCalloc(ret_dims, sizeof(float));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Memory allocation failed."); }
         matrix_exponential_s(ap_a, (float*)mem_ret, &info);
 
     } else if (PyArray_TYPE(ap_a) == NPY_FLOAT64) {
 
-        mem_ret = calloc(ret_dims, sizeof(double));
+        mem_ret = PyMem_RawCalloc(ret_dims, sizeof(double));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Memory allocation failed."); }
         matrix_exponential_d(ap_a, (double*)mem_ret, &info);
 
     } else if (PyArray_TYPE(ap_a) == NPY_COMPLEX64) {
 
-        mem_ret = calloc(ret_dims, sizeof(SCIPY_C));
+        mem_ret = PyMem_RawCalloc(ret_dims, sizeof(SCIPY_C));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Memory allocation failed."); }
         matrix_exponential_c(ap_a, (SCIPY_C*)mem_ret, &info);
 
     } else if (PyArray_TYPE(ap_a) == NPY_COMPLEX128) {
 
-        mem_ret = calloc(ret_dims, sizeof(SCIPY_Z));
+        mem_ret = PyMem_RawCalloc(ret_dims, sizeof(SCIPY_Z));
         if (mem_ret == NULL) { PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Memory allocation failed."); }
         matrix_exponential_z(ap_a, (SCIPY_Z*)mem_ret, &info);
     } else {
@@ -243,14 +243,14 @@ matrix_exponential(PyObject* Py_UNUSED(dummy), PyObject *args) {
     if (info < 0)
     {
         // Internal failure memory or LAPACK error, fail and return the error code in info
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         Py_INCREF(Py_None);
         return Py_BuildValue("Nn", Py_None, (Py_ssize_t)info);
     }
 
     PyArrayObject* ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(ndim, shape, input_type, mem_ret);
     if (ap_ret == NULL) {
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Failed to create numpy array from data.");
     }
 
@@ -258,7 +258,7 @@ matrix_exponential(PyObject* Py_UNUSED(dummy), PyObject *args) {
     PyObject* capsule = PyCapsule_New(mem_ret, NULL, capsule_destructor);
     if (capsule == NULL) {
         Py_DECREF(ap_ret);
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         PYERR(matfuncs_error, "scipy.linalg._matfuncs:expm: Failed to create capsule.");
     }
     // For ref counting of the memory

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -80,7 +80,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(2*n*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(2*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
         }
@@ -88,10 +88,10 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // query LWORK
     call_geev(&jobvl, &jobvr, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
-    if (info != 0) { free(rwork);  return -101; }
+    if (info != 0) { PyMem_RawFree(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);
-    if (lwork < 0) { free(rwork); return -102; }
+    if (lwork < 0) { PyMem_RawFree(rwork); return -102; }
 
     /*
      * Allocate memory and chop the buffer into parts
@@ -118,8 +118,8 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     npy_intp vr_size = compute_vr ? ldvr*n : 0;
     bufsize += vl_size + vr_size;
 
-    T *buf = (T *)malloc(bufsize*sizeof(T));
-    if (buf == NULL) { free(rwork); return -103; }
+    T *buf = (T *)PyMem_RawMalloc(bufsize*sizeof(T));
+    if (buf == NULL) { PyMem_RawFree(rwork); return -103; }
 
     // partition the workspace
     T *work = &buf[0];
@@ -200,8 +200,8 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     }
 
  done:
-    free(buf);
-    free(rwork);
+    PyMem_RawFree(buf);
+    PyMem_RawFree(rwork);
 
     return 0;
 }
@@ -259,7 +259,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     // similar to geev, allocate rwork right away (not sure if ?ggev segfaults otherwise, too)
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(8*n*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(8*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
         }
@@ -267,10 +267,10 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // query LWORK
     call_ggev(&jobvl, &jobvr, &intn, NULL, &lda, NULL, &ldb, NULL, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
-    if (info != 0) { free(rwork);  return -101; }
+    if (info != 0) { PyMem_RawFree(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);
-    if (lwork < 0) { free(rwork); return -102; }
+    if (lwork < 0) { PyMem_RawFree(rwork); return -102; }
 
     /*
      * Allocate memory and chop the buffer into parts
@@ -299,8 +299,8 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     npy_intp bufsize = lwork + n + n + alphai_size + A_size + B_size  + vl_size + vr_size;
 
-    T *buf = (T *)malloc(bufsize*sizeof(T));
-    if (buf == NULL) { free(rwork); return -103; }
+    T *buf = (T *)PyMem_RawMalloc(bufsize*sizeof(T));
+    if (buf == NULL) { PyMem_RawFree(rwork); return -103; }
 
     T *work = &buf[0];
     T *alphar = &buf[lwork];
@@ -405,8 +405,8 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
 
  done:
-    free(buf);
-    free(rwork);
+    PyMem_RawFree(buf);
+    PyMem_RawFree(rwork);
 
     return 0;
 }
@@ -582,7 +582,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     CBLAS_INT Z_size = (jobz != 'N') ? N * M : 0;
     CBLAS_INT A_size = (!overwrite_a) ? N * N : 0;
     CBLAS_INT B_size = (ap_Bm != NULL && !overwrite_b) ? N * N : 0;
-    T *buffer = (T *)malloc((lwork + Z_size + A_size + B_size) * sizeof(T));
+    T *buffer = (T *)PyMem_RawMalloc((lwork + Z_size + A_size + B_size) * sizeof(T));
     if (buffer == NULL) { info = -102; return int(info); }
 
     T *work = &buffer[0];
@@ -619,9 +619,9 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     CBLAS_INT ibuffer_size = iwork_size + isuppz_size + ifail_size;
 
     if (ibuffer_size > 0) {
-        ibuffer = (CBLAS_INT *)malloc(ibuffer_size * sizeof(CBLAS_INT));
+        ibuffer = (CBLAS_INT *)PyMem_RawMalloc(ibuffer_size * sizeof(CBLAS_INT));
         if(ibuffer == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
             info = -103;
             return int(info);
         }
@@ -650,12 +650,12 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     CBLAS_INT w_size = (range == 'I' && M < N) ? N : 0;
     CBLAS_INT rbuffer_size = w_size + lrwork;
     if (rbuffer_size > 0) {
-        rbuffer = (real_type *)malloc(rbuffer_size * sizeof(real_type));
+        rbuffer = (real_type *)PyMem_RawMalloc(rbuffer_size * sizeof(real_type));
         if (rbuffer == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
 
             if (ibuffer != NULL) {
-                free(ibuffer);
+                PyMem_RawFree(ibuffer);
             }
 
             info = -104;
@@ -816,14 +816,14 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     } // End of batching loop
 
 free_exit:
-    free(buffer);
+    PyMem_RawFree(buffer);
 
     if (ibuffer != NULL) {
-        free(ibuffer);
+        PyMem_RawFree(ibuffer);
     }
 
     if (rbuffer != NULL) {
-        free(rbuffer);
+        PyMem_RawFree(rbuffer);
     }
 
     return 1;

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -279,7 +279,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
      */
     CBLAS_INT buf_size = overwrite_a ? lwork : 2*n*n + lwork;
 
-    T* buffer = (T *)malloc(buf_size*sizeof(T));
+    T* buffer = (T *)PyMem_RawMalloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }
 
     T *data=NULL, *scratch=NULL, *work=NULL;
@@ -295,9 +295,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
         work = &buffer[2*n*n];
     }
 
-    CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
+    CBLAS_INT* ipiv = (CBLAS_INT *)PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) {
-        free(buffer);
+        PyMem_RawFree(buffer);
         info = -102;
         return (int)info;
     }
@@ -305,13 +305,13 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
     if constexpr(detail::type_traits<T>::is_complex) {
-        irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
+        irwork = PyMem_RawMalloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
-        irwork = malloc(n*sizeof(CBLAS_INT));
+        irwork = PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     }
     if (irwork == NULL) {
-        free(buffer);
-        free(ipiv);
+        PyMem_RawFree(buffer);
+        PyMem_RawFree(ipiv);
         info = -102;
         return (int)info;
     }
@@ -495,9 +495,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     } // end of `for(idx=...)`
 
 free_exit:
-    free(buffer);
-    free(irwork);
-    free(ipiv);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(irwork);
+    PyMem_RawFree(ipiv);
     return 1;
 }
 

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -82,7 +82,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
     npy_intp bufsize = data_a_size + data_b_size + lwork;
 
-    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    T* buffer = (T *)PyMem_RawMalloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
     // Chop the buffer into parts
@@ -105,10 +105,10 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(5*min_mn*sizeof(real_type));
 
         if (rwork == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
             return -102;
         }
     }
@@ -153,8 +153,8 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
 done:
-    free(buffer);
-    free(rwork);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(rwork);
 
     return 1;
 }
@@ -238,7 +238,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
     npy_intp bufsize = data_a_size + data_b_size + lwork;
 
-    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    T* buffer = (T *)PyMem_RawMalloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
     // Chop the buffer into parts
@@ -261,18 +261,18 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(lrwork*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(lrwork*sizeof(real_type));
 
         if (rwork == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
             return -102;
         }
     }
 
-    CBLAS_INT *iwork = (CBLAS_INT *)malloc(liwork*sizeof(CBLAS_INT));
+    CBLAS_INT *iwork = (CBLAS_INT *)PyMem_RawMalloc(liwork*sizeof(CBLAS_INT));
     if (iwork == NULL) {
-        free(buffer);
-        free(rwork);
+        PyMem_RawFree(buffer);
+        PyMem_RawFree(rwork);
         return -103;
     }
 
@@ -317,9 +317,9 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
 done:
-    free(buffer);
-    free(rwork);
-    free(iwork);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(rwork);
+    PyMem_RawFree(iwork);
     return 1;
 }
 
@@ -394,7 +394,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
     npy_intp bufsize = data_a_size + data_b_size + lwork;
 
-    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    T* buffer = (T *)PyMem_RawMalloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
     T *work = &buffer[0];
@@ -416,18 +416,18 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
 
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(2*n*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(2*n*sizeof(real_type));
 
         if (rwork == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
             return -102;
         }
     }
 
-    CBLAS_INT *jpvt = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
+    CBLAS_INT *jpvt = (CBLAS_INT *)PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (jpvt == NULL) {
-        free(buffer);
-        free(rwork);
+        PyMem_RawFree(buffer);
+        PyMem_RawFree(rwork);
         return -103;
     }
     for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
@@ -474,9 +474,9 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     }
 
 done:
-    free(buffer);
-    free(rwork);
-    free(jpvt);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(rwork);
+    PyMem_RawFree(jpvt);
     return 1;
 }
 

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -124,7 +124,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
      */
     CBLAS_INT tau_size = (mode == QR_mode::RAW_MODE) ? 0 : K;
     CBLAS_INT buf_size = ((overwrite_a && mode != QR_mode::FULL) || mode == QR_mode::RAW_MODE) ? 0 : (mode == QR_mode::FULL) ? M * max_dim : M * N;
-    T *buffer = (T *)malloc((lwork + tau_size + buf_size) * sizeof(T));
+    T *buffer = (T *)PyMem_RawMalloc((lwork + tau_size + buf_size) * sizeof(T));
     if ( buffer == NULL ) { info = -101; return int(info); }
 
     T *work = &buffer[0];
@@ -134,10 +134,10 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
     // `c/zgeqp3` needs rwork
     void *rwork = NULL;
     if (pivoting && detail::type_traits<T>::is_complex) {
-        rwork = malloc(2 * N * sizeof(real_type));
+        rwork = PyMem_RawMalloc(2 * N * sizeof(real_type));
 
         if (rwork == NULL) {
-            free(buffer);
+            PyMem_RawFree(buffer);
             info = -102;
             return int(info);
         }
@@ -243,8 +243,8 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
     } // End of batching loop
 
 free_exit:
-    free(buffer);
-    free(rwork);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(rwork);
 
     return 1;
 }

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -309,7 +309,7 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
 
     // General allocations
-    CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
+    CBLAS_INT *ipiv = (CBLAS_INT *)PyMem_RawMalloc(intn * sizeof(CBLAS_INT));
     if (ipiv == NULL) {
         info = -102;
         return int(info);
@@ -317,13 +317,13 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
 
     void *irwork;
     if constexpr (detail::type_traits<T>::is_complex) {
-        irwork = malloc(intn * sizeof(real_type));
+        irwork = PyMem_RawMalloc(intn * sizeof(real_type));
     } else {
-        irwork = malloc(intn * sizeof(CBLAS_INT));
+        irwork = PyMem_RawMalloc(intn * sizeof(CBLAS_INT));
     }
 
     if (irwork == NULL) {
-        free(ipiv);
+        PyMem_RawFree(ipiv);
         info = -102;
         return int(info);
     }
@@ -333,11 +333,11 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     // have. To avoid having to call `bandwidth` twice per slice, the results
     // are stored in these arrays.
     npy_intp ldab_max = 0;
-    ks = (npy_intp *)malloc(2 * outer_size * sizeof(npy_intp));
+    ks = (npy_intp *)PyMem_RawMalloc(2 * outer_size * sizeof(npy_intp));
 
     if (ks == NULL) {
-        free(ipiv);
-        free(irwork);
+        PyMem_RawFree(ipiv);
+        PyMem_RawFree(irwork);
         info = -102;
         return (int)info;
     }
@@ -359,12 +359,12 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
      * - `b_data` is a buffer for the rhs of the system, not needed if `overwrite_b` is set (size = 0 then)
      */
     npy_intp b_data_size = overwrite_b ? 0 : n * nrhs;
-    buffer = (T *)malloc((ldab_max * n + 3 * n + b_data_size) * sizeof(T));
+    buffer = (T *)PyMem_RawMalloc((ldab_max * n + 3 * n + b_data_size) * sizeof(T));
 
     if (buffer == NULL) {
-        free(ipiv);
-        free(irwork);
-        free(ks);
+        PyMem_RawFree(ipiv);
+        PyMem_RawFree(irwork);
+        PyMem_RawFree(ks);
         info = -102;
         return int(info);
     }
@@ -409,10 +409,10 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     }
 
 free_exit_banded:
-    free(ipiv);
-    free(irwork);
-    free(ks);
-    free(buffer);
+    PyMem_RawFree(ipiv);
+    PyMem_RawFree(irwork);
+    PyMem_RawFree(ks);
+    PyMem_RawFree(buffer);
 
     return 1;
 }
@@ -485,7 +485,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     CBLAS_INT buf_size_trcon = 2*n; // // 2*n for tridiag trcon
     CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork;
 
-    T* buffer = (T *)malloc(buf_size*sizeof(T));
+    T* buffer = (T *)PyMem_RawMalloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }
 
     /*
@@ -524,9 +524,9 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     T *work2 = &buffer[2*buf_size_a + buf_size_b]; // 2*n for is for tridiag's trcon; XXX malloc it only if needed?
     T* work = &buffer[2*buf_size_a + buf_size_b + 2*n];
 
-    CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
+    CBLAS_INT* ipiv = (CBLAS_INT *)PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) {
-        free(buffer);
+        PyMem_RawFree(buffer);
         info = -102;
         return (int)info;
     }
@@ -534,13 +534,13 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
     if constexpr (detail::type_traits<T>::is_complex) {
-        irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
+        irwork = PyMem_RawMalloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
-        irwork = malloc(n*sizeof(CBLAS_INT));
+        irwork = PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     }
     if (irwork == NULL) {
-        free(buffer);
-        free(ipiv);
+        PyMem_RawFree(buffer);
+        PyMem_RawFree(ipiv);
         info = -102;
         return (int)info;
     }
@@ -699,9 +699,9 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     }
 
 free_exit:
-    free(buffer);
-    free(irwork);
-    free(ipiv);
+    PyMem_RawFree(buffer);
+    PyMem_RawFree(irwork);
+    PyMem_RawFree(ipiv);
     return 1;
 }
 

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -116,7 +116,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
         bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
     }
 
-    T *buf = (T *)malloc(bufsize*sizeof(T));
+    T *buf = (T *)PyMem_RawMalloc(bufsize*sizeof(T));
     if (buf == NULL) { info = -101; return (int)info; }
 
     // partition the workspace
@@ -138,9 +138,9 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     CBLAS_INT *iwork = NULL;
     real_type *rwork = NULL;
     // iwork
-    iwork = (CBLAS_INT *)malloc(8*min_mn*sizeof(CBLAS_INT));
+    iwork = (CBLAS_INT *)PyMem_RawMalloc(8*min_mn*sizeof(CBLAS_INT));
     if (iwork == NULL) {
-        free(buf);
+        PyMem_RawFree(buf);
         info = -102;
         return (int)info;
     }
@@ -152,10 +152,10 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
             5*min_mn*min_mn + 5*min_mn,
             2*max_mn*min_mn + 2*min_mn*min_mn + min_mn
         );
-        rwork = (real_type *)malloc(lrwork * sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(lrwork * sizeof(real_type));
         if (rwork == NULL) {
-            free(buf);
-            free(iwork);
+            PyMem_RawFree(buf);
+            PyMem_RawFree(iwork);
             info = -103;
             return (int)info;
         }
@@ -199,9 +199,9 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
  done:
-    free(buf);
-    free(iwork);
-    free(rwork);
+    PyMem_RawFree(buf);
+    PyMem_RawFree(iwork);
+    PyMem_RawFree(rwork);
     return 0;
 }
 
@@ -279,7 +279,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
         bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
     }
 
-    T *buf = (T *)malloc(bufsize*sizeof(T));
+    T *buf = (T *)PyMem_RawMalloc(bufsize*sizeof(T));
     if (buf == NULL) { info = -101; return (int)info; }
 
     // partition the workspace
@@ -300,9 +300,9 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
 
     real_type *rwork = NULL;
     if constexpr (detail::type_traits<T>::is_complex) {
-        rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
+        rwork = (real_type *)PyMem_RawMalloc(5*min_mn*sizeof(real_type));
         if (rwork == NULL) {
-            free(buf);
+            PyMem_RawFree(buf);
             info = -103;
             return (int)info;
         }
@@ -346,8 +346,8 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
  done:
-    free(buf);
-    free(rwork);
+    PyMem_RawFree(buf);
+    PyMem_RawFree(rwork);
     return 0;
 }
 

--- a/scipy/linalg/src/_matfuncs_expm.c
+++ b/scipy/linalg/src/_matfuncs_expm.c
@@ -2219,10 +2219,10 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
     // n*n for holding the absolute values of A
     // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
-    float* restrict Am = malloc(sizeof(float)*(6*n*n + 4*n));
+    float* restrict Am = PyMem_RawMalloc(sizeof(float)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
-    CBLAS_INT* ipiv = malloc(sizeof(CBLAS_INT)*n);
-    if (ipiv == NULL) { free(Am); *info = -101; return; }
+    CBLAS_INT* ipiv = PyMem_RawMalloc(sizeof(CBLAS_INT)*n);
+    if (ipiv == NULL) { PyMem_RawFree(Am); *info = -101; return; }
     float* restrict Am1 = &Am[n*n];
     // These two arrays are only used for the triangular case for scaling/squaring
     float* restrict diag_aw = &Am[6*n*n + 2*n];
@@ -2279,15 +2279,15 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
 
         pick_pade_structure_s(Am, n, &m, &s);
         if (m < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
         pade_UV_calc_s(Am, ipiv, n, m, info);
         if (*info < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
@@ -2348,8 +2348,8 @@ matrix_exponential_s(PyArrayObject* a, float* restrict result, CBLAS_INT* info)
         swap_cf_s(temp1, &result[idx*n*n], n, n, n);
     }
 
-    free(ipiv);
-    free(Am);
+    PyMem_RawFree(ipiv);
+    PyMem_RawFree(Am);
 }
 
 
@@ -2376,10 +2376,10 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
     // n*n for holding the absolute values of A
     // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
-    double* restrict Am = malloc(sizeof(double)*(6*n*n + 4*n));
+    double* restrict Am = PyMem_RawMalloc(sizeof(double)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
-    CBLAS_INT* ipiv = malloc(sizeof(CBLAS_INT)*n);
-    if (ipiv == NULL) { free(Am); *info = -101; return; }
+    CBLAS_INT* ipiv = PyMem_RawMalloc(sizeof(CBLAS_INT)*n);
+    if (ipiv == NULL) { PyMem_RawFree(Am); *info = -101; return; }
     double* restrict Am1 = &Am[n*n];
     // These two arrays are only used for the triangular case for scaling/squaring
     double* restrict diag_aw = &Am[6*n*n + 2*n];
@@ -2436,15 +2436,15 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
 
         pick_pade_structure_d(Am, n, &m, &s);
         if (m < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
         pade_UV_calc_d(Am, ipiv, n, m, info);
         if (*info < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
@@ -2505,8 +2505,8 @@ matrix_exponential_d(PyArrayObject* a, double* restrict result, CBLAS_INT* info)
         swap_cf_d(temp1, &result[idx*n*n], n, n, n);
     }
 
-    free(ipiv);
-    free(Am);
+    PyMem_RawFree(ipiv);
+    PyMem_RawFree(Am);
 }
 
 
@@ -2533,10 +2533,10 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
     // n*n for holding the absolute values of A
     // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
-    SCIPY_C* restrict Am = malloc(sizeof(SCIPY_C)*(6*n*n + 4*n));
+    SCIPY_C* restrict Am = PyMem_RawMalloc(sizeof(SCIPY_C)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
-    CBLAS_INT* ipiv = malloc(sizeof(CBLAS_INT)*n);
-    if (ipiv == NULL) { free(Am); *info = -101; return; }
+    CBLAS_INT* ipiv = PyMem_RawMalloc(sizeof(CBLAS_INT)*n);
+    if (ipiv == NULL) { PyMem_RawFree(Am); *info = -101; return; }
     SCIPY_C* restrict Am1 = &Am[n*n];
     // These two arrays are only used for the triangular case for scaling/squaring
     SCIPY_C* restrict diag_aw = &Am[6*n*n + 2*n];
@@ -2593,15 +2593,15 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
 
         pick_pade_structure_c(Am, n, &m, &s);
         if (m < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
         pade_UV_calc_c(Am, ipiv, n, m, info);
         if (*info < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
@@ -2710,8 +2710,8 @@ matrix_exponential_c(PyArrayObject* a, SCIPY_C* restrict result, CBLAS_INT* info
         swap_cf_c(temp1, &result[idx*n*n], n, n, n);
     }
 
-    free(ipiv);
-    free(Am);
+    PyMem_RawFree(ipiv);
+    PyMem_RawFree(Am);
 }
 
 
@@ -2737,10 +2737,10 @@ matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info
     // n*n for holding the absolute values of A
     // 2*n is the alternating vector pair for the ell() power iterations
     // 2*n for the scaling/squaring in the triangular case
-    SCIPY_Z* restrict Am = malloc(sizeof(SCIPY_Z)*(6*n*n + 4*n));
+    SCIPY_Z* restrict Am = PyMem_RawMalloc(sizeof(SCIPY_Z)*(6*n*n + 4*n));
     if (Am == NULL) { *info = -100; return; }
-    CBLAS_INT* ipiv = malloc(sizeof(CBLAS_INT)*n);
-    if (ipiv == NULL) { free(Am); *info = -101; return; }
+    CBLAS_INT* ipiv = PyMem_RawMalloc(sizeof(CBLAS_INT)*n);
+    if (ipiv == NULL) { PyMem_RawFree(Am); *info = -101; return; }
     SCIPY_Z* restrict Am1 = &Am[n*n];
     // These two arrays are only used for the triangular case for scaling/squaring
     SCIPY_Z* restrict diag_aw = &Am[6*n*n + 2*n];
@@ -2797,15 +2797,15 @@ matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info
 
         pick_pade_structure_z(Am, n, &m, &s);
         if (m < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
         pade_UV_calc_z(Am, ipiv, n, m, info);
         if (*info < 0) {
-            free(ipiv);
-            free(Am);
+            PyMem_RawFree(ipiv);
+            PyMem_RawFree(Am);
             *info = -100 + *info;
             return;
         }
@@ -2914,6 +2914,6 @@ matrix_exponential_z(PyArrayObject* a, SCIPY_Z* restrict result, CBLAS_INT* info
         swap_cf_z(temp1, &result[idx*n*n], n, n, n);
     }
 
-    free(ipiv);
-    free(Am);
+    PyMem_RawFree(ipiv);
+    PyMem_RawFree(Am);
 }

--- a/scipy/linalg/src/_matfuncs_sqrtm.c
+++ b/scipy/linalg/src/_matfuncs_sqrtm.c
@@ -49,7 +49,7 @@ matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* i
     // n + n for wr, wi (needed for gees calls)
     // lwork for work
     size_t buffer_size = 4*n*n + 2*n + lwork;
-    float* restrict buffer = malloc(buffer_size*sizeof(float));
+    float* restrict buffer = PyMem_RawMalloc(buffer_size*sizeof(float));
     if (buffer == NULL) { *sq_info = -101; return; }
 
     // --------------------------------------------------------------------
@@ -110,7 +110,7 @@ matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* i
             BLAS_FUNC(sgees)("V", "N", NULL, &intn, data, &intn, &sdim, wr, wi, vs, &intn, work, &lwork, NULL, &info);
             if (info != 0)
             {
-                free(buffer);
+                PyMem_RawFree(buffer);
                 *sq_info = -102;
                 return;
             }
@@ -303,7 +303,7 @@ matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* i
     /*====================================================================
     |                  END OF nxn SLICE LOOP                             |
     ====================================================================*/
-    free(buffer);
+    PyMem_RawFree(buffer);
     return;
 }
 
@@ -335,7 +335,7 @@ matrix_squareroot_d(const PyArrayObject* ap_Am, double* restrict ret_data, int* 
     if (info != 0) { *sq_info = -100; return; }
     lwork = (CBLAS_INT)tmp_float;
     size_t buffer_size = 4*n*n + 2*n + lwork;
-    double* restrict buffer = malloc(buffer_size*sizeof(double));
+    double* restrict buffer = PyMem_RawMalloc(buffer_size*sizeof(double));
     if (buffer == NULL) { *sq_info = -101; return; }
 
     double* restrict data = &buffer[0];
@@ -370,7 +370,7 @@ matrix_squareroot_d(const PyArrayObject* ap_Am, double* restrict ret_data, int* 
             BLAS_FUNC(dgees)("V", "N", NULL, &intn, data, &intn, &sdim, wr, wi, vs, &intn, work, &lwork, NULL, &info);
             if (info != 0)
             {
-                free(buffer);
+                PyMem_RawFree(buffer);
                 *sq_info = -102;
                 return;
             }
@@ -496,7 +496,7 @@ matrix_squareroot_d(const PyArrayObject* ap_Am, double* restrict ret_data, int* 
             if (upcasted_to_complex) { zebra_pattern_d(&ret_data[2*idx*n*n], n*n); }
         }
     }
-    free(buffer);
+    PyMem_RawFree(buffer);
     return;
 }
 
@@ -526,7 +526,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
 
     lwork = (CBLAS_INT)crealf(tmp_float);
     size_t buffer_size = 2*n*n + 2*n + lwork;
-    SCIPY_C* buffer = malloc(buffer_size*sizeof(SCIPY_C));
+    SCIPY_C* buffer = PyMem_RawMalloc(buffer_size*sizeof(SCIPY_C));
     if (buffer == NULL) { *sq_info = -101; return; }
 
 
@@ -572,7 +572,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
             BLAS_FUNC(cgees)("V", "N", NULL, &intn, data, &intn, &sdim, w, vs, &intn, work, &lwork, rwork, NULL, &info);
             if (info != 0)
             {
-                free(buffer);
+                PyMem_RawFree(buffer);
                 *sq_info = -102;
                 return;
             }
@@ -598,7 +598,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
         if (info != 0) { *isIllconditioned = 1; }
         swap_cf_c(data, &ret_data[idx*n*n], n, n, n);
     }
-    free(buffer);
+    PyMem_RawFree(buffer);
     return;
 }
 
@@ -628,7 +628,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
 
     lwork = (CBLAS_INT)creal(tmp_float);
     size_t buffer_size = 2*n*n + 2*n + lwork;
-    SCIPY_Z* buffer = malloc(buffer_size*sizeof(SCIPY_Z));
+    SCIPY_Z* buffer = PyMem_RawMalloc(buffer_size*sizeof(SCIPY_Z));
     if (buffer == NULL) { *sq_info = -101; return; }
 
 
@@ -674,7 +674,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
             BLAS_FUNC(zgees)("V", "N", NULL, &intn, data, &intn, &sdim, w, vs, &intn, work, &lwork, rwork, NULL, &info);
             if (info != 0)
             {
-                free(buffer);
+                PyMem_RawFree(buffer);
                 *sq_info = -102;
                 return;
             }
@@ -700,7 +700,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
         if (info != 0) { *isIllconditioned = 1; }
         swap_cf_z(data, &ret_data[idx*n*n], n, n, n);
     }
-    free(buffer);
+    PyMem_RawFree(buffer);
     return;
 }
 

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -828,10 +828,10 @@ static PyObject *Py_FindObjects(PyObject *obj, PyObject *args)
         max_label = 0;
     if (max_label > 0) {
         if (PyArray_NDIM(input) > 0) {
-            regions = (npy_intp*)malloc(2 * max_label * PyArray_NDIM(input) *
+            regions = (npy_intp*)PyMem_RawMalloc(2 * max_label * PyArray_NDIM(input) *
                                         sizeof(npy_intp));
         } else {
-            regions = (npy_intp*)malloc(max_label * sizeof(npy_intp));
+            regions = (npy_intp*)PyMem_RawMalloc(max_label * sizeof(npy_intp));
         }
         if (!regions) {
             PyErr_NoMemory();
@@ -893,7 +893,7 @@ static PyObject *Py_FindObjects(PyObject *obj, PyObject *args)
     Py_XDECREF(start);
     Py_XDECREF(end);
     Py_XDECREF(slc);
-    free(regions);
+    PyMem_RawFree(regions);
     if (PyErr_Occurred()) {
         return NULL;
     } else {
@@ -928,7 +928,7 @@ static PyObject *Py_FindObjects(PyObject *obj, PyObject *args)
 }
 #define CASE_VALUEINDICES_MAKEHISTOGRAM(valType) {\
     numPossibleVals = (VALUEINDICES_MAXVAL(valType) - VALUEINDICES_MINVAL(valType) + 1); \
-    hist = (npy_intp *)calloc(numPossibleVals, sizeof(npy_intp)); \
+    hist = (npy_intp *)PyMem_RawCalloc(numPossibleVals, sizeof(npy_intp)); \
     if (hist != NULL) { \
         NI_InitPointIterator(arr, &ndiIter); \
         arrData = (char *)PyArray_DATA(arr); \
@@ -1032,8 +1032,8 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
     if (hist != NULL) {
         /* Allocate local data structures to track where we are up to while
            assigning index values */
-        valCtr = (npy_intp *)calloc(numPossibleVals, sizeof(npy_intp));
-        ndxPtr = (PyObject **)calloc(numPossibleVals, sizeof(PyObject  *));
+        valCtr = (npy_intp *)PyMem_RawCalloc(numPossibleVals, sizeof(npy_intp));
+        ndxPtr = (PyObject **)PyMem_RawCalloc(numPossibleVals, sizeof(PyObject  *));
         if (valCtr == NULL)
             PyErr_SetString(PyExc_MemoryError, "Couldn't allocate valCtr");
         else if (ndxPtr == NULL)
@@ -1131,9 +1131,9 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
     }
 
     /* Clean up everything */
-    if (hist != NULL) free(hist);
-    if (valCtr != NULL) free(valCtr);
-    if (ndxPtr != NULL) free(ndxPtr);
+    if (hist != NULL) PyMem_RawFree(hist);
+    if (valCtr != NULL) PyMem_RawFree(valCtr);
+    if (ndxPtr != NULL) PyMem_RawFree(ndxPtr);
     Py_DECREF(minMaxArr);
 
     if (PyErr_Occurred()) {

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -129,8 +129,8 @@ int NI_Correlate1D(PyArrayObject *input, PyArrayObject *weights,
     } while(more);
 exit:
     NPY_END_THREADS;
-    free(ibuffer);
-    free(obuffer);
+    PyMem_RawFree(ibuffer);
+    PyMem_RawFree(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -180,7 +180,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
     /* get the footprint: */
     fsize = PyArray_SIZE(weights);
     pw = (npy_double*)PyArray_DATA(weights);
-    pf = malloc(fsize * sizeof(npy_bool));
+    pf = PyMem_RawMalloc(fsize * sizeof(npy_bool));
     if (!pf) {
         PyErr_NoMemory();
         goto exit;
@@ -194,7 +194,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
         }
     }
     /* copy the weights to contiguous memory: */
-    ww = malloc(filter_size * sizeof(npy_double));
+    ww = PyMem_RawMalloc(filter_size * sizeof(npy_double));
     if (!ww) {
         PyErr_NoMemory();
         goto exit;
@@ -301,9 +301,9 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    free(offsets);
-    free(ww);
-    free(pf);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(ww);
+    PyMem_RawFree(pf);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -369,8 +369,8 @@ NI_UniformFilter1D(PyArrayObject *input, npy_intp filter_size,
 
  exit:
     NPY_END_THREADS;
-    free(ibuffer);
-    free(obuffer);
+    PyMem_RawFree(ibuffer);
+    PyMem_RawFree(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -424,7 +424,7 @@ NI_MinOrMaxFilter1D(PyArrayObject *input, npy_intp filter_size,
     length = PyArray_NDIM(input) > 0 ? PyArray_DIM(input, axis) : 1;
 
     /* ring is a dequeue of pairs implemented as a circular array */
-    ring = malloc(filter_size * sizeof(struct pairs));
+    ring = PyMem_RawMalloc(filter_size * sizeof(struct pairs));
     if (!ring) {
         goto exit;
     }
@@ -490,9 +490,9 @@ NI_MinOrMaxFilter1D(PyArrayObject *input, npy_intp filter_size,
 
  exit:
     NPY_END_THREADS;
-    free(ibuffer);
-    free(obuffer);
-    free(ring);
+    PyMem_RawFree(ibuffer);
+    PyMem_RawFree(obuffer);
+    PyMem_RawFree(ring);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -558,7 +558,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     }
     /* get the structure: */
     if (structure) {
-        ss = malloc(filter_size * sizeof(double));
+        ss = PyMem_RawMalloc(filter_size * sizeof(double));
         if (!ss) {
             PyErr_NoMemory();
             goto exit;
@@ -667,8 +667,8 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    free(offsets);
-    free(ss);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(ss);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -750,7 +750,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
         }
     }
     /* buffer for rank calculation: */
-    buffer = malloc(filter_size * sizeof(double));
+    buffer = PyMem_RawMalloc(filter_size * sizeof(double));
     if (!buffer) {
         PyErr_NoMemory();
         goto exit;
@@ -853,8 +853,8 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    free(offsets);
-    free(buffer);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -910,8 +910,8 @@ int NI_GenericFilter1D(PyArrayObject *input,
         }
     } while(more);
 exit:
-    free(ibuffer);
-    free(obuffer);
+    PyMem_RawFree(ibuffer);
+    PyMem_RawFree(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -982,7 +982,7 @@ int NI_GenericFilter(PyArrayObject* input,
     po = (void *)PyArray_DATA(output);
     size = PyArray_SIZE(input);
     /* buffer for filter calculation: */
-    buffer = malloc(filter_size * sizeof(double));
+    buffer = PyMem_RawMalloc(filter_size * sizeof(double));
     if (!buffer) {
         PyErr_NoMemory();
         goto exit;
@@ -1058,7 +1058,7 @@ int NI_GenericFilter(PyArrayObject* input,
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }
 exit:
-    free(offsets);
-    free(buffer);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -196,7 +196,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
     NPY_BEGIN_THREADS_DEF;
 
     /* precalculate the parameters: */
-    parameters = malloc(PyArray_NDIM(input) * sizeof(double));
+    parameters = PyMem_RawMalloc(PyArray_NDIM(input) * sizeof(double));
     if (!parameters) {
         PyErr_NoMemory();
         goto exit;
@@ -219,7 +219,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
         }
     }
     /* allocate memory for tables: */
-    params = malloc(PyArray_NDIM(input) * sizeof(double*));
+    params = PyMem_RawMalloc(PyArray_NDIM(input) * sizeof(double*));
     if (!params) {
         PyErr_NoMemory();
         goto exit;
@@ -229,7 +229,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
     }
     for (kk = 0; kk < PyArray_NDIM(input); kk++) {
         if (PyArray_DIM(input, kk) > 1 || filter_type == _NI_ELLIPSOID) {
-            params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
+            params[kk] = PyMem_RawMalloc(PyArray_DIM(input, kk) * sizeof(double));
             if (!params[kk]) {
                 PyErr_NoMemory();
                 goto exit;
@@ -441,12 +441,12 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
 
  exit:
     NPY_END_THREADS;
-    free(parameters);
+    PyMem_RawFree(parameters);
     if (params) {
         for (kk = 0; kk < PyArray_NDIM(input); kk++) {
-            free(params[kk]);
+            PyMem_RawFree(params[kk]);
         }
-        free(params);
+        PyMem_RawFree(params);
     }
     return PyErr_Occurred() ? 0 : 1;
 }
@@ -475,7 +475,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
     NPY_BEGIN_THREADS_DEF;
 
     /* precalculate the shifts: */
-    shifts = malloc(PyArray_NDIM(input) * sizeof(double));
+    shifts = PyMem_RawMalloc(PyArray_NDIM(input) * sizeof(double));
     if (!shifts) {
         PyErr_NoMemory();
         goto exit;
@@ -489,7 +489,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
         shifts[kk] = -2.0 * M_PI * *ishifts++ / (double)shape;
     }
     /* allocate memory for tables: */
-    params = malloc(PyArray_NDIM(input) * sizeof(double*));
+    params = PyMem_RawMalloc(PyArray_NDIM(input) * sizeof(double*));
     if (!params) {
         PyErr_NoMemory();
         goto exit;
@@ -499,7 +499,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
     }
     for (kk = 0; kk < PyArray_NDIM(input); kk++) {
         if (PyArray_DIM(input, kk) > 1) {
-            params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
+            params[kk] = PyMem_RawMalloc(PyArray_DIM(input, kk) * sizeof(double));
             if (!params[kk]) {
                 PyErr_NoMemory();
                 goto exit;
@@ -594,12 +594,12 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
 
  exit:
     NPY_END_THREADS;
-    free(shifts);
+    PyMem_RawFree(shifts);
     if (params) {
         for (kk = 0; kk < PyArray_NDIM(input); kk++) {
-            free(params[kk]);
+            PyMem_RawFree(params[kk]);
         }
-        free(params);
+        PyMem_RawFree(params);
     }
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -201,7 +201,7 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
 
  exit:
     NPY_END_THREADS;
-    free(buffer);
+    PyMem_RawFree(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -294,13 +294,13 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     }
 
     /* offsets used at the borders: */
-    edge_offsets = malloc(irank * sizeof(npy_intp*));
+    edge_offsets = PyMem_RawMalloc(irank * sizeof(npy_intp*));
     if (NPY_UNLIKELY(!edge_offsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
         goto exit;
     }
-    data_offsets = malloc(irank * sizeof(npy_intp*));
+    data_offsets = PyMem_RawMalloc(irank * sizeof(npy_intp*));
     if (NPY_UNLIKELY(!data_offsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -312,7 +312,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     if (mode == NI_EXTEND_GRID_CONSTANT) {
         // boolean indicating if the current point in the filter footprint is
         // outside the bounds
-        edge_grid_const = malloc(irank * sizeof(char*));
+        edge_grid_const = PyMem_RawMalloc(irank * sizeof(char*));
         if (NPY_UNLIKELY(!edge_grid_const)) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -321,7 +321,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         for(jj = 0; jj < irank; jj++)
             edge_grid_const[jj] = NULL;
         for(jj = 0; jj < irank; jj++) {
-            edge_grid_const[jj] = malloc((order + 1) * sizeof(char));
+            edge_grid_const[jj] = PyMem_RawMalloc((order + 1) * sizeof(char));
             if (NPY_UNLIKELY(!edge_grid_const[jj])) {
                 NPY_END_THREADS;
                 PyErr_NoMemory();
@@ -331,7 +331,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     }
 
     for(jj = 0; jj < irank; jj++) {
-        data_offsets[jj] = malloc((order + 1) * sizeof(npy_intp));
+        data_offsets[jj] = PyMem_RawMalloc((order + 1) * sizeof(npy_intp));
         if (NPY_UNLIKELY(!data_offsets[jj])) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -339,7 +339,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         }
     }
     /* will hold the spline coefficients: */
-    splvals = malloc(irank * sizeof(double*));
+    splvals = PyMem_RawMalloc(irank * sizeof(double*));
     if (NPY_UNLIKELY(!splvals)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -348,7 +348,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     for(jj = 0; jj < irank; jj++)
         splvals[jj] = NULL;
     for(jj = 0; jj < irank; jj++) {
-        splvals[jj] = malloc((order + 1) * sizeof(double));
+        splvals[jj] = PyMem_RawMalloc((order + 1) * sizeof(double));
         if (NPY_UNLIKELY(!splvals[jj])) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -369,9 +369,9 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     po = (void *)PyArray_DATA(output);
 
     /* make a table of all possible coordinates within the spline filter: */
-    fcoordinates = malloc(irank * filter_size * sizeof(npy_intp));
+    fcoordinates = PyMem_RawMalloc(irank * filter_size * sizeof(npy_intp));
     /* make a table of all offsets within the spline filter: */
-    foffsets = malloc(filter_size * sizeof(npy_intp));
+    foffsets = PyMem_RawMalloc(filter_size * sizeof(npy_intp));
     if (NPY_UNLIKELY(!fcoordinates || !foffsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -636,24 +636,24 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
 
  exit:
     NPY_END_THREADS;
-    free(edge_offsets);
+    PyMem_RawFree(edge_offsets);
     if (edge_grid_const) {
         for(jj = 0; jj < irank; jj++)
-            free(edge_grid_const[jj]);
-        free(edge_grid_const);
+            PyMem_RawFree(edge_grid_const[jj]);
+        PyMem_RawFree(edge_grid_const);
     }
     if (data_offsets) {
         for(jj = 0; jj < irank; jj++)
-            free(data_offsets[jj]);
-        free(data_offsets);
+            PyMem_RawFree(data_offsets[jj]);
+        PyMem_RawFree(data_offsets);
     }
     if (splvals) {
         for(jj = 0; jj < irank; jj++)
-            free(splvals[jj]);
-        free(splvals);
+            PyMem_RawFree(splvals[jj]);
+        PyMem_RawFree(splvals);
     }
-    free(foffsets);
-    free(fcoordinates);
+    PyMem_RawFree(foffsets);
+    PyMem_RawFree(fcoordinates);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -686,7 +686,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
 
     /* if the mode is 'constant' we need some temps later: */
     if (mode == NI_EXTEND_CONSTANT) {
-        zeros = malloc(rank * sizeof(npy_intp*));
+        zeros = PyMem_RawMalloc(rank * sizeof(npy_intp*));
         if (NPY_UNLIKELY(!zeros)) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -695,7 +695,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         for(jj = 0; jj < rank; jj++)
             zeros[jj] = NULL;
         for(jj = 0; jj < rank; jj++) {
-            zeros[jj] = malloc(odimensions[jj] * sizeof(npy_intp));
+            zeros[jj] = PyMem_RawMalloc(odimensions[jj] * sizeof(npy_intp));
             if (NPY_UNLIKELY(!zeros[jj])) {
                 NPY_END_THREADS;
                 PyErr_NoMemory();
@@ -705,7 +705,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     } else if (mode == NI_EXTEND_GRID_CONSTANT) {
         // boolean indicating if the current point in the filter footprint is
         // outside the bounds
-        edge_grid_const = malloc(rank * sizeof(char*));
+        edge_grid_const = PyMem_RawMalloc(rank * sizeof(char*));
         if (NPY_UNLIKELY(!edge_grid_const)) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -714,7 +714,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         for(jj = 0; jj < rank; jj++)
             edge_grid_const[jj] = NULL;
         for(jj = 0; jj < rank; jj++) {
-            edge_grid_const[jj] = malloc(odimensions[jj] * sizeof(char*));
+            edge_grid_const[jj] = PyMem_RawMalloc(odimensions[jj] * sizeof(char*));
             if (NPY_UNLIKELY(!edge_grid_const[jj])) {
                 NPY_END_THREADS;
                 PyErr_NoMemory();
@@ -726,7 +726,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         }
     }
     /* store offsets, along each axis: */
-    offsets = malloc(rank * sizeof(npy_intp*));
+    offsets = PyMem_RawMalloc(rank * sizeof(npy_intp*));
     if (NPY_UNLIKELY(!offsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -736,7 +736,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         offsets[jj] = NULL;
 
     /* store spline coefficients, along each axis: */
-    splvals = malloc(rank * sizeof(double**));
+    splvals = PyMem_RawMalloc(rank * sizeof(double**));
     if (NPY_UNLIKELY(!splvals)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -747,8 +747,8 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
 
     /* store offsets at all edges: */
     for(jj = 0; jj < rank; jj++) {
-        offsets[jj] = malloc(odimensions[jj] * sizeof(npy_intp));
-        splvals[jj] = malloc(odimensions[jj] * sizeof(double*));
+        offsets[jj] = PyMem_RawMalloc(odimensions[jj] * sizeof(npy_intp));
+        splvals[jj] = PyMem_RawMalloc(odimensions[jj] * sizeof(double*));
         if (NPY_UNLIKELY(!offsets[jj] || !splvals[jj])) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -760,7 +760,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     }
 
     if (mode != NI_EXTEND_GRID_CONSTANT){
-        edge_offsets = malloc(rank * sizeof(npy_intp**));
+        edge_offsets = PyMem_RawMalloc(rank * sizeof(npy_intp**));
         if (NPY_UNLIKELY(!edge_offsets)) {
             NPY_END_THREADS;
             PyErr_NoMemory();
@@ -770,7 +770,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
             edge_offsets[jj] = NULL;
         }
         for(jj = 0; jj < rank; jj++) {
-            edge_offsets[jj] = malloc(odimensions[jj] * sizeof(npy_intp*));
+            edge_offsets[jj] = PyMem_RawMalloc(odimensions[jj] * sizeof(npy_intp*));
             if (NPY_UNLIKELY(!edge_offsets[jj])) {
                 NPY_END_THREADS;
                 PyErr_NoMemory();
@@ -824,7 +824,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                     npy_intp idx = 0;
 
                     if (mode == NI_EXTEND_GRID_CONSTANT) {
-                        edge_grid_const[jj][kk] = malloc((order + 1) * sizeof(char));
+                        edge_grid_const[jj][kk] = PyMem_RawMalloc((order + 1) * sizeof(char));
                         if (NPY_UNLIKELY(!edge_grid_const[jj][kk])) {
                             NPY_END_THREADS;
                             PyErr_NoMemory();
@@ -835,7 +835,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                             edge_grid_const[jj][kk][hh] = (idx < 0 || idx >= idimensions[jj]);
                         }
                     } else {
-                        edge_offsets[jj][kk] = malloc((order + 1) * sizeof(npy_intp));
+                        edge_offsets[jj][kk] = PyMem_RawMalloc((order + 1) * sizeof(npy_intp));
                         if (NPY_UNLIKELY(!edge_offsets[jj][kk])) {
                             NPY_END_THREADS;
                             PyErr_NoMemory();
@@ -850,7 +850,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
 
                 }
                 if (order > 0) {
-                    splvals[jj][kk] = malloc((order + 1) * sizeof(double));
+                    splvals[jj][kk] = PyMem_RawMalloc((order + 1) * sizeof(double));
                     if (NPY_UNLIKELY(!splvals[jj][kk])) {
                         NPY_END_THREADS;
                         PyErr_NoMemory();
@@ -875,8 +875,8 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     po = (void *)PyArray_DATA(output);
 
     /* store all coordinates and offsets with filter: */
-    fcoordinates = malloc(rank * filter_size * sizeof(npy_intp));
-    foffsets = malloc(filter_size * sizeof(npy_intp));
+    fcoordinates = PyMem_RawMalloc(rank * filter_size * sizeof(npy_intp));
+    foffsets = PyMem_RawMalloc(filter_size * sizeof(npy_intp));
     if (NPY_UNLIKELY(!fcoordinates || !foffsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -1023,45 +1023,45 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     NPY_END_THREADS;
     if (zeros) {
         for(jj = 0; jj < rank; jj++)
-            free(zeros[jj]);
-        free(zeros);
+            PyMem_RawFree(zeros[jj]);
+        PyMem_RawFree(zeros);
     }
     if (offsets) {
         for(jj = 0; jj < rank; jj++)
-            free(offsets[jj]);
-        free(offsets);
+            PyMem_RawFree(offsets[jj]);
+        PyMem_RawFree(offsets);
     }
     if (splvals) {
         for(jj = 0; jj < rank; jj++) {
             if (splvals[jj]) {
                 for(hh = 0; hh < odimensions[jj]; hh++)
-                    free(splvals[jj][hh]);
-                free(splvals[jj]);
+                    PyMem_RawFree(splvals[jj][hh]);
+                PyMem_RawFree(splvals[jj]);
             }
         }
-        free(splvals);
+        PyMem_RawFree(splvals);
     }
     if (edge_offsets) {
         for(jj = 0; jj < rank; jj++) {
             if (edge_offsets[jj]) {
                 for(hh = 0; hh < odimensions[jj]; hh++)
-                    free(edge_offsets[jj][hh]);
-                free(edge_offsets[jj]);
+                    PyMem_RawFree(edge_offsets[jj][hh]);
+                PyMem_RawFree(edge_offsets[jj]);
             }
         }
-        free(edge_offsets);
+        PyMem_RawFree(edge_offsets);
     }
     if (edge_grid_const) {
         for(jj = 0; jj < rank; jj++) {
             if (edge_grid_const[jj]) {
                 for(hh = 0; hh < odimensions[jj]; hh++)
-                    free(edge_grid_const[jj][hh]);
-                free(edge_grid_const[jj]);
+                    PyMem_RawFree(edge_grid_const[jj][hh]);
+                PyMem_RawFree(edge_grid_const[jj]);
             }
         }
-        free(edge_grid_const);
+        PyMem_RawFree(edge_grid_const);
     }
-    free(foffsets);
-    free(fcoordinates);
+    PyMem_RawFree(foffsets);
+    PyMem_RawFree(fcoordinates);
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -231,7 +231,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     }
     size = PyArray_SIZE(input);
     /* Storage for the temporary queue data. */
-    temp = malloc(size * sizeof(NI_WatershedElement));
+    temp = PyMem_RawMalloc(size * sizeof(NI_WatershedElement));
     if (!temp) {
         PyErr_NoMemory();
         goto exit;
@@ -262,8 +262,8 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     }
     pi = (void *)PyArray_DATA(input);
     /* Allocate and initialize the storage for the queue. */
-    first = malloc((maxval + 1) * sizeof(NI_WatershedElement*));
-    last = malloc((maxval + 1) * sizeof(NI_WatershedElement*));
+    first = PyMem_RawMalloc((maxval + 1) * sizeof(NI_WatershedElement*));
+    last = PyMem_RawMalloc((maxval + 1) * sizeof(NI_WatershedElement*));
     if (NPY_UNLIKELY(!first || !last)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -366,7 +366,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     for (kk = 0; kk < ssize; kk++)
         if (ps[kk] && kk != (ssize / 2))
             ++nneigh;
-    nstrides = malloc(nneigh * sizeof(npy_intp));
+    nstrides = PyMem_RawMalloc(nneigh * sizeof(npy_intp));
     if (NPY_UNLIKELY(!nstrides)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
@@ -612,9 +612,9 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     }
  exit:
     NPY_END_THREADS;
-    free(temp);
-    free(first);
-    free(last);
-    free(nstrides);
+    PyMem_RawFree(temp);
+    PyMem_RawFree(first);
+    PyMem_RawFree(last);
+    PyMem_RawFree(nstrides);
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -295,7 +295,7 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
 
  exit:
     NPY_END_THREADS;
-    free(offsets);
+    PyMem_RawFree(offsets);
     if (PyErr_Occurred()) {
         if (coordinate_list) {
             NI_FreeCoordinateList(*coordinate_list);
@@ -565,8 +565,8 @@ int NI_BinaryErosion2(PyArrayObject* array, PyArrayObject* strct,
 
  exit:
     NPY_END_THREADS;
-    free(offsets);
-    free(coordinate_offsets);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(coordinate_offsets);
     NI_FreeCoordinateList(list1);
     NI_FreeCoordinateList(list2);
     return PyErr_Occurred() ? 0 : 1;
@@ -617,7 +617,7 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
 
     for(jj = 0; jj < size; jj++) {
         if (*(npy_int8*)pi < 0) {
-            temp = malloc(sizeof(NI_BorderElement));
+            temp = PyMem_RawMalloc(sizeof(NI_BorderElement));
             if (NPY_UNLIKELY(!temp)) {
                 PyErr_NoMemory();
                 goto exit;
@@ -625,7 +625,7 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
             temp->next = border_elements;
             border_elements = temp;
             temp->index = jj;
-            temp->coordinates = malloc(PyArray_NDIM(input) *
+            temp->coordinates = PyMem_RawMalloc(PyArray_NDIM(input) *
                                        sizeof(npy_intp));
             if (!temp->coordinates) {
                 PyErr_NoMemory();
@@ -740,8 +740,8 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
     while (border_elements) {
         temp = border_elements;
         border_elements = border_elements->next;
-        free(temp->coordinates);
-        free(temp);
+        PyMem_RawFree(temp->coordinates);
+        PyMem_RawFree(temp);
     }
     return PyErr_Occurred() ? 0 : 1;
 }
@@ -763,7 +763,7 @@ int NI_DistanceTransformOnePass(PyArrayObject *strct,
 
     /* we only use the first half of the structure data, so we make a
          temporary structure for use with the filter functions: */
-    footprint = malloc(ssize * sizeof(npy_bool));
+    footprint = PyMem_RawMalloc(ssize * sizeof(npy_bool));
     if (!footprint) {
         PyErr_NoMemory();
         goto exit;
@@ -851,9 +851,9 @@ int NI_DistanceTransformOnePass(PyArrayObject *strct,
 
  exit:
     NPY_END_THREADS;
-    free(offsets);
-    free(foffsets);
-    free(footprint);
+    PyMem_RawFree(offsets);
+    PyMem_RawFree(foffsets);
+    PyMem_RawFree(footprint);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -1030,9 +1030,9 @@ int NI_EuclideanFeatureTransform(PyArrayObject* input,
     }
 
     /* Some temporaries */
-    f = malloc(mx * sizeof(npy_intp*));
-    g = malloc(mx * sizeof(npy_intp));
-    tmp = malloc(mx * PyArray_NDIM(input) * sizeof(npy_intp));
+    f = PyMem_RawMalloc(mx * sizeof(npy_intp*));
+    g = PyMem_RawMalloc(mx * sizeof(npy_intp));
+    tmp = PyMem_RawMalloc(mx * PyArray_NDIM(input) * sizeof(npy_intp));
     if (!f || !g || !tmp) {
         PyErr_NoMemory();
         goto exit;
@@ -1049,9 +1049,9 @@ int NI_EuclideanFeatureTransform(PyArrayObject* input,
     NPY_END_THREADS;
 
  exit:
-    free(f);
-    free(g);
-    free(tmp);
+    PyMem_RawFree(f);
+    PyMem_RawFree(g);
+    PyMem_RawFree(tmp);
 
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -109,7 +109,7 @@ int NI_AllocateLineBuffer(PyArrayObject* array, int axis, npy_intp size1,
     if (*lines > max_lines)
         *lines = max_lines;
     /* allocate data for the buffer: */
-    *buffer = malloc(*lines * line_size);
+    *buffer = PyMem_RawMalloc(*lines * line_size);
     if (!*buffer) {
         PyErr_NoMemory();
         return 0;
@@ -553,13 +553,13 @@ int NI_InitFilterOffsets(PyArrayObject *array, npy_bool *footprint,
     for(ii = 0; ii < rank; ii++)
         offsets_size *= (ashape[ii] < fshape[ii] ? ashape[ii] : fshape[ii]);
     /* allocate offsets data: */
-    *offsets = malloc(offsets_size * footprint_size * sizeof(npy_intp));
+    *offsets = PyMem_RawMalloc(offsets_size * footprint_size * sizeof(npy_intp));
     if (!*offsets) {
         PyErr_NoMemory();
         goto exit;
     }
     if (coordinate_offsets) {
-        *coordinate_offsets = malloc(offsets_size * rank
+        *coordinate_offsets = PyMem_RawMalloc(offsets_size * rank
                                      * footprint_size * sizeof(npy_intp));
         if (!*coordinate_offsets) {
             PyErr_NoMemory();
@@ -733,10 +733,10 @@ int NI_InitFilterOffsets(PyArrayObject *array, npy_bool *footprint,
 
  exit:
     if (PyErr_Occurred()) {
-        free(*offsets);
+        PyMem_RawFree(*offsets);
         *offsets = NULL;
         if (coordinate_offsets) {
-            free(*coordinate_offsets);
+            PyMem_RawFree(*coordinate_offsets);
             *coordinate_offsets = NULL;
         }
         return 0;
@@ -747,7 +747,7 @@ int NI_InitFilterOffsets(PyArrayObject *array, npy_bool *footprint,
 
 NI_CoordinateList* NI_InitCoordinateList(int size, int rank)
 {
-    NI_CoordinateList *list = malloc(sizeof(NI_CoordinateList));
+    NI_CoordinateList *list = PyMem_RawMalloc(sizeof(NI_CoordinateList));
     if (!list) {
         return NULL;
     }
@@ -777,14 +777,14 @@ int NI_CoordinateListStealBlocks(NI_CoordinateList *list1,
 NI_CoordinateBlock* NI_CoordinateListAddBlock(NI_CoordinateList *list)
 {
     NI_CoordinateBlock* block = NULL;
-    block = malloc(sizeof(NI_CoordinateBlock));
+    block = PyMem_RawMalloc(sizeof(NI_CoordinateBlock));
     if (!block) {
         return NULL;
     }
-    block->coordinates = malloc((size_t)list->block_size * list->rank
+    block->coordinates = PyMem_RawMalloc((size_t)list->block_size * list->rank
                                 * sizeof(npy_intp));
     if (!block->coordinates) {
-        free(block);
+        PyMem_RawFree(block);
         return NULL;
     }
     block->next = list->blocks;
@@ -799,8 +799,8 @@ NI_CoordinateBlock* NI_CoordinateListDeleteBlock(NI_CoordinateList *list)
     NI_CoordinateBlock* block = list->blocks;
     if (block) {
         list->blocks = block->next;
-        free(block->coordinates);
-        free(block);
+        PyMem_RawFree(block->coordinates);
+        PyMem_RawFree(block);
     }
     return list->blocks;
 }
@@ -812,10 +812,10 @@ void NI_FreeCoordinateList(NI_CoordinateList *list)
         while (block) {
             NI_CoordinateBlock *tmp = block;
             block = block->next;
-            free(tmp->coordinates);
-            free(tmp);
+            PyMem_RawFree(tmp->coordinates);
+            PyMem_RawFree(tmp);
         }
         list->blocks = NULL;
-        free(list);
+        PyMem_RawFree(list);
     }
 }

--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -35,7 +35,7 @@ direct(PyObject *self, PyObject *args)
     }
 
     dimension = PyArray_DIMS((PyArrayObject*)lb)[0];
-    x = (double *) malloc(sizeof(double) * (dimension + 1));
+    x = (double *) PyMem_RawMalloc(sizeof(double) * (dimension + 1));
     if (!x) {
         PyErr_NoMemory();
         return NULL;
@@ -55,7 +55,7 @@ direct(PyObject *self, PyObject *args)
     if (!direct_ret) {
         Py_DECREF(x_seq);
         if (x)
-            free(x);
+            PyMem_RawFree(x);
         /* Some failure paths inside direct_direct_ return NULL without
            setting a Python exception. Surface those here so CPython does not
            raise SystemError for "returned NULL without setting an error". */
@@ -76,7 +76,7 @@ direct(PyObject *self, PyObject *args)
        original reference since the tuple now owns it. */
     Py_DECREF(x_seq);
     if (x)
-        free(x);
+        PyMem_RawFree(x);
     return ret_py;
 }
 

--- a/scipy/optimize/_minpackmodule.c
+++ b/scipy/optimize/_minpackmodule.c
@@ -430,7 +430,7 @@ static PyObject *minpack_hybrd(PyObject *dummy, PyObject *args) {
   fjac = (double *) PyArray_DATA(ap_fjac);
   ldfjac = dims[1];
 
-  if ((wa = malloc(4*n * sizeof(double)))==NULL) {
+  if ((wa = PyMem_RawMalloc(4*n * sizeof(double)))==NULL) {
     PyErr_NoMemory();
     goto fail;
   }
@@ -445,7 +445,7 @@ static PyObject *minpack_hybrd(PyObject *dummy, PyObject *args) {
   if (info < 0) goto fail;            /* Python Terminated */
 
 
-  free(wa);
+  PyMem_RawFree(wa);
   Py_DECREF(extra_args);
   Py_DECREF(ap_diag);
 
@@ -470,7 +470,7 @@ static PyObject *minpack_hybrd(PyObject *dummy, PyObject *args) {
   Py_XDECREF(ap_fjac);
   Py_XDECREF(ap_r);
   Py_XDECREF(ap_qtf);
-  if (allocated) free(wa);
+  if (allocated) PyMem_RawFree(wa);
   return NULL;
 }
 
@@ -574,7 +574,7 @@ static PyObject *minpack_hybrj(PyObject *dummy, PyObject *args) {
 
   ldfjac = dims[1];
 
-  if ((wa = malloc(4*n * sizeof(double)))==NULL) {
+  if ((wa = PyMem_RawMalloc(4*n * sizeof(double)))==NULL) {
     PyErr_NoMemory();
     goto fail;
   }
@@ -588,7 +588,7 @@ static PyObject *minpack_hybrj(PyObject *dummy, PyObject *args) {
 
   if (info < 0) goto fail;            /* Python Terminated */
 
-  free(wa);
+  PyMem_RawFree(wa);
   Py_DECREF(extra_args);
   Py_DECREF(ap_diag);
 
@@ -613,7 +613,7 @@ static PyObject *minpack_hybrj(PyObject *dummy, PyObject *args) {
   Py_XDECREF(ap_diag);
   Py_XDECREF(ap_r);
   Py_XDECREF(ap_qtf);
-  if (allocated) free(wa);
+  if (allocated) PyMem_RawFree(wa);
   return NULL;
 
 }
@@ -715,7 +715,7 @@ static PyObject *minpack_lmdif(PyObject *dummy, PyObject *args) {
   qtf = (double *) PyArray_DATA(ap_qtf);
   fjac = (double *) PyArray_DATA(ap_fjac);
   ldfjac = dims[1];
-  wa = (double *)malloc((3*n + m)* sizeof(double));
+  wa = (double *)PyMem_RawMalloc((3*n + m)* sizeof(double));
   if (wa == NULL) {
     PyErr_NoMemory();
     goto fail;
@@ -730,7 +730,7 @@ static PyObject *minpack_lmdif(PyObject *dummy, PyObject *args) {
 
   if (info < 0) goto fail;           /* Python error */
 
-  free(wa);
+  PyMem_RawFree(wa);
   Py_DECREF(extra_args);
   Py_DECREF(ap_diag);
 
@@ -755,7 +755,7 @@ static PyObject *minpack_lmdif(PyObject *dummy, PyObject *args) {
   Py_XDECREF(ap_diag);
   Py_XDECREF(ap_ipvt);
   Py_XDECREF(ap_qtf);
-  if (allocated) free(wa);
+  if (allocated) PyMem_RawFree(wa);
   return NULL;
 }
 
@@ -858,7 +858,7 @@ static PyObject *minpack_lmder(PyObject *dummy, PyObject *args) {
   qtf = (double *) PyArray_DATA(ap_qtf);
   fjac = (double *) PyArray_DATA(ap_fjac);
   ldfjac = dims[1];
-  wa = (double *)malloc((3*n + m)* sizeof(double));
+  wa = (double *)PyMem_RawMalloc((3*n + m)* sizeof(double));
   if (wa == NULL) {
     PyErr_NoMemory();
     goto fail;
@@ -873,7 +873,7 @@ static PyObject *minpack_lmder(PyObject *dummy, PyObject *args) {
 
   if (info < 0) goto fail;           /* Python error */
 
-  free(wa);
+  PyMem_RawFree(wa);
   Py_DECREF(extra_args);
   Py_DECREF(ap_diag);
 
@@ -898,7 +898,7 @@ static PyObject *minpack_lmder(PyObject *dummy, PyObject *args) {
   Py_XDECREF(ap_diag);
   Py_XDECREF(ap_ipvt);
   Py_XDECREF(ap_qtf);
-  if (allocated) free(wa);
+  if (allocated) PyMem_RawFree(wa);
   return NULL;
 }
 

--- a/scipy/optimize/_slsqpmodule.c
+++ b/scipy/optimize/_slsqpmodule.c
@@ -13,7 +13,7 @@ static PyObject* slsqp_error;
 static void
 capsule_destructor(PyObject *capsule) {
     void *ptr = PyCapsule_GetPointer(capsule, NULL);
-    free(ptr);
+    PyMem_RawFree(ptr);
 }
 
 
@@ -81,15 +81,15 @@ nnls(PyObject* Py_UNUSED(dummy), PyObject* args) {
     // A is m x n, b is m, x is n, w is n, zz is m
     // total m*(n+2) + 2*n
     //indices is n
-    buffer = malloc((m*(n+2) + 3*n)*sizeof(double));
+    buffer = PyMem_RawMalloc((m*(n+2) + 3*n)*sizeof(double));
     if (buffer == NULL)
     {
         PYERR(slsqp_error, "Memory allocation failed.");
     }
-    CBLAS_INT *indices = malloc(n*sizeof(CBLAS_INT));
+    CBLAS_INT *indices = PyMem_RawMalloc(n*sizeof(CBLAS_INT));
     if (indices == NULL)
     {
-        free(buffer);
+        PyMem_RawFree(buffer);
         PYERR(slsqp_error, "Memory allocation failed.");
     }
 
@@ -120,19 +120,19 @@ nnls(PyObject* Py_UNUSED(dummy), PyObject* args) {
     // Call nnls
     __nnls((CBLAS_INT)m, (CBLAS_INT)n, a, b, x, w, zz, indices, maxiter, &rnorm, &info);
     // x is the first n elements of buffer, shrink buffer to n elements
-    free(indices);
-    double* mem_ret = realloc(buffer, n*sizeof(double));
+    PyMem_RawFree(indices);
+    double* mem_ret = PyMem_RawRealloc(buffer, n*sizeof(double));
     // Very unlikely, but just in case
     if (mem_ret == NULL)
     {
-        free(buffer);
+        PyMem_RawFree(buffer);
         PYERR(slsqp_error, "scipy.optimize._slsqplib: Memory reallocation failed.");
     }
 
     npy_intp shape_ret[1] = {n};
     PyArrayObject* ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(1, shape_ret, NPY_FLOAT64, mem_ret);
     if (ap_ret == NULL) {
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         PYERR(slsqp_error, "scipy.optimize._slsqplib: Failed to create numpy array from data.");
     }
 
@@ -140,7 +140,7 @@ nnls(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyObject* capsule = PyCapsule_New(mem_ret, NULL, capsule_destructor);
     if (capsule == NULL) {
         Py_DECREF(ap_ret);
-        free(mem_ret);
+        PyMem_RawFree(mem_ret);
         PYERR(slsqp_error, "scipy.optimize._slsqplib: Failed to create capsule.");
     }
 

--- a/scipy/signal/_firfilter.cc
+++ b/scipy/signal/_firfilter.cc
@@ -196,7 +196,7 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
   if ((boundary != PAD) && (boundary != REFLECT) && (boundary != CIRCULAR))
     return -2; /* Invalid boundary flag */
 
-  char **indices = (char **)malloc(Nwin[1] * sizeof(indices[0]));
+  char **indices = (char **)PyMem_RawMalloc(Nwin[1] * sizeof(indices[0]));
   if (indices == NULL) return -3; /* No memory */
 
   /* Speed this up by not doing any if statements in the for loop.  Need 3*3*2=18 different
@@ -259,6 +259,6 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
       }
     }
   }
-  free(indices);
+  PyMem_RawFree(indices);
   return 0;
 }

--- a/scipy/signal/_lfilter.cc
+++ b/scipy/signal/_lfilter.cc
@@ -411,19 +411,19 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
 
     nfilt = na > nb ? na : nb;
 
-    azfilled = (char *)malloc(nal * nfilt);
+    azfilled = (char *)PyMem_RawMalloc(nal * nfilt);
     if (azfilled == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Could not create azfilled");
         goto clean_itzf;
     }
-    bzfilled = (char *)malloc(nbl * nfilt);
+    bzfilled = (char *)PyMem_RawMalloc(nbl * nfilt);
     if (bzfilled == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Could not create bzfilled");
         goto clean_azfilled;
     }
 
     nxl = PyArray_ITEMSIZE(x);
-    zfzfilled = (char *)malloc(nxl * (nfilt - 1));
+    zfzfilled = (char *)PyMem_RawMalloc(nxl * (nfilt - 1));
     if (zfzfilled == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Could not create zfzfilled");
         goto clean_bzfilled;
@@ -485,9 +485,9 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
     }
 
     /* Free up allocated memory */
-    free(zfzfilled);
-    free(bzfilled);
-    free(azfilled);
+    PyMem_RawFree(zfzfilled);
+    PyMem_RawFree(bzfilled);
+    PyMem_RawFree(azfilled);
 
     if (zi != NULL) {
         Py_DECREF(itzf);
@@ -499,11 +499,11 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
     return 0;
 
 clean_zfzfilled:
-    free(zfzfilled);
+    PyMem_RawFree(zfzfilled);
 clean_bzfilled:
-    free(bzfilled);
+    PyMem_RawFree(bzfilled);
 clean_azfilled:
-    free(azfilled);
+    PyMem_RawFree(azfilled);
 clean_itzf:
     if (zf != NULL) {
         Py_DECREF(itzf);

--- a/scipy/signal/_medianfilter.cc
+++ b/scipy/signal/_medianfilter.cc
@@ -79,7 +79,7 @@ void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns, int* errnum)    \
     TYPE *myvals, *fptr1, *fptr2, *ptr1, *ptr2;                         \
                                                                         \
     totN = Nwin[0] * Nwin[1];                                           \
-    myvals = (TYPE *) malloc( totN * sizeof(TYPE));                     \
+    myvals = (TYPE *) PyMem_RawMalloc( totN * sizeof(TYPE));                     \
     if (myvals == NULL) {                                               \
 	*errnum = -1;                                                   \
 	return;                                                         \
@@ -120,7 +120,7 @@ void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns, int* errnum)    \
                                                                         \
     Py_END_ALLOW_THREADS                                                \
                                                                         \
-    free(myvals);                                                       \
+    PyMem_RawFree(myvals);                                                       \
     *errnum = 0;                                                        \
 }
 

--- a/scipy/signal/_sigtoolsmodule.cc
+++ b/scipy/signal/_sigtoolsmodule.cc
@@ -508,7 +508,7 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
      work  (dimsize+1)*6
 
   */
-  tempstor = (double *)malloc((total_dsize)*sizeof(double)+(total_isize)*sizeof(int));
+  tempstor = (double *)PyMem_RawMalloc((total_dsize)*sizeof(double)+(total_isize)*sizeof(int));
   if (tempstor == NULL) return -2;
 
   des = tempstor; grid = des + wrksize+1;
@@ -549,7 +549,7 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
 	    wt[j] = wate(temp,fx,wtx,lband,jtype);
 	    if (++j > wrksize) {
                 /* too many points, or too dense grid */
-                free(tempstor);
+                PyMem_RawFree(tempstor);
                 return -1;
             }
 	    grid[j] = temp + delf;
@@ -574,7 +574,7 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
     if (ngrid < nfcns + 1) {
 	*ngrid_out = ngrid;
 	*nfcns_out = nfcns;
-	free(tempstor);
+	PyMem_RawFree(tempstor);
 	return -3;
     }
 
@@ -617,7 +617,7 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
 
     if (remez(&dev, des, grid, edge, wt, ngrid, numbands, iext, alpha, nfcns,
               maxiter, work, dimsize, niter_out) < 0) {
-        free(tempstor);
+        PyMem_RawFree(tempstor);
         return -1;
     }
 
@@ -665,7 +665,7 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
     }
     if (neg == 1 && nodd == 1) h[nz] = 0.0;
 
-  free(tempstor);
+  PyMem_RawFree(tempstor);
   return 0;
 
 }
@@ -745,7 +745,7 @@ static PyObject *_sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *arg
         if (afill == NULL) goto fail;
     }
 
-    aout_dimens = (npy_intp *)malloc(PyArray_NDIM(ain1)*sizeof(npy_intp));
+    aout_dimens = (npy_intp *)PyMem_RawMalloc(PyArray_NDIM(ain1)*sizeof(npy_intp));
     if (aout_dimens == NULL) goto fail;
     switch(mode & OUTSIZE_MASK) {
     case VALID:
@@ -796,7 +796,7 @@ static PyObject *_sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *arg
 
     switch (ret) {
     case 0:
-      free(aout_dimens);
+      PyMem_RawFree(aout_dimens);
       Py_DECREF(ain1);
       Py_DECREF(ain2);
       Py_XDECREF(afill);
@@ -821,7 +821,7 @@ static PyObject *_sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *arg
     }
 
 fail:
-    free(aout_dimens);
+    PyMem_RawFree(aout_dimens);
     Py_XDECREF(ain1);
     Py_XDECREF(ain2);
     Py_XDECREF(aout);

--- a/scipy/signal/_splinemodule.h
+++ b/scipy/signal/_splinemodule.h
@@ -336,7 +336,7 @@ int _separable_2Dconvolve_mirror(T *in, T *out, int M, int N, T *hr, T *hc, int 
     T *inptr = NULL;
     T *outptr = NULL;
 
-    tmpmem = (T *)malloc((size_t)M*N*sizeof(T));
+    tmpmem = (T *)PyMem_RawMalloc((size_t)M*N*sizeof(T));
     if (tmpmem == NULL) {
         return -1;
     }
@@ -365,6 +365,6 @@ int _separable_2Dconvolve_mirror(T *in, T *out, int M, int N, T *hr, T *hc, int 
     } else
         memmove(out, tmpmem, (size_t)M*N*sizeof(T));
 
-    free(tmpmem);
+    PyMem_RawFree(tmpmem);
     return 0;
 }

--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -107,7 +107,7 @@ void *superlu_python_module_malloc(size_t size)
     if (g == NULL) {
         return NULL;
     }
-    mem_ptr = malloc(size);
+    mem_ptr = PyMem_RawMalloc(size);
     if (mem_ptr == NULL) {
         NPY_DISABLE_C_API;
         return NULL;
@@ -125,7 +125,7 @@ void *superlu_python_module_malloc(size_t size)
   fail:
     Py_XDECREF(key);
     NPY_DISABLE_C_API;
-    free(mem_ptr);
+    PyMem_RawFree(mem_ptr);
     superlu_python_module_abort
         ("superlu_malloc: Cannot set dictionary key value in malloc.");
     return NULL;
@@ -157,7 +157,7 @@ void superlu_python_module_free(void *ptr)
      */
     if (key != NULL) {
         if (!PyDict_DelItem(g->memory_dict, key)) {
-            free(ptr);
+            PyMem_RawFree(ptr);
         }
         Py_DECREF(key);
     }
@@ -175,7 +175,7 @@ static void SuperLUGlobal_dealloc(SuperLUGlobalObject *self)
         while (PyDict_Next(self->memory_dict, &pos, &key, &value)) {
             void *ptr;
             ptr = PyLong_AsVoidPtr(key);
-            free(ptr);
+            PyMem_RawFree(ptr);
         }
     }
 

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -270,7 +270,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
 
             if ((*p == 'l' || PyArray_EquivTypenums(I_typenum, NPY_INT64))
                     && value == (npy_int64)value) {
-                arg_list[j] = std::malloc(sizeof(npy_int64));
+                arg_list[j] = PyMem_RawMalloc(sizeof(npy_int64));
                 if (arg_list[j] == NULL) {
                     PyErr_NoMemory();
                     goto fail;
@@ -279,7 +279,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
             }
             else if (*p == 'i' && PyArray_EquivTypenums(I_typenum, NPY_INT32)
                      && value == (npy_int32)value) {
-                arg_list[j] = std::malloc(sizeof(npy_int32));
+                arg_list[j] = PyMem_RawMalloc(sizeof(npy_int32));
                 if (arg_list[j] == NULL) {
                     PyErr_NoMemory();
                     goto fail;
@@ -450,7 +450,7 @@ fail:
         }
         Py_XDECREF(arg_arrays[j]);
         if ((*p == 'i' || *p == 'l') && arg_list[j] != NULL) {
-            std::free(arg_list[j]);
+            PyMem_RawFree(arg_list[j]);
         }
         else if (*p == 'V' && arg_list[j] != NULL) {
             free_std_vector_typenum(I_typenum, arg_list[j]);


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/issues/25648

#### What does this implement/fix?
<!--Please explain your changes.-->

Replace direct malloc/calloc/realloc/free calls with PyMem_RawMalloc, PyMem_RawCalloc, PyMem_RawRealloc and PyMem_RawFree in SciPy's own C/C++ code that already includes Python.h directly or transitively.



#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Used Claude to find all the places where Python.h was already included and raw allocator could be used directly. 