### PR TITLE
DOC: wilcoxon - note pvalue may slightly exceed [0,1] with ties/zeros

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4036,7 +4036,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     The presence of "ties" (i.e. not all elements of ``d`` are unique) or
     "zeros" (i.e. elements of ``d`` are zero) changes the null distribution
     of the test statistic, and ``method='exact'`` no longer calculates
-    the exact p-value. If ``method='asymptotic'``, the z-statistic is adjusted
+    the exact p-value. In this case, the returned p-value may lie slightly
+    outside the interval [0, 1] due to floating point error. If
+    ``method='asymptotic'``, the z-statistic is adjusted
     for more accurate comparison against the standard normal, but still,
     for finite sample sizes, the standard normal is only an approximation of
     the true null distribution of the z-statistic. For such situations, the


### PR DESCRIPTION
#### Reference issue
Closes gh-26028

#### What does this implement/fix?
Clarifies the `wilcoxon` docstring Notes section. When ties or zeros are
present, `method='exact'` no longer computes an exact p-value this was
already documented but the resulting value can also fall slightly
outside `[0, 1]` due to floating point error, which was not mentioned.
For example:

```python
>>> import numpy as np
>>> from scipy import stats
>>> x = np.array([-1.0] + [0.0] * 99)
>>> stats.wilcoxon(x, zero_method='pratt', method='exact',
...                alternative='greater').pvalue
1.0000000000000002
```

This adds a single sentence to the Notes section stating that the
returned p-value may lie slightly outside `[0, 1]` in this regime, so
users don't assume the output is a strictly valid p-value. No code
behavior is changed.


