### PR TITLE
DOC: mirroring numpy docstring update for numpy.trapezoid

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -29,9 +29,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
 
     Integrate `y` (`x`) along each 1d slice on the given axis, compute
     :math:`\int y(x) dx`.
-    When `x` is specified, this integrates along the parametric curve,
-    computing :math:`\int_t y(t) dt =
-    \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt`.
+    When `x` is specified, this integrates along the parametric curve
+    :math:`C` given by :math:`(x(t), y(t))`, computing the line integral
+    :math:`\int_C y \, dx = \int y(t) \frac{dx}{dt} \, dt`.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference PR
This mirrors https://github.com/numpy/numpy/pull/32404 , which updates the docstring of `numpy.trapezoid`,and just got merged.

#### What does this update?
The docstring of `scipy.integrate.trapezoid`.

#### AI Generation Disclosure
No AI tools used. 
