### PR TITLE
ENH/BENCH: signal.oaconvolve: performance enhancements

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -84,11 +84,27 @@ class Convolve2D(Benchmark):
 
 
 class FFTConvolve(Benchmark):
+    # Square-ish cross product of small/medium sizes (a >= b), plus a
+    # large-signal / small-kernel (FIR) sweep: fixed small/medium kernels
+    # against signal lengths from a few thousand up to 100k. The FIR regime is
+    # where overlap-add (oaconvolve) is expected to beat both direct convolve
+    # and a single big FFT (fftconvolve); the small/medium grid is where the
+    # pure-Python overlap-add overhead currently dominates (see gh-24834).
+    _sizes = (8, 36, 65, 151, 500, 2000, 4000)
+    _grid = [(a, b) for a, b in product(_sizes, repeat=2) if a >= b]
+    # Build the FIR sweep with an explicit loop (not a comprehension) so we can
+    # dedup against _grid: class-body comprehensions can't see class variables
+    # in their body, only in the outermost iterable.
+    _all_sizes = list(_grid)
+    for _n in (2000, 4000, 8000, 20000, 100000):
+        for _m in (65, 512, 2000):
+            if _n > _m and (_n, _m) not in _all_sizes:
+                _all_sizes.append((_n, _m))
+    del _n, _m
     param_names = ["mode", "size"]
     params = [
         ["full", "valid", "same"],
-        [(a,b) for a,b in product((8, 36, 65, 151, 500, 2000, 4000), repeat=2)
-         if a >= b]
+        _all_sizes,
     ]
 
     def setup(self, mode, size):
@@ -101,6 +117,49 @@ class FFTConvolve(Benchmark):
 
     def time_oaconvolve_1d(self, mode, size):
         signal.oaconvolve(self.a, self.b, mode=mode)
+
+
+class OAConvolveND(Benchmark):
+    # Convolve one axis of an N-D array, batching over the rest.
+    param_names = ["mode", "shape_axis"]
+    params = [
+        ["full", "valid", "same"],
+        [((64, 20000), 1), ((20000, 64), 0), ((16, 100000), 1)],
+    ]
+
+    def setup(self, mode, shape_axis):
+        shape, axis = shape_axis
+        rng = np.random.default_rng(1234)
+        self.a = rng.standard_normal(shape)
+        kshape = list(shape)
+        kshape[axis] = 65
+        self.b = rng.standard_normal(tuple(kshape))
+        self.axis = axis
+
+    def time_oaconvolve_nd(self, mode, shape_axis):
+        signal.oaconvolve(self.a, self.b, mode=mode, axes=[self.axis])
+
+    def time_fftconvolve_nd(self, mode, shape_axis):
+        signal.fftconvolve(self.a, self.b, mode=mode, axes=[self.axis])
+
+
+class ConvolveMethod(Benchmark):
+    # convolve() dispatch per method across the 1-D FIR grid. 'oa' is the
+    # explicit overlap-add path (gh-24834); 'auto' is the predicted default
+    # (which selects direct/fft only — it does not auto-select 'oa').
+    param_names = ["method", "size"]
+    params = [
+        ["auto", "direct", "fft", "oa"],
+        [(n, 65) for n in (2000, 8000, 20000, 100000)],
+    ]
+
+    def setup(self, method, size):
+        rng = np.random.default_rng(1234)
+        self.a = rng.standard_normal(size[0])
+        self.b = rng.standard_normal(size[1])
+
+    def time_convolve_method(self, method, size):
+        signal.convolve(self.a, self.b, method=method)
 
 
 class Convolve(Benchmark):

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -46,6 +46,7 @@ ignore-missing-imports = [
     "scipy.ndimage._nd_image",
     "scipy.ndimage._ni_label",
     "scipy.ndimage._rank_filter_1d",
+    "scipy.signal._fftconv",
     "scipy.signal._sigtools",
     "scipy.sparse._sparsetools",
     "scipy.sparse.linalg._dsolve._superlu",

--- a/scipy/signal/_fftconv.h
+++ b/scipy/signal/_fftconv.h
@@ -1,0 +1,258 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <type_traits>
+#include <vector>
+#include "ducc0/fft/fft.h"
+#include "ducc0/fft/fftnd_impl.h"
+namespace fftconv {
+
+// M_E is POSIX, not standard C++ (absent on MSVC-style compilers without
+// _USE_MATH_DEFINES), so use our own constant for Euler's number.
+constexpr double euler_e = 2.718281828459045235360287471352662498;
+
+// Real lower branch W_{-1}(x) for x in [-1/e, 0), via Halley iteration.
+// Matches scipy.special.lambertw(x, k=-1).real, used by _calc_oa_lens.
+inline double lambertw_wm1(double x) {
+    // W_{-1}(-1/e) = -1 exactly; both real branches meet here. Guard the
+    // boundary where the Halley denominator degenerates to 0/0 (w -> -1).
+    if (x <= -1.0 / euler_e) return -1.0;
+    // Initial guess from the asymptotic expansion near 0^- (Corless et al.).
+    const double L1 = std::log(-x);
+    const double L2 = std::log(-L1);
+    double w = L1 - L2 + L2 / L1;
+    for (int i = 0; i < 20; ++i) {
+        const double ew = std::exp(w);
+        const double f = w * ew - x;
+        // Halley step
+        const double denom = ew * (w + 1.0) - (w + 2.0) * f / (2.0 * w + 2.0);
+        const double dw = f / denom;
+        w -= dw;
+        if (std::fabs(dw) <= 1e-16 * (1.0 + std::fabs(w))) break;
+    }
+    return w;
+}
+
+struct OaLens { size_t block_size, overlap, in1_step, in2_step; bool fallback; };
+
+// Port of _calc_oa_lens(s1, s2) from _signaltools.py.
+inline OaLens calc_oa_lens(size_t s1, size_t s2) {
+    OaLens f{s1 + s2 - 1, 0, s1, s2, true};
+    if (s1 == s2 || s1 == 1 || s2 == 1) return f;
+    bool swapped = false;
+    size_t a = s1, b = s2;
+    if (b > a) { std::swap(a, b); swapped = true; }
+    if (b >= a / 2.0) return f;                       // s2 >= s1/2
+    const double overlap = double(b) - 1.0;
+    const double opt = -overlap *
+        lambertw_wm1(-1.0 / (2.0 * euler_e * overlap));
+    size_t block_size = ducc0::good_size_complex(size_t(std::ceil(opt)));
+    if (block_size >= a) return f;                    // only one block
+    OaLens r;
+    r.fallback = false;
+    r.block_size = block_size;
+    r.overlap = size_t(overlap);
+    if (!swapped) { r.in1_step = block_size - b + 1; r.in2_step = b; }
+    else          { r.in1_step = b; r.in2_step = block_size - b + 1; }
+    return r;
+}
+
+template<typename T> struct is_complex : std::false_type {};
+template<typename T> struct is_complex<std::complex<T>> : std::true_type {};
+template<typename T> inline constexpr bool is_complex_v = is_complex<T>::value;
+
+template<typename T> struct real_type { using type = T; };
+template<typename T> struct real_type<std::complex<T>> { using type = T; };
+template<typename T> using real_t = typename real_type<T>::type;
+
+enum class ConvMode { Full, Same, Valid };
+
+// N-D single-axis overlap-add convolution. in1 is (outer, n, inner), in2 is
+// (outer, m, inner), out is (outer, out_n, inner), all C-contiguous. Convolves
+// the middle axis, batching over outer*inner. Real via r2c/c2r, complex via c2c
+// (if constexpr). Returns false (decline) on the calc_oa_lens fallback.
+template<typename T>
+bool oaconvolve_axis(const T* in1, size_t outer, size_t n, size_t inner,
+                     const T* in2, size_t m, T* out, ConvMode mode, size_t nthreads) {
+    OaLens L = calc_oa_lens(n, m);
+    if (L.fallback) return false;
+
+    // Orient so `sig` has the longer conv length. Keep original n,m for slicing.
+    const T *sig = in1, *ker = in2;
+    size_t ns = n, nk = m;
+    if (nk > ns) { std::swap(sig, ker); std::swap(ns, nk); }
+
+    const size_t B  = L.block_size;
+    const size_t S  = B - (nk - 1);
+    using R  = real_t<T>;
+    using Cx = std::complex<R>;
+    constexpr bool cplx = is_complex_v<T>;
+    const size_t Bc   = cplx ? B : (B / 2 + 1);
+    const size_t nblk = (ns + S - 1) / S;
+    const R fct       = R(1) / R(B);
+    const size_t full = ns + nk - 1;
+
+    // Kernel spectrum: pad ker (outer, nk, inner) -> (outer, B, inner), FFT over axis 1.
+    std::vector<T> kbuf(outer * B * inner, T(0));
+    for (size_t o = 0; o < outer; ++o)
+        std::copy(ker + o * nk * inner, ker + (o + 1) * nk * inner,
+                  kbuf.begin() + o * B * inner);
+    std::vector<Cx> kspec(outer * Bc * inner);
+    {
+        ducc0::cfmav<T>  kin(kbuf.data(), ducc0::fmav_info::shape_t{outer, B, inner});
+        ducc0::vfmav<Cx> kout(kspec.data(), ducc0::fmav_info::shape_t{outer, Bc, inner});
+        if constexpr (cplx) ducc0::c2c(kin, kout, ducc0::fmav_info::shape_t{1}, true, R(1), nthreads);
+        else                ducc0::r2c(kin, kout, /*axis=*/1, true, R(1), nthreads);
+    }
+
+    // Blocked signal (outer, nblk, B, inner), zero-padded.
+    std::vector<T> blocks(outer * nblk * B * inner, T(0));
+    for (size_t o = 0; o < outer; ++o)
+        for (size_t blk = 0; blk < nblk; ++blk) {
+            size_t start = blk * S;
+            size_t len = std::min(S, ns > start ? ns - start : 0);
+            if (len)
+                std::copy(sig + (o * ns + start) * inner,
+                          sig + (o * ns + start + len) * inner,
+                          blocks.begin() + ((o * nblk + blk) * B) * inner);
+        }
+
+    // Batched forward FFT over the B axis (axis 2 of the 4-D layout).
+    std::vector<Cx> spec(outer * nblk * Bc * inner);
+    {
+        ducc0::cfmav<T>  bin(blocks.data(), ducc0::fmav_info::shape_t{outer, nblk, B, inner});
+        ducc0::vfmav<Cx> bout(spec.data(), ducc0::fmav_info::shape_t{outer, nblk, Bc, inner});
+        if constexpr (cplx) ducc0::c2c(bin, bout, ducc0::fmav_info::shape_t{2}, true, R(1), nthreads);
+        else                ducc0::r2c(bin, bout, /*axis=*/2, true, R(1), nthreads);
+    }
+    // Multiply by kernel spectrum, broadcast over the nblk axis.
+    for (size_t o = 0; o < outer; ++o)
+        for (size_t blk = 0; blk < nblk; ++blk) {
+            Cx* sp = spec.data() + ((o * nblk + blk) * Bc) * inner;
+            const Cx* kp = kspec.data() + (o * Bc) * inner;
+            for (size_t t = 0; t < Bc * inner; ++t) sp[t] *= kp[t];
+        }
+    // Batched inverse FFT over the B axis, scaled 1/B.
+    {
+        ducc0::cfmav<Cx> sin(spec.data(), ducc0::fmav_info::shape_t{outer, nblk, Bc, inner});
+        ducc0::vfmav<T>  sout(blocks.data(), ducc0::fmav_info::shape_t{outer, nblk, B, inner});
+        if constexpr (cplx) ducc0::c2c(sin, sout, ducc0::fmav_info::shape_t{2}, false, fct, nthreads);
+        else                ducc0::c2r(sin, sout, /*axis=*/2, false, fct, nthreads);
+    }
+
+    // Overlap-add into acc (outer, full, inner).
+    std::vector<T> acc(outer * full * inner, T(0));
+    for (size_t o = 0; o < outer; ++o)
+        for (size_t blk = 0; blk < nblk; ++blk) {
+            size_t start = blk * S;
+            size_t cnt = (start < full ? std::min(B, full - start) : 0) * inner;
+            T* dst = acc.data() + (o * full + start) * inner;
+            const T* src = blocks.data() + ((o * nblk + blk) * B) * inner;
+            for (size_t t = 0; t < cnt; ++t) dst[t] += src[t];
+        }
+
+    // Mode slice along the middle axis into out. Offsets use the ORIGINAL n,m
+    // (so the internal sig/ker swap is invisible), identical to the 1-D core.
+    size_t offset, out_n;
+    if (mode == ConvMode::Full)      { offset = 0;           out_n = n + m - 1; }
+    else if (mode == ConvMode::Same) { offset = (m - 1) / 2; out_n = n; }
+    else { size_t big = std::max(n, m), sm = std::min(n, m); offset = sm - 1; out_n = big - sm + 1; }
+    for (size_t o = 0; o < outer; ++o)
+        std::copy(acc.begin() + (o * full + offset) * inner,
+                  acc.begin() + (o * full + offset + out_n) * inner,
+                  out + o * out_n * inner);
+    return true;
+}
+
+// Full 1-D overlap-add convolution. out must have length s1+s2-1 for Full.
+// Returns false (decline) when calc_oa_lens says fallback; caller handles it.
+template<typename T>
+bool oaconvolve_1d(const T* in1, size_t s1, const T* in2, size_t s2,
+                   T* out, ConvMode mode, size_t nthreads) {
+    OaLens L = calc_oa_lens(s1, s2);
+    if (L.fallback) return false;  // decline: caller routes to fftconvolve
+
+    // Orient so `sig` is the longer, `ker` the shorter (OA is symmetric).
+    const T *sig = in1, *ker = in2;
+    size_t ns = s1, nk = s2;
+    if (nk > ns) { std::swap(sig, ker); std::swap(ns, nk); }
+
+    const size_t B  = L.block_size;              // FFT length
+    const size_t S  = B - (nk - 1);              // step (valid samples/block)
+    using R  = real_t<T>;              // float or double
+    using Cx = std::complex<R>;        // spectrum element type
+    constexpr bool cplx = is_complex_v<T>;
+    const size_t Bc = cplx ? B : (B / 2 + 1);   // c2c: full length; r2c: half+1
+    const size_t nblk = (ns + S - 1) / S;
+    const R fct = R(1) / R(B);
+
+    // Kernel spectrum (once).
+    std::vector<T> kbuf(B, T(0));
+    std::copy(ker, ker + nk, kbuf.begin());
+    std::vector<Cx> kspec(Bc);
+    {
+        ducc0::cfmav<T>  kin(kbuf.data(), ducc0::fmav_info::shape_t{B});
+        ducc0::vfmav<Cx> kout(kspec.data(), ducc0::fmav_info::shape_t{Bc});
+        if constexpr (cplx) ducc0::c2c(kin, kout, ducc0::fmav_info::shape_t{0}, /*forward=*/true, R(1), nthreads);
+        else                ducc0::r2c(kin, kout, /*axis=*/0, /*forward=*/true, R(1), nthreads);
+    }
+
+    // Blocked signal buffer (nblk x B), zero-padded.
+    std::vector<T> blocks(nblk * B, T(0));
+    for (size_t i = 0; i < nblk; ++i) {
+        size_t start = i * S;
+        size_t len = std::min(S, ns > start ? ns - start : 0);
+        if (len) std::copy(sig + start, sig + start + len, blocks.begin() + i * B);
+    }
+
+    // Batched forward transform over the block-length axis (axis 1).
+    std::vector<Cx> spec(nblk * Bc);
+    {
+        ducc0::cfmav<T>  bin(blocks.data(), ducc0::fmav_info::shape_t{nblk, B});
+        ducc0::vfmav<Cx> bout(spec.data(), ducc0::fmav_info::shape_t{nblk, Bc});
+        if constexpr (cplx) ducc0::c2c(bin, bout, ducc0::fmav_info::shape_t{1}, true, R(1), nthreads);
+        else                ducc0::r2c(bin, bout, /*axis=*/1, true, R(1), nthreads);
+    }
+    // Multiply each block spectrum by the kernel spectrum.
+    // For the complex path this is a full-length (Bc == B) elementwise product;
+    // the real path uses the half spectrum (Bc == B/2+1).
+    for (size_t i = 0; i < nblk; ++i)
+        for (size_t j = 0; j < Bc; ++j)
+            spec[i * Bc + j] *= kspec[j];
+    // Batched inverse transform, scaled by 1/B.
+    {
+        ducc0::cfmav<Cx> sin(spec.data(), ducc0::fmav_info::shape_t{nblk, Bc});
+        ducc0::vfmav<T>  sout(blocks.data(), ducc0::fmav_info::shape_t{nblk, B});
+        if constexpr (cplx) ducc0::c2c(sin, sout, ducc0::fmav_info::shape_t{1}, false, fct, nthreads);
+        else                ducc0::c2r(sin, sout, /*axis=*/1, false, fct, nthreads);
+    }
+
+    // Overlap-add into a full-length accumulator.
+    const size_t full = ns + nk - 1;
+    std::vector<T> acc(full, T(0));
+    for (size_t i = 0; i < nblk; ++i) {
+        size_t start = i * S;
+        for (size_t j = 0; j < B && start + j < full; ++j)
+            acc[start + j] += blocks[i * B + j];
+    }
+
+    // Mode slicing. `acc` holds the length-(ns+nk-1) full convolution.
+    // Note: for Same, the output length is s1 (the ORIGINAL first input),
+    // centered in the full result. Because we may have swapped sig/ker,
+    // recompute offsets from the original s1/s2.
+    if (mode == ConvMode::Full) {
+        std::copy(acc.begin(), acc.end(), out);
+    } else if (mode == ConvMode::Same) {
+        size_t offset = (s2 - 1) / 2;          // center wrt in1
+        std::copy(acc.begin() + offset, acc.begin() + offset + s1, out);
+    } else {  // Valid: length max-min+1, starts at min-1
+        size_t big = std::max(s1, s2), small = std::min(s1, s2);
+        size_t nvalid = big - small + 1;
+        std::copy(acc.begin() + (small - 1),
+                  acc.begin() + (small - 1) + nvalid, out);
+    }
+    return true;
+}
+
+}  // namespace fftconv

--- a/scipy/signal/_fftconv.h
+++ b/scipy/signal/_fftconv.h
@@ -17,7 +17,9 @@ constexpr double euler_e = 2.718281828459045235360287471352662498;
 inline double lambertw_wm1(double x) {
     // W_{-1}(-1/e) = -1 exactly; both real branches meet here. Guard the
     // boundary where the Halley denominator degenerates to 0/0 (w -> -1).
-    if (x <= -1.0 / euler_e) return -1.0;
+    // Widened by one ulp: on i386/x87 the caller's -1/e can round to one ulp
+    // inside the domain, where the iteration below would still hit 0/0.
+    if (x <= std::nextafter(-1.0 / euler_e, 0.0)) return -1.0;
     // Initial guess from the asymptotic expansion near 0^- (Corless et al.).
     const double L1 = std::log(-x);
     const double L2 = std::log(-L1);
@@ -28,6 +30,9 @@ inline double lambertw_wm1(double x) {
         // Halley step
         const double denom = ew * (w + 1.0) - (w + 2.0) * f / (2.0 * w + 2.0);
         const double dw = f / denom;
+        // Near the branch point denom can still underflow to 0 (dw = 0/0);
+        // w is already at the fixed point there, so stop rather than poison it.
+        if (!std::isfinite(dw)) break;
         w -= dw;
         if (std::fabs(dw) <= 1e-16 * (1.0 + std::fabs(w))) break;
     }

--- a/scipy/signal/_fftconv_pybind.cc
+++ b/scipy/signal/_fftconv_pybind.cc
@@ -105,7 +105,7 @@ static py::tuple calc_oa_lens(size_t s1, size_t s2) {
     return py::make_tuple(r.block_size, overlap, r.in1_step, r.in2_step);
 }
 
-PYBIND11_MODULE(_fftconv, m) {
+PYBIND11_MODULE(_fftconv, m, py::mod_gil_not_used()) {
     m.doc() = "C++ overlap-add convolution (duccfft backend)";
     m.def("oaconvolve", &oaconvolve,
           py::arg("in1"), py::arg("in2"), py::arg("mode"), py::arg("axes"));

--- a/scipy/signal/_fftconv_pybind.cc
+++ b/scipy/signal/_fftconv_pybind.cc
@@ -1,0 +1,115 @@
+#include <string_view>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "_fftconv.h"
+
+namespace py = pybind11;
+
+static fftconv::ConvMode parse_mode(std::string_view m) {
+    if (m == "full")  return fftconv::ConvMode::Full;
+    if (m == "same")  return fftconv::ConvMode::Same;
+    if (m == "valid") return fftconv::ConvMode::Valid;
+    throw std::invalid_argument("acceptable mode flags are 'valid', 'same', or 'full'");
+}
+
+// Parse the axes argument to a single non-negative conv axis, or return -1 to
+// decline. None -> axis 0 only when 1-D (None on N-D means all axes = multi-axis).
+static long parse_single_axis(py::object axes, py::ssize_t ndim) {
+    if (axes.is_none()) return (ndim == 1) ? 0 : -1;
+    auto norm = [ndim](long a) -> long { if (a < 0) a += ndim; return (a >= 0 && a < ndim) ? a : -1; };
+    if (py::isinstance<py::int_>(axes)) return norm(axes.cast<long>());
+    try {
+        auto v = axes.cast<std::vector<long>>();
+        if (v.size() != 1) return -1;
+        return norm(v[0]);
+    } catch (...) { return -1; }
+}
+
+// Non-contiguous inputs of the accepted dtype are handled by an internal
+// contiguous copy (the `c_style | forcecast` conversion below), not declined.
+// dtype/ndim/axes are already validated in `oaconvolve` before this point, so
+// forcecast here only normalizes memory layout; it never silently changes dtype.
+template<typename T>
+static py::object run_nd(py::array_t<T, py::array::c_style | py::array::forcecast> a,
+                         py::array_t<T, py::array::c_style | py::array::forcecast> b,
+                         long axis, fftconv::ConvMode mode) {
+    const py::ssize_t ndim = a.ndim();
+    size_t outer = 1, inner = 1;
+    for (py::ssize_t d = 0; d < axis; ++d)        outer *= static_cast<size_t>(a.shape(d));
+    for (py::ssize_t d = axis + 1; d < ndim; ++d) inner *= static_cast<size_t>(a.shape(d));
+    const size_t n = static_cast<size_t>(a.shape(axis));
+    const size_t m = static_cast<size_t>(b.shape(axis));
+    size_t out_n;
+    switch (mode) {
+        case fftconv::ConvMode::Full:  out_n = n + m - 1; break;
+        case fftconv::ConvMode::Same:  out_n = n; break;
+        default: { size_t big = std::max(n, m), sm = std::min(n, m); out_n = big - sm + 1; }
+    }
+    std::vector<py::ssize_t> oshape(a.shape(), a.shape() + ndim);
+    oshape[axis] = static_cast<py::ssize_t>(out_n);
+    py::array_t<T> out(oshape);
+    bool ok;
+    {
+        py::gil_scoped_release rel;
+        if (outer == 1 && inner == 1)
+            ok = fftconv::oaconvolve_1d<T>(a.data(), n, b.data(), m,
+                                           out.mutable_data(), mode, 1);
+        else
+            ok = fftconv::oaconvolve_axis<T>(a.data(), outer, n, inner, b.data(), m,
+                                             out.mutable_data(), mode, 1);
+    }
+    if (!ok) return py::none();  // decline -> Python fallback
+    return out;
+}
+
+static py::object oaconvolve(py::object in1, py::object in2,
+                             std::string_view mode_str, py::object axes) {
+    auto a = py::array::ensure(in1);
+    auto b = py::array::ensure(in2);
+    if (!a || !b) return py::none();
+    if (a.ndim() != b.ndim()) return py::none();
+    const long axis = parse_single_axis(axes, a.ndim());
+    if (axis < 0) return py::none();  // not a single-axis request -> decline
+    // Non-conv dims must match between the inputs (broadcasting -> decline).
+    for (py::ssize_t d = 0; d < a.ndim(); ++d)
+        if (d != axis && a.shape(d) != b.shape(d)) return py::none();
+    const auto mode = parse_mode(mode_str);
+    // Decline the block-size fallback here, before run_nd's forcecast
+    // conversion (which contiguous-copies non-contiguous inputs) and output
+    // allocation can do speculative work that a decline would throw away.
+    // The same check inside oaconvolve_1d/oaconvolve_axis is then unreachable
+    // from Python but kept so the C++ core stands on its own.
+    if (fftconv::calc_oa_lens(static_cast<size_t>(a.shape(axis)),
+                              static_cast<size_t>(b.shape(axis))).fallback)
+        return py::none();
+
+    if (py::isinstance<py::array_t<double>>(a) && py::isinstance<py::array_t<double>>(b))
+        return run_nd<double>(in1, in2, axis, mode);
+    if (py::isinstance<py::array_t<float>>(a) && py::isinstance<py::array_t<float>>(b))
+        return run_nd<float>(in1, in2, axis, mode);
+    if (py::isinstance<py::array_t<std::complex<double>>>(a)
+            && py::isinstance<py::array_t<std::complex<double>>>(b))
+        return run_nd<std::complex<double>>(in1, in2, axis, mode);
+    if (py::isinstance<py::array_t<std::complex<float>>>(a)
+            && py::isinstance<py::array_t<std::complex<float>>>(b))
+        return run_nd<std::complex<float>>(in1, in2, axis, mode);
+    return py::none();  // mixed / other dtype -> Python fallback
+}
+
+// Mirrors _signaltools._calc_oa_lens: (block_size, overlap, in1_step,
+// in2_step), with overlap=None signaling the single-FFT fallback.
+static py::tuple calc_oa_lens(size_t s1, size_t s2) {
+    fftconv::OaLens r = fftconv::calc_oa_lens(s1, s2);
+    py::object overlap = r.fallback ? py::none() : py::cast(r.overlap);
+    return py::make_tuple(r.block_size, overlap, r.in1_step, r.in2_step);
+}
+
+PYBIND11_MODULE(_fftconv, m) {
+    m.doc() = "C++ overlap-add convolution (duccfft backend)";
+    m.def("oaconvolve", &oaconvolve,
+          py::arg("in1"), py::arg("in2"), py::arg("mode"), py::arg("axes"));
+    // Internal helpers exposed for testing only.
+    m.def("_lambertw_wm1", &fftconv::lambertw_wm1, py::arg("x"));
+    m.def("_calc_oa_lens", &calc_oa_lens, py::arg("s1"), py::arg("s2"));
+}

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -11,7 +11,7 @@ from typing import Literal
 from numpy._typing import ArrayLike
 
 from scipy.spatial import cKDTree
-from . import _sigtools
+from . import _sigtools, _fftconv
 from ._ltisys import dlti
 from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
@@ -961,6 +961,20 @@ def oaconvolve(in1, in2, mode="full", axes=None):
 
     s1 = in1.shape
     s2 = in2.shape
+
+    # Fast path: whole overlap-add in C++ for numpy inputs convolved along a
+    # single axis (1-D, or N-D with len(axes)==1), matching real/complex dtype,
+    # and equal non-convolution dimensions. Everything else falls through.
+    if (is_numpy(xp)
+            and len(axes) == 1
+            and xp.isdtype(in1.dtype, ('real floating', 'complex floating'))
+            and in1.dtype == in2.dtype
+            and all(in1.shape[a] == in2.shape[a]
+                    for a in range(in1.ndim) if a != axes[0])):
+        res = _fftconv.oaconvolve(in1, in2, mode, axes[0])
+        if res is not None:
+            return res
+    # else: fall through to the existing Python overlap-add (unchanged).
 
     if not axes:
         ret = in1 * in2

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -125,7 +125,7 @@ def correlate(in1, in2, mode='full', method='auto'):
            Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
            Boundary effects may be visible.
-    method : str {'auto', 'direct', 'fft'}, optional
+    method : str {'auto', 'direct', 'fft', 'oa'}, optional
         A string indicating which method to use to calculate the correlation.
 
         ``direct``
@@ -134,6 +134,12 @@ def correlate(in1, in2, mode='full', method='auto'):
         ``fft``
            The Fast Fourier Transform is used to perform the correlation more
            quickly (only available for numerical arrays.)
+        ``oa``
+           The overlap-add method is used, by calling `oaconvolve`. This can
+           be much faster than ``fft`` when one input is much larger than the
+           other.
+
+           .. versionadded:: 1.19.0
         ``auto``
            Automatically chooses direct or Fourier method based on an estimate
            of which is faster (default).  See `convolve` Notes for more detail.
@@ -254,7 +260,7 @@ def correlate(in1, in2, mode='full', method='auto'):
                          " 'same', or 'full'.") from e
 
     # this either calls fftconvolve or this function with method=='direct'
-    if method in ('fft', 'auto'):
+    if method in ('fft', 'auto', 'oa'):
         return convolve(in1, _reverse_and_conj(in2, xp), mode, method)
 
     elif method == 'direct':
@@ -310,7 +316,7 @@ def correlate(in1, in2, mode='full', method='auto'):
 
     else:
         raise ValueError("Acceptable method flags are 'auto',"
-                         " 'direct', or 'fft'.")
+                         " 'direct', 'fft', or 'oa'.")
 
 
 def correlation_lags(in1_len, in2_len, mode='full'):
@@ -1286,8 +1292,13 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Returns
     -------
     method : str
-        A string indicating which convolution method is fastest, either
-        'direct' or 'fft'
+        A string indicating which convolution method is fastest, one of
+        'direct', 'fft', or 'oa'.
+
+        .. versionchanged:: 1.19.0
+            May now also return 'oa' (overlap-add) when ``measure=True``
+            finds `oaconvolve` fastest. The default (predicted) path
+            selects only 'direct' or 'fft'.
     times : dict, optional
         A dictionary containing the times (in seconds) needed for each method.
         This value is only returned if ``measure=True``.
@@ -1365,11 +1376,11 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     if measure:
         times = {}
-        for method in ['fft', 'direct']:
+        for method in ['fft', 'direct', 'oa']:
             times[method] = _timeit_fast(lambda: convolve(volume, kernel,
                                          mode=mode, method=method))
 
-        chosen_method = 'fft' if times['fft'] < times['direct'] else 'direct'
+        chosen_method = min(times, key=times.get)
         return chosen_method, times
 
     # for integer input,
@@ -1389,6 +1400,21 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
             return 'fft'
 
     return 'direct'
+
+
+def _finalize_freq_conv(out, volume, kernel, xp):
+    """Post-process an FFT-based convolution result (fftconvolve/oaconvolve):
+    round for integral result dtypes, warn on NaN/inf, and cast to result dtype.
+    """
+    result_type = xp.result_type(volume, kernel)
+    if xp.isdtype(result_type, 'integral'):
+        out = xp.round(out)
+    if xp.isnan(xp.reshape(out, (-1,))[0]) or xp.isinf(xp.reshape(out, (-1,))[0]):
+        warnings.warn("Use of FFT convolution on input with NAN or inf"
+                      " results in NAN or inf output. Consider using"
+                      " method='direct' instead.",
+                      category=RuntimeWarning, stacklevel=3)
+    return xp.astype(out, result_type)
 
 
 def convolve(in1, in2, mode='full', method='auto'):
@@ -1418,7 +1444,7 @@ def convolve(in1, in2, mode='full', method='auto'):
            Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
            Boundary effects may be visible.
-    method : str {'auto', 'direct', 'fft'}, optional
+    method : str {'auto', 'direct', 'fft', 'oa'}, optional
         A string indicating which method to use to calculate the convolution.
 
         ``direct``
@@ -1427,6 +1453,12 @@ def convolve(in1, in2, mode='full', method='auto'):
         ``fft``
            The Fourier Transform is used to perform the convolution by calling
            `fftconvolve`.
+        ``oa``
+           The overlap-add method is used, by calling `oaconvolve`. This can
+           be much faster than ``fft`` when one input is much larger than the
+           other.
+
+           .. versionadded:: 1.19.0
         ``auto``
            Automatically chooses direct or Fourier method based on an estimate
            of which is faster (default).  See Notes for more detail.
@@ -1518,17 +1550,10 @@ def convolve(in1, in2, mode='full', method='auto'):
 
     if method == 'fft':
         out = fftconvolve(volume, kernel, mode=mode)
-        result_type = xp.result_type(volume, kernel)
-        if xp.isdtype(result_type, 'integral'):
-            out = xp.round(out)
-
-        if xp.isnan(xp.reshape(out, (-1,))[0]) or xp.isinf(xp.reshape(out, (-1,))[0]):
-            warnings.warn("Use of fft convolution on input with NAN or inf"
-                          " results in NAN or inf output. Consider using"
-                          " method='direct' instead.",
-                          category=RuntimeWarning, stacklevel=2)
-
-        return xp.astype(out, result_type)
+        return _finalize_freq_conv(out, volume, kernel, xp)
+    elif method == 'oa':
+        out = oaconvolve(volume, kernel, mode=mode)
+        return _finalize_freq_conv(out, volume, kernel, xp)
     elif method == 'direct':
         # fastpath to faster numpy.convolve for 1d inputs when possible
         if _np_conv_ok(volume, kernel, mode, xp):
@@ -1540,8 +1565,8 @@ def convolve(in1, in2, mode='full', method='auto'):
 
         return correlate(volume, _reverse_and_conj(kernel, xp), mode, 'direct')
     else:
-        raise ValueError("Acceptable method flags are 'auto',"
-                         " 'direct', or 'fft'.")
+        raise ValueError("Acceptable method flags are 'auto', 'direct',"
+                         " 'fft', or 'oa'.")
 
 
 def order_filter(a, domain, rank):

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -60,6 +60,14 @@ py3.extension_module('_spline',
   subdir: 'scipy/signal'
 )
 
+py3.extension_module('_fftconv',
+  ['_fftconv_pybind.cc'],
+  dependencies: [np_dep, pybind11_dep, duccfft_dep],
+  link_args: version_link_args,
+  install: true,
+  subdir: 'scipy/signal'
+)
+
 py3.install_sources([
     '__init__.py',
     '_support_alternative_backends.py',

--- a/scipy/signal/tests/meson.build
+++ b/scipy/signal/tests/meson.build
@@ -9,6 +9,7 @@ py3.install_sources([
     'test_czt.py',
     'test_dltisys.py',
     'test_filter_design.py',
+    'test_fftconv_smoke.py',
     'test_fir_filter_design.py',
     'test_ltisys.py',
     'test_max_len_seq.py',

--- a/scipy/signal/tests/test_fftconv_smoke.py
+++ b/scipy/signal/tests/test_fftconv_smoke.py
@@ -1,0 +1,181 @@
+import numpy as np
+import pytest
+
+from scipy import signal
+
+
+@pytest.mark.parametrize("x", [-0.3, -0.1, -0.01, -1e-4])
+def test_lambertw_wm1_inverse(x):
+    # W_{-1}(x) satisfies W*exp(W) = x on the lower branch (W <= -1).
+    from scipy.signal import _fftconv
+    from scipy.special import lambertw
+    w = _fftconv._lambertw_wm1(x)
+    assert w <= -1.0
+    np.testing.assert_allclose(w * np.exp(w), x, rtol=1e-12, atol=1e-15)
+    np.testing.assert_allclose(w, lambertw(x, k=-1).real, rtol=1e-12)
+
+
+def test_lambertw_wm1_boundary():
+    # At x = -1/e the W_{-1} and W_0 branches meet: W_{-1}(-1/e) = -1 exactly.
+    from scipy.signal import _fftconv
+    w = _fftconv._lambertw_wm1(-1.0 / np.e)
+    assert np.isfinite(w)
+    np.testing.assert_allclose(w, -1.0, atol=1e-9)
+
+
+@pytest.mark.parametrize("s1,s2", [
+    (500, 500), (4000, 4000),      # equal sizes -> fallback
+    (2000, 1), (1, 2000),          # unit length -> fallback
+    (2000, 1500),                  # s2 >= s1/2 -> fallback
+    (2000, 65), (100000, 65), (100000, 512),
+    (65, 2000), (512, 100000),     # swapped (kernel-first) orientation
+])
+def test_calc_oa_lens_matches_python(s1, s2):
+    from scipy.signal import _fftconv
+    from scipy.signal._signaltools import _calc_oa_lens
+    assert _fftconv._calc_oa_lens(s1, s2) == _calc_oa_lens(s1, s2)
+
+
+def test_calc_oa_lens_known_values():
+    from scipy.signal import _fftconv
+    # (block_size, overlap, in1_step, in2_step)
+    assert _fftconv._calc_oa_lens(2000, 65) == (512, 64, 448, 65)
+    assert _fftconv._calc_oa_lens(100000, 65) == (512, 64, 448, 65)
+    assert _fftconv._calc_oa_lens(100000, 512) == (5250, 511, 4739, 512)
+    assert _fftconv._calc_oa_lens(500, 500)[1] is None   # fallback
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_fftconv_oaconvolve_1d_matches_reference(mode, dtype):
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal(5000).astype(dtype)
+    b = rng.standard_normal(65).astype(dtype)
+    got = _fftconv.oaconvolve(a, b, mode, None)
+    assert got is not None
+    ref = signal.fftconvolve(a, b, mode=mode)
+    rtol = 1e-5 if dtype == np.float32 else 1e-10
+    np.testing.assert_allclose(got, ref, rtol=rtol, atol=rtol)
+
+
+def test_fftconv_oaconvolve_non_contiguous_input():
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal(10000)[::2]   # non-contiguous view (stride 2)
+    b = rng.standard_normal(65)
+    assert not a.flags['C_CONTIGUOUS']
+    got = _fftconv.oaconvolve(a, b, "full", None)
+    assert got is not None   # handled (copied), not declined
+    np.testing.assert_allclose(got, signal.fftconvolve(a, b, mode="full"),
+                               rtol=1e-10, atol=1e-10)
+
+
+def test_fftconv_oaconvolve_list_axes():
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal(5000)
+    b = rng.standard_normal(65)
+    got = _fftconv.oaconvolve(a, b, "full", [0])   # list axes must be accepted
+    assert got is not None
+    np.testing.assert_allclose(got, signal.fftconvolve(a, b, mode="full"),
+                               rtol=1e-10, atol=1e-10)
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("dtype", [np.complex128, np.complex64])
+def test_fftconv_oaconvolve_complex_matches_reference(mode, dtype):
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = (rng.standard_normal(5000) + 1j*rng.standard_normal(5000)).astype(dtype)
+    b = (rng.standard_normal(65) + 1j*rng.standard_normal(65)).astype(dtype)
+    got = _fftconv.oaconvolve(a, b, mode, None)
+    assert got is not None
+    ref = signal.fftconvolve(a, b, mode=mode)
+    rtol = 1e-5 if dtype == np.complex64 else 1e-10
+    np.testing.assert_allclose(got, ref, rtol=rtol, atol=rtol)
+
+
+def _random_of_dtype(rng, size, dtype):
+    r = rng.standard_normal(size)
+    if np.issubdtype(dtype, np.complexfloating):
+        r = r + 1j*rng.standard_normal(size)
+    return r.astype(dtype)
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("dtype",
+                         [np.float64, np.complex128, np.float32, np.complex64])
+@pytest.mark.parametrize("shape_axis",
+                         [((8, 2000), 1), ((2000, 8), 0), ((4, 2000, 3), 1)])
+def test_fftconv_oaconvolve_nd_single_axis(mode, dtype, shape_axis):
+    from scipy.signal import _fftconv
+    shape, axis = shape_axis
+    rng = np.random.default_rng(0)
+    kshape = list(shape)
+    kshape[axis] = 65
+    a = _random_of_dtype(rng, shape, dtype)
+    b = _random_of_dtype(rng, tuple(kshape), dtype)
+    got = _fftconv.oaconvolve(a, b, mode, axis)
+    assert got is not None
+    ref = signal.fftconvolve(a, b, mode=mode, axes=[axis])
+    rtol = 1e-4 if dtype in (np.complex64, np.float32) else 1e-9
+    np.testing.assert_allclose(got, ref, rtol=rtol, atol=rtol)
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_fftconv_oaconvolve_swapped_inputs(mode, dtype):
+    # Kernel passed FIRST (in1 shorter than in2) exercises the internal
+    # sig/ker reorientation; 'same' output length must follow the original
+    # in1, not the reoriented one.
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = _random_of_dtype(rng, 65, dtype)
+    b = _random_of_dtype(rng, 5000, dtype)
+    got = _fftconv.oaconvolve(a, b, mode, None)
+    assert got is not None
+    ref = signal.fftconvolve(a, b, mode=mode)
+    np.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-9)
+
+
+def test_fftconv_oaconvolve_exact_multiple_block():
+    # ns an exact multiple of the block step: with m=65 the block step is
+    # 448 (block_size 512, overlap 64), so n=4480 fills the last block
+    # exactly and must not read or add past the full-length output.
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal(4480)
+    b = rng.standard_normal(65)
+    got = _fftconv.oaconvolve(a, b, "full", None)
+    assert got is not None
+    np.testing.assert_allclose(got, signal.fftconvolve(a, b, mode="full"),
+                               rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_fftconv_oaconvolve_nd_kernel_longer(mode, dtype):
+    # N-D single-axis with the KERNEL longer than the signal along the conv
+    # axis: exercises the internal swap in the batched (outer, n, inner) core.
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = _random_of_dtype(rng, (4, 65, 3), dtype)
+    b = _random_of_dtype(rng, (4, 2000, 3), dtype)
+    got = _fftconv.oaconvolve(a, b, mode, 1)
+    assert got is not None
+    ref = signal.fftconvolve(a, b, mode=mode, axes=[1])
+    np.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("da,db", [
+    (np.complex128, np.complex64),
+    (np.float64, np.complex128),
+    (np.float64, np.float32),
+])
+def test_fftconv_oaconvolve_mixed_dtype_declines(da, db):
+    from scipy.signal import _fftconv
+    rng = np.random.default_rng(0)
+    a = _random_of_dtype(rng, 2000, da)
+    b = _random_of_dtype(rng, 65, db)
+    assert _fftconv.oaconvolve(a, b, "full", None) is None   # mixed dtype -> decline

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1067,8 +1067,8 @@ class TestOAConvolve:
         kshape[axis] = 65
         a = xp.asarray(mk(shape))
         b = xp.asarray(mk(tuple(kshape)))
-        got = oaconvolve(a, b, mode=mode, axes=[axis])
-        ref = fftconvolve(a, b, mode=mode, axes=[axis])
+        got = oaconvolve(a, b, mode=mode, axes=(axis,))
+        ref = fftconvolve(a, b, mode=mode, axes=(axis,))
         rtol = 1e-4 if dtype in (np.float32, np.complex64) else 1e-9
         xp_assert_close(got, ref, rtol=rtol, atol=rtol)
 
@@ -1076,8 +1076,8 @@ class TestOAConvolve:
         rng = np.random.default_rng(5)
         a = xp.asarray(rng.standard_normal((8, 4000)))[:, ::2]   # non-contiguous
         b = xp.asarray(rng.standard_normal((8, 65)))
-        xp_assert_close(oaconvolve(a, b, mode="full", axes=[1]),
-                        fftconvolve(a, b, mode="full", axes=[1]), rtol=1e-9, atol=1e-9)
+        xp_assert_close(oaconvolve(a, b, mode="full", axes=(1,)),
+                        fftconvolve(a, b, mode="full", axes=(1,)), rtol=1e-9, atol=1e-9)
 
     def test_cpp_path_multiaxis_falls_back(self, xp):
         # 2-D with both axes convolved (axes=None) must still be correct (Python path).

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1001,6 +1001,98 @@ def gen_oa_shapes_eq(sizes):
 
 @make_xp_test_case(oaconvolve)
 class TestOAConvolve:
+    @pytest.mark.parametrize("mode", ["full", "same", "valid"])
+    @pytest.mark.parametrize("dtype", [np.float64, np.float32])
+    @pytest.mark.parametrize("shapes", [(5000, 65), (100000, 512), (2000, 500)])
+    def test_cpp_path_matches_python_fallback(self, mode, dtype, shapes, xp):
+        # numpy-only fast path vs the reference fftconvolve
+        n, m = shapes
+        rng = np.random.default_rng(1)
+        a = xp.asarray(rng.standard_normal(n).astype(dtype))
+        b = xp.asarray(rng.standard_normal(m).astype(dtype))
+        got = oaconvolve(a, b, mode=mode)
+        ref = fftconvolve(a, b, mode=mode)
+        rtol = 1e-4 if dtype == np.float32 else 1e-9
+        xp_assert_close(got, ref, rtol=rtol, atol=rtol)
+
+    def test_cpp_path_noncontiguous_input(self, xp):
+        # Non-contiguous 1-D real input exercises the C++ copy path
+        # through the public API.
+        rng = np.random.default_rng(2)
+        a = xp.asarray(rng.standard_normal(10000)[::2])
+        b = xp.asarray(rng.standard_normal(37))
+        got = oaconvolve(a, b, mode="full")
+        ref = fftconvolve(a, b, mode="full")
+        xp_assert_close(got, ref, rtol=1e-9, atol=1e-9)
+
+    @pytest.mark.parametrize("mode", ["full", "same", "valid"])
+    @pytest.mark.parametrize("dtype", [np.complex128, np.complex64])
+    @pytest.mark.parametrize("shapes", [(5000, 65), (100000, 512), (2000, 500)])
+    def test_cpp_path_complex_matches_fftconvolve(self, mode, dtype, shapes, xp):
+        n, m = shapes
+        rng = np.random.default_rng(2)
+        a = xp.asarray(
+            (rng.standard_normal(n) + 1j*rng.standard_normal(n)).astype(dtype))
+        b = xp.asarray(
+            (rng.standard_normal(m) + 1j*rng.standard_normal(m)).astype(dtype))
+        got = oaconvolve(a, b, mode=mode)
+        ref = fftconvolve(a, b, mode=mode)
+        rtol = 1e-4 if dtype == np.complex64 else 1e-9
+        xp_assert_close(got, ref, rtol=rtol, atol=rtol)
+
+    def test_cpp_path_complex_noncontiguous(self, xp):
+        rng = np.random.default_rng(3)
+        a = xp.asarray(rng.standard_normal(10000)
+                       + 1j*rng.standard_normal(10000))[::2]
+        b = xp.asarray(rng.standard_normal(65) + 1j*rng.standard_normal(65))
+        xp_assert_close(oaconvolve(a, b, mode="full"),
+                        fftconvolve(a, b, mode="full"), rtol=1e-9, atol=1e-9)
+
+    @pytest.mark.parametrize("mode", ["full", "same", "valid"])
+    @pytest.mark.parametrize("dtype",
+                             [np.float64, np.complex128, np.float32, np.complex64])
+    @pytest.mark.parametrize("shape_axis",
+                             [((8, 2000), 1), ((2000, 8), 0), ((4, 2000, 3), 1)])
+    def test_cpp_path_nd_single_axis(self, mode, dtype, shape_axis, xp):
+        shape, axis = shape_axis
+        rng = np.random.default_rng(4)
+
+        def mk(shp):
+            r = rng.standard_normal(shp)
+            if np.issubdtype(dtype, np.complexfloating):
+                r = r + 1j*rng.standard_normal(shp)
+            return r.astype(dtype)
+
+        kshape = list(shape)
+        kshape[axis] = 65
+        a = xp.asarray(mk(shape))
+        b = xp.asarray(mk(tuple(kshape)))
+        got = oaconvolve(a, b, mode=mode, axes=[axis])
+        ref = fftconvolve(a, b, mode=mode, axes=[axis])
+        rtol = 1e-4 if dtype in (np.float32, np.complex64) else 1e-9
+        xp_assert_close(got, ref, rtol=rtol, atol=rtol)
+
+    def test_cpp_path_nd_noncontiguous(self, xp):
+        rng = np.random.default_rng(5)
+        a = xp.asarray(rng.standard_normal((8, 4000)))[:, ::2]   # non-contiguous
+        b = xp.asarray(rng.standard_normal((8, 65)))
+        xp_assert_close(oaconvolve(a, b, mode="full", axes=[1]),
+                        fftconvolve(a, b, mode="full", axes=[1]), rtol=1e-9, atol=1e-9)
+
+    def test_cpp_path_multiaxis_falls_back(self, xp):
+        # 2-D with both axes convolved (axes=None) must still be correct (Python path).
+        rng = np.random.default_rng(6)
+        a = xp.asarray(rng.standard_normal((200, 200)))
+        b = xp.asarray(rng.standard_normal((30, 30)))
+        xp_assert_close(oaconvolve(a, b, mode="full"),
+                        fftconvolve(a, b, mode="full"), rtol=1e-9, atol=1e-9)
+        if is_numpy(xp):
+            # Defense against future mis-routing: the C++ layer itself must
+            # decline multi-axis convolution directly (axes=None -> both axes).
+            from scipy.signal import _fftconv
+            res = _fftconv.oaconvolve(np.asarray(a), np.asarray(b), "full", None)
+            assert res is None
+
     @pytest.mark.slow()
     @pytest.mark.parametrize('shape_a_0, shape_b_0',
                              gen_oa_shapes_eq(list(range(1, 100, 1)) +

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -290,6 +290,39 @@ class TestConvolve:
         assert_raises(ValueError, convolve, [3], 2)
 
 
+class TestConvolveMethodOA:
+    @pytest.mark.parametrize("mode", ["full", "same", "valid"])
+    @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+    def test_convolve_method_oa_matches_fft(self, mode, dtype):
+        rng = np.random.default_rng(0)
+        a = rng.standard_normal(5000).astype(dtype)
+        b = rng.standard_normal(65).astype(dtype)
+        got = convolve(a, b, mode=mode, method='oa')
+        ref = convolve(a, b, mode=mode, method='fft')
+        np.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-9)
+
+    @pytest.mark.parametrize("mode", ["full", "same", "valid"])
+    def test_correlate_method_oa_matches_fft(self, mode):
+        rng = np.random.default_rng(1)
+        a = rng.standard_normal(5000)
+        b = rng.standard_normal(65)
+        got = correlate(a, b, mode=mode, method='oa')
+        ref = correlate(a, b, mode=mode, method='fft')
+        np.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-9)
+
+    def test_convolve_invalid_method_mentions_oa(self):
+        a = np.arange(5.0)
+        b = np.arange(3.0)
+        with pytest.raises(ValueError, match="oa"):
+            convolve(a, b, method='nonsense')
+
+    def test_correlate_invalid_method_mentions_oa(self):
+        a = np.arange(5.0)
+        b = np.arange(3.0)
+        with pytest.raises(ValueError, match="oa"):
+            correlate(a, b, method='nonsense')
+
+
 @make_xp_test_case(convolve2d)
 class TestConvolve2d:
 
@@ -934,7 +967,7 @@ class TestFFTConvolve:
             sig_nan[100] = val
             coeffs = xp.asarray(signal.firwin(200, 0.2))
 
-            msg = "Use of fft convolution.*|invalid value encountered.*"
+            msg = "Use of FFT convolution.*|invalid value encountered.*"
             with pytest.warns(RuntimeWarning, match=msg):
                 signal.convolve(sig_nan, coeffs, mode='same', method='fft')
 
@@ -3062,9 +3095,9 @@ def test_choose_conv_method(xp):
             assert method == true_method
 
             method_try, times = choose_conv_method(x, h, mode=mode, measure=True)
-            assert method_try in {'fft', 'direct'}
+            assert method_try in {'fft', 'direct', 'oa'}
             assert isinstance(times, dict)
-            assert 'fft' in times.keys() and 'direct' in times.keys()
+            assert {'fft', 'direct', 'oa'} <= times.keys()
 
         n = 10
         for not_fft_conv_supp in ["complex256", "complex192"]:
@@ -3087,6 +3120,44 @@ def test_choose_conv_method_2(xp):
                 x = np.ones(n, dtype=not_fft_conv_supp)
                 h = x.copy()
                 assert choose_conv_method(x, h, mode=mode) == 'direct'
+
+
+class TestChooseConvMethodOA:
+    def test_1d_equal_size_not_oa(self):
+        a = np.random.default_rng(0).standard_normal(2000)
+        b = np.random.default_rng(1).standard_normal(2000)
+        assert choose_conv_method(a, b, mode='full') != 'oa'
+
+    def test_2d_never_oa(self):
+        a = np.random.default_rng(0).standard_normal((300, 300))
+        b = np.random.default_rng(1).standard_normal((8, 8))
+        assert choose_conv_method(a, b, mode='full') != 'oa'
+
+    def test_integer_input_direct_not_oa(self):
+        a = np.arange(100000, dtype=np.int64) % 7
+        b = np.arange(65, dtype=np.int64) % 3
+        assert choose_conv_method(a, b, mode='full') == 'direct'
+
+    def test_measure_includes_oa(self):
+        a = np.random.default_rng(0).standard_normal(100000)
+        b = np.random.default_rng(1).standard_normal(65)
+        method, times = choose_conv_method(a, b, mode='full', measure=True)
+        assert 'oa' in times
+        assert method in ('oa', 'fft', 'direct')
+        assert method == min(times, key=times.get)
+
+    def test_measure_selects_min_including_oa(self, monkeypatch):
+        # Deterministically verify the measure path times fft/direct/oa and
+        # returns the fastest, without depending on real hardware timing.
+        from scipy.signal import _signaltools
+        # choose_conv_method times methods in the order ['fft', 'direct', 'oa'].
+        fake = iter([0.3, 0.2, 0.1])
+        monkeypatch.setattr(_signaltools, '_timeit_fast', lambda f: next(fake))
+        a = np.random.default_rng(0).standard_normal(1000)
+        b = np.random.default_rng(1).standard_normal(65)
+        method, times = choose_conv_method(a, b, mode='full', measure=True)
+        assert times == {'fft': 0.3, 'direct': 0.2, 'oa': 0.1}
+        assert method == 'oa'
 
 
 @pytest.mark.fail_slow(10)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-24834

#### What does this implement/fix?
- Implement 1-D and N-D with `len(axes)==1` overlap-add convolve (`oaconvolve`) in C++ using the duccfft backend to improve performance. The existing Python impl is kept for the N-D multi axes case as it would be non trivial to optimize in C++
    - Unit tested against existing convolve impls.
    - Also ported `calc_oa_lens` so the hot path stays in C++.
- Added additional, more representative benchmarks for FIR filter use cases.

#### Additional information
<!--Any additional information you think is important.-->

ASV benchmarks should show massive improvements, but here's results [my quick reference benchmark](https://github.com/kwsp/fftconv/blob/main/test.py). Still underperforming the fftw backend by 2-3x but much better than before.

```patch
=== test case (1664, 65) ===
 Vectors are equal.
     (5000 runs) convolve_fftw took 55ms
     (5000 runs) oaconvolve_fftw took 33ms
     (5000 runs) np.convolve took 73ms
     (5000 runs) scipy.signal.convolve took 110ms
     (5000 runs) scipy.signal.fftconvolve took 233ms
-    (5000 runs) scipy.signal.oaconvolve took 511ms
+    (5000 runs) scipy.signal.oaconvolve took 95ms
 === test case (2816, 65) ===
 Vectors are equal.
     (5000 runs) convolve_fftw took 92ms
     (5000 runs) oaconvolve_fftw took 50ms
     (5000 runs) np.convolve took 119ms
     (5000 runs) scipy.signal.convolve took 157ms
     (5000 runs) scipy.signal.fftconvolve took 296ms
-    (5000 runs) scipy.signal.oaconvolve took 556ms
+    (5000 runs) scipy.signal.oaconvolve took 139ms
 === test case (2304, 65) ===
 Vectors are equal.
     (5000 runs) convolve_fftw took 259ms
     (5000 runs) oaconvolve_fftw took 45ms
     (5000 runs) np.convolve took 101ms
     (5000 runs) scipy.signal.convolve took 135ms
     (5000 runs) scipy.signal.fftconvolve took 272ms
-    (5000 runs) scipy.signal.oaconvolve took 532ms
+    (5000 runs) scipy.signal.oaconvolve took 118ms
 === test case (4352, 65) ===
 Vectors are equal.
     (5000 runs) convolve_fftw took 210ms
     (5000 runs) oaconvolve_fftw took 69ms
     (5000 runs) np.convolve took 183ms
     (5000 runs) scipy.signal.convolve took 224ms
     (5000 runs) scipy.signal.fftconvolve took 420ms
-    (5000 runs) scipy.signal.oaconvolve took 577ms
+    (5000 runs) scipy.signal.oaconvolve took 178ms

```

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
Pointed Claude at https://github.com/kwsp/fftconv for the initial port from fftw to duccfft.