### PR TITLE
MAINT: stats: improve input validation of circular statistics functions

### DIFF
--- a/scipy/stats/_circstats.py
+++ b/scipy/stats/_circstats.py
@@ -228,11 +228,7 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
 
     """
     xp = array_namespace(sample)
-    low_, high_ = low, high  # do value-based I.V. on floats rather than arrays
-    sample, low, high = xp_promote(sample, low, high, force_floating=True, xp=xp)
-
-    if low.shape or high.shape or low_ >= high_:
-        raise ValueError("`low` and `high` must be scalars such that `low < high`.")
+    sample, high, low = _circfuncs_common_input_validation(sample, high, low, xp=xp)
 
     tol = 10*xp.finfo(sample).eps
     T = high - low
@@ -271,11 +267,15 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     return median[()]
 
 
-def _circfuncs_common(samples, period, xp=None):
-    xp = array_namespace(samples) if xp is None else xp
+def _circfuncs_common_input_validation(sample, high, low, *, xp):
+    low_, high_ = low, high  # do value-based I.V. on floats rather than arrays
+    sample, low, high = xp_promote(sample, low, high, force_floating=True, xp=xp)
+    if low.shape or high.shape or low_ >= high_:
+        raise ValueError("`low` and `high` must be scalars such that `low < high`.")
+    return sample, high, low
 
-    samples = xp_promote(samples, force_floating=True, xp=xp)
 
+def _circfuncs_common_calc(samples, period, *, xp):
     # Recast samples as radians that range between 0 and 2 pi and calculate
     # the sine and cosine
     scaled_samples = samples * ((2.0 * pi) / period)
@@ -365,12 +365,13 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
     """
     xp = array_namespace(samples)
+    samples, high, low = _circfuncs_common_input_validation(samples, high, low, xp=xp)
     # Needed for non-NumPy arrays to get appropriate NaN result
     # Apparently atan2(0, 0) is 0, even though it is mathematically undefined
     if xp_size(samples) == 0:
         return xp.mean(samples, axis=axis)
     period = high - low
-    samples, sin_samp, cos_samp = _circfuncs_common(samples, period, xp=xp)
+    samples, sin_samp, cos_samp = _circfuncs_common_calc(samples, period, xp=xp)
     sin_sum = xp.sum(sin_samp, axis=axis)
     cos_sum = xp.sum(cos_samp, axis=axis)
     res = xp.atan2(sin_sum, cos_sum)
@@ -462,8 +463,9 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
     """
     xp = array_namespace(samples)
+    samples, high, low = _circfuncs_common_input_validation(samples, high, low, xp=xp)
     period = high - low
-    samples, sin_samp, cos_samp = _circfuncs_common(samples, period, xp=xp)
+    samples, sin_samp, cos_samp = _circfuncs_common_calc(samples, period, xp=xp)
     sin_mean = xp.mean(sin_samp, axis=axis)
     cos_mean = xp.mean(cos_samp, axis=axis)
     hypotenuse = (sin_mean**2. + cos_mean**2.)**0.5
@@ -584,8 +586,9 @@ def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate', *,
 
     """
     xp = array_namespace(samples)
+    samples, high, low = _circfuncs_common_input_validation(samples, high, low, xp=xp)
     period = high - low
-    samples, sin_samp, cos_samp = _circfuncs_common(samples, period, xp=xp)
+    samples, sin_samp, cos_samp = _circfuncs_common_calc(samples, period, xp=xp)
     sin_mean = xp.mean(sin_samp, axis=axis)  # [1] (2.2.3)
     cos_mean = xp.mean(cos_samp, axis=axis)  # [1] (2.2.3)
     hypotenuse = (sin_mean**2. + cos_mean**2.)**0.5

--- a/scipy/stats/tests/test_circstats.py
+++ b/scipy/stats/tests/test_circstats.py
@@ -90,19 +90,10 @@ class TestCircMedian:
         xp_assert_close(res, xp.asarray(ref))
 
     def test_input_validation(self, xp):
-        x = xp.asarray([1., 2., 3.])
-
+        # high/low input validation done in TestCircfuncs
         message = "`convention` must be either 'arc-distance' or 'bisecting'."
         with pytest.raises(ValueError, match=message):
-            stats.circmedian(x, convention='ekki-ekki')
-
-        message = "`low` and `high` must be scalars such that `low < high`."
-        with pytest.raises(ValueError, match=message):
-            stats.circmedian(x, low = xp.asarray([1., 2.]))
-        with pytest.raises(ValueError, match=message):
-            stats.circmedian(x, high = xp.asarray([1., 2.]))
-        with pytest.raises(ValueError, match=message):
-            stats.circmedian(x, low = 1.0, high=0.0)
+            stats.circmedian(xp.asarray([1., 2., 3.]), convention='ekki-ekki')
 
     @pytest.mark.parametrize('convention', ['arc-distance', 'bisecting'])
     def test_edge_cases(self, convention, xp):
@@ -168,6 +159,18 @@ class TestCircFuncs:
         S1 = xp.std(x, correction=0)
         S2 = stats.circstd(x, high=360)
         xp_assert_close(S2, S1, rtol=1e-4)
+
+    @pytest.mark.parametrize("circfun", [stats.circmedian, stats.circmean,
+                                         stats.circvar, stats.circstd])
+    def test_circfuncs_input_validation(self, circfun, xp):
+        x = xp.asarray([1., 2., 3.])
+        message = "`low` and `high` must be scalars such that `low < high`."
+        with pytest.raises(ValueError, match=message):
+            circfun(x, low = xp.asarray([1., 2.]))
+        with pytest.raises(ValueError, match=message):
+            circfun(x, high = xp.asarray([1., 2.]))
+        with pytest.raises(ValueError, match=message):
+            circfun(x, low = 1.0, high=0.0)
 
     @pytest.mark.parametrize("test_func, numpy_func",
                              [(stats.circmean, np.mean),


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-26006

#### What does this implement/fix?
Shares the `high`/`low` input validation of `circmedian` with other circular statistics functions

#### Additional information
Failures unrelated (gh-26019)

#### AI Generation Disclosure
No AI
