### PR TITLE
ENH: stats.circmedian: add geometric median

### DIFF
--- a/scipy/stats/_circstats.py
+++ b/scipy/stats/_circstats.py
@@ -81,7 +81,7 @@ def _circmeandev(sample, alpha, *, high=2*math.pi, low=0):
     return _xp_mean(xp.minimum(y, T - y), axis=-1)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_axis_nan_policy_factory(lambda x: x, n_outputs=1, default_axis=None,
                           result_to_tuple=lambda x, _: (x,))
 def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis=0):
@@ -240,7 +240,7 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     if convention not in conventions:
         raise ValueError(f"`convention` must be one of {conventions}.")
     if is_jax(xp) and convention == 'geometric':
-        raise ValueError(f"`method='geometric'` is not compatible with JAX arrays.")
+        raise ValueError("`method='geometric'` is not compatible with JAX arrays.")
 
     tol = 10*xp.finfo(sample).eps
     T = high - low

--- a/scipy/stats/_circstats.py
+++ b/scipy/stats/_circstats.py
@@ -1,8 +1,8 @@
 import math
 from math import pi
 import scipy._external.array_api_extra as xpx
-from scipy._lib._array_api import (array_namespace, xp_promote, xp_capabilities,
-                                   xp_vector_norm, is_marray, xp_size)
+from scipy._lib._array_api import (array_namespace, xp_promote, xp_capabilities, is_jax,
+                                   xp_vector_norm, is_marray, xp_size, xp_device)
 from scipy.stats._axis_nan_policy import _axis_nan_policy_factory, _broadcast_arrays
 from scipy.stats._stats_py import _xp_mean
 
@@ -97,7 +97,7 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     ----------
     sample : array_like
         Input array of angle observations.
-    convention : {'arc-distance', 'bisecting'}
+    convention : {'arc-distance', 'bisecting', 'geometric'}
         Definition of the circular median, following the terminology of [3]_.
 
         - An ``'arc-distance'`` median minimizes the circular mean deviation: the
@@ -109,6 +109,12 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
           minimize the circular mean deviation. Instead, the number of observations
           within 90 degrees of a bisecting median is greater than the number of
           observations within 90 degrees of its antipode.
+        - A ``'geometric'`` median treats angle observations extrinsically: it maps
+          them to points on the unit circle in the ambient two-dimensional vector space,
+          computes their vector median, and extracts the angular phase of the result.
+          A geometric median does not necessarily have the bisecting property, but it
+          is unique unless all points lie on a line, and it is the only convention here
+          that is defined extrinsically, like the circular mean and circular variance.
 
         See [3]_ for precise mathematical definitions.
 
@@ -142,7 +148,7 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     Although the two definitions produce the same circular median in many cases
     (unimodal distribution, no ties), [3]_ demonstrates that the two definitions can
     lead to different - and in fact, entirely opposite - results. [3]_ also compares the
-    arc-distance and bisecting medians with two other definitions adopted from
+    arc-distance, bisecting, and geometric medians with one other definition from
     vector-space literature, and it concludes that the arc-distance median is the only
     one that provides all four properties under consideration. This, and the fact that
     the arc-distance definition is used by default in other circular statistics software
@@ -150,7 +156,8 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     default convention.
 
     [7]_ addresses the fact that many points - even continuous arcs of the unit circle -
-    may satisfy the definition of a circular median. It proposes that "the estimate of
+    may satisfy the definition of an arc-distance or bisecting circular median. It
+    proposes that "the estimate of
     the population circular median be the average (circular mean) of all angles
     satisfying the definition of median", and that "for odd samples, the candidate
     values are the observations themselves". However, it suggests that "for even
@@ -229,6 +236,11 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
     """
     xp = array_namespace(sample)
     sample, high, low = _circfuncs_common_input_validation(sample, high, low, xp=xp)
+    conventions = {'arc-distance', 'bisecting', 'geometric'}
+    if convention not in conventions:
+        raise ValueError(f"`convention` must be one of {conventions}.")
+    if is_jax(xp) and convention == 'geometric':
+        raise ValueError(f"`method='geometric'` is not compatible with JAX arrays.")
 
     tol = 10*xp.finfo(sample).eps
     T = high - low
@@ -256,12 +268,28 @@ def circmedian(sample, *, convention='arc-distance', high=2*math.pi, low=0, axis
         count_left = xp.astype(xp.count_nonzero(i_left, axis=-1), sample.dtype)
         count_right = xp.astype(xp.count_nonzero(i_right, axis=-1), sample.dtype)
         i = (count_left >= n/2) & (count_right >= n/2)
-    else:
-        raise ValueError("`convention` must be either 'arc-distance' or 'bisecting'.")
 
+    # work in complex plane
     phi = xp.exp(1j * (sample - low) * two_pi / T)
-    median = _xp_mean(phi, weights=xp.astype(i, phi.dtype), axis=-1)
+    if convention == 'geometric':
+        y = xp.mean(phi, axis=-1, keepdims=True)
+        delta = xp.full_like(xp.real(y), xp.inf, device=xp_device(sample))
+        while xp.any(delta > tol*10) and phi.shape[axis] > 1:
+            distances = abs(phi - y)
+            yk = (xp.sum(phi / distances, axis=-1, keepdims=True)
+                  / xp.sum(1 / distances, axis=-1, keepdims=True))
+            delta = abs(y - yk)
+            y = yk
+        median = xp.squeeze(y, axis=-1)
+    else:
+        # It's surprising that the typical way of defining a unique circular median
+        # is to take an extrinsic mean of an intrinsic median. Then again, it is also
+        # surprising that the typical definitions of circular median are intrinsic
+        # while the typical circular mean/variance/std. dev. are extrinsic.
+        median = _xp_mean(phi, weights=xp.astype(i, phi.dtype), axis=-1)
     median = xpx.at(median)[xp.abs(median) < tol].set(xp.nan)
+
+    # back to angles
     median = xp.atan2(xp.imag(median), xp.real(median)) % (2*math.pi)
     median = median * T / two_pi + low
     return median[()]

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -217,6 +217,10 @@ axis_nan_policy_cases = [
     (boxcox_llf, tuple(), dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
     (yeojohnson_llf, tuple(), dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
     (stats.circmedian, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.circmedian, tuple(), dict(convention='bisecting'),
+     1, 1, False, lambda x: (x,)),
+    (stats.circmedian, tuple(), dict(convention='geometric'),
+     1, 1, False, lambda x: (x,)),
     (stats.expectile, (0.4,), dict(), 1, 1, False, lambda x: (x,)),
 ]
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -708,6 +708,8 @@ def test_keepdims(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker,
     small_sample_raises = {stats.skewtest, stats.kurtosistest, stats.normaltest,
                            stats.differential_entropy, stats.epps_singleton_2samp,
                            stats.shapiro}
+    if hypotest == stats.circmedian:
+        sample_shape = (2, 3, 4, 3)  # slow convergence along axis of size 4!
     if sample_shape == (2, 3, 3, 4) and hypotest in small_sample_raises:
         pytest.skip("Sample too small; test raises error.")
     if hypotest in {weightedtau_weighted}:

--- a/scipy/stats/tests/test_circstats.py
+++ b/scipy/stats/tests/test_circstats.py
@@ -6,7 +6,7 @@ from pytest import raises as assert_raises
 import numpy as np
 from numpy.testing import assert_, assert_allclose
 from scipy._external import array_api_extra as xpx
-from scipy._lib._array_api import (make_xp_test_case, eager_warns)
+from scipy._lib._array_api import make_xp_test_case, eager_warns, is_jax
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_1d_omit,
                                           too_small_nd_omit, too_small_1d_not_omit)
@@ -18,6 +18,13 @@ lazy_xp_modules = [stats]
 
 @make_xp_test_case(stats.circmedian)
 class TestCircMedian:
+    conventions = [
+        pytest.param('arc-distance'),
+        pytest.param('bisecting'),
+        # JAX is not compatible with `convention='geometric'`
+        pytest.param('geometric', marks=skip_xp_backends('jax.numpy'))
+    ]
+
     # Example data from references; e.g. `example_3_2` is [3] Example #2
     example_2 = [43, 45, 52, 61, 75, 88, 88, 279, 375]
     example_3_1 = [-9 * pi / 16, -9 * pi / 16, 0, 9 * pi / 16, 9 * pi / 16]
@@ -37,6 +44,8 @@ class TestCircMedian:
                    160, 285, 200, 210, 220, 225, 270]
     example_8_3 = [67, 66, 74, 61, 58, 60, 100, 89, 171, 166, 98, 60, 197, 98, 86, 123,
                    165, 133, 101, 105, 71, 84, 75, 98, 83, 71, 74, 91, 38, 200, 56]
+    # [9] is Ducharme and Milasevic "Spatial Median and Directional Data"
+    example_9_1 = example_7_1
     _bisect = dict(convention='bisecting')
     _deg_bisect = dict(high=360, convention='bisecting')
 
@@ -60,6 +69,30 @@ class TestCircMedian:
         # Test against examples from references
         res = stats.circmedian(xp.asarray(sample), **kwargs)
         xp_assert_close(res, xp.asarray(ref))
+
+    @pytest.mark.parametrize("dtype", [None, 'float32', 'float64'])
+    def test_geometric(self, dtype, xp):
+        dtype = xpx.default_dtype(xp) if dtype is None else getattr(xp, dtype)
+        kwargs = dict(high=360, convention='geometric')
+        example_9_1 = xp.asarray(self.example_9_1, dtype=dtype)
+
+        if is_jax(xp):
+            message = "`method='geometric'` is not compatible with JAX arrays."
+            with assert_raises(ValueError, match=message):
+                res = stats.circmedian(example_9_1, **kwargs)
+            return
+
+        res = stats.circmedian(example_9_1, **kwargs)
+        xp_assert_close(res, xp.asarray(135.6, dtype=dtype), rtol=1e-3)
+
+        example_9_2 = example_9_1[:-1]
+        res = stats.circmedian(example_9_2, **kwargs)
+        xp_assert_close(res, xp.asarray(135.4, dtype=dtype), rtol=1e-3)
+
+        example_9_3 = example_9_1
+        example_9_3[-1] = 10
+        res = stats.circmedian(example_9_3, **kwargs)
+        xp_assert_close(res, xp.asarray(134.1, dtype=dtype), rtol=1e-3)
 
     @pytest.mark.parametrize("sample, ref", [
         (example_2, 52.00000000000002), (example_7_1, 136.99714451257873),
@@ -91,24 +124,32 @@ class TestCircMedian:
 
     def test_input_validation(self, xp):
         # high/low input validation done in TestCircfuncs
-        message = "`convention` must be either 'arc-distance' or 'bisecting'."
+        message = "`convention` must be one of..."
         with pytest.raises(ValueError, match=message):
             stats.circmedian(xp.asarray([1., 2., 3.]), convention='ekki-ekki')
 
-    @pytest.mark.parametrize('convention', ['arc-distance', 'bisecting'])
+    @pytest.mark.parametrize('convention', conventions)
     def test_edge_cases(self, convention, xp):
         x = xp.empty((0,))
         with eager_warns(SmallSampleWarning, match="One or more sample...", xp=xp):
             res = stats.circmedian(x, convention=convention)
-        xp_assert_close(res, xp.asarray(xp.nan))
+        xp_assert_equal(res, xp.asarray(xp.nan))
 
         rng = np.random.default_rng(1664271345)
         x = xp.asarray(rng.uniform(0, 2*np.pi, size=1))
         res = stats.circmedian(x, convention=convention)
         xp_assert_close(res, x[0])
 
+        x = xp.asarray([0., xp.pi])
+        res = stats.circmedian(x, convention=convention)
+        xp_assert_equal(res, xp.asarray(xp.nan))
+
+        x = xp.asarray([0., xp.pi, xp.pi])
+        res = stats.circmedian(x, convention=convention)
+        xp_assert_close(res, xp.asarray(xp.pi))
+
     @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
-    @pytest.mark.parametrize('convention', ['arc-distance', 'bisecting'])
+    @pytest.mark.parametrize('convention', conventions)
     def test_circle_parameterization(self, dtype, convention, xp):
         # test that result is independent of parametrization of unit circle
         # also convenient to test here that dtypes are respected


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-24166

#### What does this implement/fix?
This implements another convention for the circular median. It is not as standard as the others, but it has two major advantages in my book:
- it is unique (see note inline)
- like the other circular statistics - `circmean`, `circvar`, `circstd` - it is defined through extrinsic reasoning.

#### AI Generation Disclosure
No AI