### PR TITLE
BUG: signal.placepoles: Always return complex-valued `computed_poles`.

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3331,14 +3331,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     full_state_feedback = Bunch()
     full_state_feedback.gain_matrix = gain_matrix
     full_state_feedback.computed_poles = _order_complex_poles(
-        np.linalg.eig(A - np.dot(B, gain_matrix))[0]
-        )
-    # Before NumPy 2.5, `np.linalg.eig` would return eithera a real-valued or a
-    # complex-valued array. Hence, ensure that computed_poles is always complex-valued:
-    if not np.isdtype(full_state_feedback.computed_poles.dtype, 'complex floating'):
-        dtyp = np.result_type(full_state_feedback.computed_poles, np.complex64)
-        full_state_feedback.computed_poles = \
-            full_state_feedback.computed_poles.astype(dtyp)
+        linalg.eigvals(A - np.dot(B, gain_matrix)))  # complex-valued poles
     full_state_feedback.requested_poles = poles
     full_state_feedback.X = transfer_matrix
     full_state_feedback.rtol = cur_rtol

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2661,6 +2661,9 @@ def _order_complex_poles(poles):
     real_poles, complex_i, conjugate complex_i, ....
     The lexicographic sort on the complex poles is added to help the user to
     compare sets of poles.
+
+    The return dtype is always of type complex floating.
+    Currently, this helper is only used by `_valid_inputs` and `place_poles`.
     """
     ordered_poles = np.sort(poles[np.isreal(poles)])
     im_poles = []
@@ -2672,6 +2675,9 @@ def _order_complex_poles(poles):
 
     if poles.shape[0] != len(ordered_poles):
         raise ValueError("Complex poles must come with their conjugates")
+    if not np.isdtype(ordered_poles.dtype, 'complex floating'):
+        out_dtype = np.result_type(ordered_poles, 0.+1j)
+        ordered_poles = ordered_poles.astype(out_dtype)
     return ordered_poles
 
 
@@ -3100,7 +3106,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
-
+    ...
     >>> A = np.array([[ 1.380,  -0.2077,  6.715, -5.676  ],
     ...               [-0.5814, -4.290,   0,      0.6750 ],
     ...               [ 1.067,   4.273,  -6.654,  5.893  ],
@@ -3122,7 +3128,8 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
 
     >>> fsf2 = signal.place_poles(A, B, P)  # uses YT method
     >>> fsf2.computed_poles
-    array([-8.6659, -5.0566, -0.5   , -0.2   ])
+    array([-8.6659+0.j, -5.0566+0.j, -0.5   +0.j, -0.2   +0.j])
+
 
     >>> fsf3 = signal.place_poles(A, B, P, rtol=-1, maxiter=100)
     >>> fsf3.X

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2662,7 +2662,6 @@ def _order_complex_poles(poles):
     The lexicographic sort on the complex poles is added to help the user to
     compare sets of poles.
 
-    The return dtype is always of type complex floating.
     Currently, this helper is only used by `_valid_inputs` and `place_poles`.
     """
     ordered_poles = np.sort(poles[np.isreal(poles)])
@@ -2675,9 +2674,6 @@ def _order_complex_poles(poles):
 
     if poles.shape[0] != len(ordered_poles):
         raise ValueError("Complex poles must come with their conjugates")
-    if not np.isdtype(ordered_poles.dtype, 'complex floating'):
-        out_dtype = np.result_type(ordered_poles, 0.+1j)
-        ordered_poles = ordered_poles.astype(out_dtype)
     return ordered_poles
 
 
@@ -3337,6 +3333,12 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     full_state_feedback.computed_poles = _order_complex_poles(
         np.linalg.eig(A - np.dot(B, gain_matrix))[0]
         )
+    # Before NumPy 2.5, `np.linalg.eig` would return eithera a real-valued or a
+    # complex-valued array. Hence, ensure that computed_poles is always complex-valued:
+    if not np.isdtype(full_state_feedback.computed_poles.dtype, 'complex floating'):
+        dtyp = np.result_type(full_state_feedback.computed_poles, np.complex64)
+        full_state_feedback.computed_poles = \
+            full_state_feedback.computed_poles.astype(dtyp)
     full_state_feedback.requested_poles = poles
     full_state_feedback.X = transfer_matrix
     full_state_feedback.rtol = cur_rtol

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -66,7 +66,7 @@ class TestPlacePoles:
         and return the Bunch object for further specific tests
         """
         fsf = place_poles(A, B, P, **kwargs)
-        expected, _ = np.linalg.eig(A - np.dot(B, fsf.gain_matrix))
+        expected = linalg.eigvals(A - np.dot(B, fsf.gain_matrix))
         _assert_poles_close(expected, fsf.requested_poles)
         _assert_poles_close(expected, fsf.computed_poles)
         _assert_poles_close(P,fsf.requested_poles)
@@ -93,6 +93,20 @@ class TestPlacePoles:
         # value in divide (see gh-7590), so suppress it for now
         with np.errstate(invalid='ignore'):
             self._check(A, B, (2,2,3,3))
+
+    def test_computed_poles_dtype(self):
+        """Verify that the `computed_poles` are always complex-valued.
+
+        Before NumPy 2.5, `np.linalg.eig` would return either a real-valued or a
+        complex-valued array. PR #26004 enforces that the `computed_poles` are always
+        complex-valued by using SciPy's `eig` function.
+        """
+        A, B, P = np.eye(3), np.eye(3), np.array([-4., -3., -2.])
+        fsf = place_poles(A, B, P, method='YT')
+
+        xp_assert_equal(fsf.requested_poles, P)  # poles need to be in ascending order
+        complex_dtype =  np.result_type(P, np.complex64)  # complex64 or complex128
+        xp_assert_close(fsf.computed_poles, P.astype(complex_dtype))
 
     def test_complex(self):
         # Test complex pole placement on a linearized car model, taken from L.

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -15,7 +15,27 @@ from scipy.signal import (ss2tf, tf2ss, lti,
                           TransferFunction, StateSpace, ZerosPolesGain)
 
 from scipy.signal._filter_design import BadCoefficients
+from scipy.signal._ltisys import _order_complex_poles
 import scipy.linalg as linalg
+
+class Test_OrderComplexPoles:
+    """Test for `_order_complex_poles` function. """
+
+    @pytest.mark.parametrize('p_in, p_ref', [
+        ([3, 2, 1], [1, 2, 3]), ([], []),
+        ([1j, 2j, -2j, -1j], [-2j, 2j, -1j, 1j]),
+        ([1j, -1j, 1+1j, 2, 1-1j], [2, -1j, 1j, 1-1j, 1+1j])])
+    def test_basic(self, p_in, p_ref):
+        p_in = np.asarray(p_in)
+        p_ref = np.asarray(p_ref, dtype=np.result_type(p_in.dtype, np.complex64))
+
+        p = _order_complex_poles(p_in)
+        np.testing.assert_allclose(p, p_ref)
+
+    def test_exception(self):
+        p = np.asarray([1, 2-1j])
+        with pytest.raises(ValueError):
+            _order_complex_poles(p)
 
 
 def _assert_poles_close(P1,P2, rtol=1e-8, atol=1e-8):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -26,8 +26,7 @@ class Test_OrderComplexPoles:
         ([1j, 2j, -2j, -1j], [-2j, 2j, -1j, 1j]),
         ([1j, -1j, 1+1j, 2, 1-1j], [2, -1j, 1j, 1-1j, 1+1j])])
     def test_basic(self, p_in, p_ref):
-        p_in = np.asarray(p_in)
-        p_ref = np.asarray(p_ref, dtype=np.result_type(p_in.dtype, np.complex64))
+        p_in, p_ref = np.asarray(p_in), np.asarray(p_ref)
 
         p = _order_complex_poles(p_in)
         np.testing.assert_allclose(p, p_ref)


### PR DESCRIPTION
Before NumPy 2.5, `eig()` could return either real- or complex-valued arrays, which affected the returned `computed_poles` attribute. [From NumPy 2.5 on], it is always complex-valued.

This PR ensures that the returned `complex_poles` attribute is always complex by:

* Converting the `complex_poles` to a complex floating type, if needed.
~~* Making the return value of the `_order_complex_poles` helper always complex-valued.~~
~~* Add unit test for `_order_complex_poles`.~~
* Fix doctest output in the `place_poles` docstring, which makes `spin smoke-docs` pass reliably.

I left the unit tests for `_order_complex_poles` in this PR, since having unit tests for each functions (marginally) useful, IMO. Furthermore, it does marginally increase coverage at [line 2670](https://github.com/DietBru/scipy/blob/7ec340e7cef9cc4f881194c65cddaf15223e516a/scipy/signal/_ltisys.py#L2670). 

This PR was motivated by this [comment].

__Release Note__: 
`place_poles` now always returns `computed_poles` as a complex-valued array even if all poles are real-valued.

PS: No AI was used in this PR.

[From Numpy 2.5 on]: https://numpy.org/devdocs/release/2.5.0-notes.html#linalg-eig-and-linalg-eigvals-now-always-return-complex-arrays
[comment]: https://github.com/scipy/scipy/pull/25972#issuecomment-5355219020
