### PR TITLE
TYP: sparse: ``_spbase`` as base class for ``sparray`` and ``spmatrix``

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -135,7 +135,7 @@ class _spbase(SparseABC):
 
     def __init__(self, arg1, *, maxprint=None):
         self._shape = None
-        if self.__class__.__name__ == '_spbase':
+        if self.__class__.__name__ in {'_spbase', 'sparray', 'spmatrix'}:
             raise ValueError("This class is not intended"
                              " to be instantiated directly.")
         if isinstance(self, sparray) and np.isscalar(arg1):
@@ -1719,7 +1719,8 @@ class sparray(_spbase):  # numpydoc ignore=PR01
     """A namespace class to separate sparray from spmatrix.
 
     This class serves as the namespace for SciPy sparse array types.
-    It cannot be instantiated and is designed as a mixin class.
+    It cannot be instantiated. Most of the work is provided by subclasses.
+    Use a subclass that overrides at least one of ``tocoo`` or ``tocsr``.
     """
 
     @classmethod

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -10,8 +10,6 @@ from ._sputils import (asmatrix, check_shape,
                        matrix, validateaxis, getdtype, is_pydata_spmatrix)
 from scipy._lib._sparse import SparseABC, issparse
 
-from ._matrix import spmatrix
-
 __all__ = ['isspmatrix', 'issparse', 'sparray',
            'SparseWarning', 'SparseEfficiencyWarning']
 
@@ -1717,7 +1715,7 @@ class _spbase(SparseABC):
                                (check_contents and not isinstance(self, sparray)))
 
 
-class sparray:
+class sparray(_spbase):  # numpydoc ignore=PR01
     """A namespace class to separate sparray from spmatrix.
 
     This class serves as the namespace for SciPy sparse array types.
@@ -1789,4 +1787,6 @@ def isspmatrix(x):
     >>> isspmatrix(5)
     False
     """
+    from ._matrix import spmatrix
+
     return isinstance(x, spmatrix)

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -9,7 +9,8 @@ import os
 from warnings import warn
 
 from ._coo import coo_array, coo_matrix
-from ._base import sparray, spmatrix
+from ._base import sparray
+from ._matrix import spmatrix
 
 
 def find(A):

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -1,8 +1,10 @@
 import os
 from warnings import warn
 
+from ._base import _spbase
 
-class spmatrix:
+
+class spmatrix(_spbase):
     """This class provides a base class for all sparse matrix classes.
 
     .. warning::

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -17,7 +17,8 @@ class spmatrix(_spbase):
        :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     This class also serves as the namespace for SciPy sparse matrix types.
-    It cannot be instantiated.  Most of the work is provided by subclasses.
+    It cannot be instantiated. Most of the work is provided by subclasses.
+    Use a subclass that overrides at least one of ``tocoo`` or ``tocsr``.
     """
     _allow_nd: tuple[int, ...] = (2,)
 


### PR DESCRIPTION
As explained in #22432, the public `sparse.{sparray,spmatrix}` mixin classes do not have any of the methods that the concrete sparse array/matrix classes have. This is problematic for static typing, and there is no good way to work around this in scipy-stubs. The only viable solution is to have `sparray` and `spmatrix` inherit directly from `_spbase` in SciPy itself.

The resulting pullback-y / diamond-like inheritance pattern might seem sketchy, but is actually perfectly fine, and is even used in the CPython standard library (e.g. `pathlib`).

This doesn't change any behavior, and I don't expect that this will affect any downstream users (assuming they don't rely on subclass checks against the private `_spbase` class). 

#### Reference issue
Closes #22432

#### Additional information
The Egyptian goose is a duck; not a goose.

#### AI Generation Disclosure
No AI tools used