### PR TITLE
BUG: optimize.shgo: reorder X_min along with minimizer_pool in sort_min_pool

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1255,8 +1255,10 @@ class SHGO:
     def sort_min_pool(self):
         # Sort to find minimum func value in min_pool
         self.ind_f_min = np.argsort(np.ravel(self.minimizer_pool_F))
-        self.minimizer_pool = [self.minimizer_pool[i] for i in self.ind_f_min]
-        self.minimizer_pool_F = [self.minimizer_pool_F[i] for i in self.ind_f_min]
+        self.minimizer_pool = np.array(self.minimizer_pool)
+        self.minimizer_pool = self.minimizer_pool[self.ind_f_min]
+        self.minimizer_pool_F = np.array(self.minimizer_pool_F)
+        self.minimizer_pool_F = self.minimizer_pool_F[self.ind_f_min]
         self.X_min = self.X_min[self.ind_f_min]
         return
 

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1254,10 +1254,10 @@ class SHGO:
 
     def sort_min_pool(self):
         # Sort to find minimum func value in min_pool
-        self.ind_f_min = np.argsort(self.minimizer_pool_F)
-        self.minimizer_pool = np.array(self.minimizer_pool)[self.ind_f_min]
-        self.minimizer_pool_F = np.array(self.minimizer_pool_F)[
-            self.ind_f_min]
+        self.ind_f_min = np.argsort(np.ravel(self.minimizer_pool_F))
+        self.minimizer_pool = [self.minimizer_pool[i] for i in self.ind_f_min]
+        self.minimizer_pool_F = [self.minimizer_pool_F[i] for i in self.ind_f_min]
+        self.X_min = self.X_min[self.ind_f_min]
         return
 
     def trim_min_pool(self, trim_ind):
@@ -1274,14 +1274,14 @@ class SHGO:
         negative entries.
 
         """
-        x_min = np.array([x_min])
+        x_min = np.reshape(x_min, (1, self.dim))
+        X_min = np.reshape(X_min, (-1, self.dim))
         self.Y = spatial.distance.cdist(x_min, X_min, 'euclidean')
         # Find sorted indexes of spatial distances:
         self.Z = np.argsort(self.Y, axis=-1)
 
-        self.Ss = X_min[self.Z][0]
-        self.minimizer_pool = self.minimizer_pool[self.Z]
-        self.minimizer_pool = self.minimizer_pool[0]
+        self.Ss = X_min[self.Z[0]]
+        self.minimizer_pool = self.minimizer_pool[self.Z[0]]
         return self.Ss
 
     # Local bound functions
@@ -1371,7 +1371,7 @@ class SHGO:
             logging.info(f'Starting minimization at {x_min}...')
 
         if self.sampling_method == 'simplicial':
-            x_min_t = tuple(x_min)
+            x_min_t = tuple(np.ravel(x_min))
             # Find the normalized tuple in the Vertex cache:
             x_min_t_norm = self.X_min_cache[tuple(x_min_t)]
             x_min_t_norm = tuple(x_min_t_norm)
@@ -1391,6 +1391,7 @@ class SHGO:
             logging.info(self.minimizer_kwargs['bounds'])
 
         # Local minimization using scipy.optimize.minimize:
+        x_min = np.ravel(x_min)
         lres = minimize(self.func, x_min, **self.minimizer_kwargs)
 
         if self.disp:
@@ -1566,7 +1567,7 @@ class LMapCache:
 
     def __getitem__(self, v):
         try:
-            v = np.ndarray.tolist(v)
+            v = tuple(np.ravel(v))
         except TypeError:
             pass
         v = tuple(v)

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1226,3 +1226,15 @@ def test_gh16971():
 
     assert s.minimizer_kwargs['method'].lower() == 'cobyla'
     assert s.minimizer_kwargs['options']['catol'] == 0.05
+def test_sort_min_pool_x_min_ordering():
+    def f(x):
+        return x[0]**2
+
+    optimizer = SHGO(f, [(-2, 2)], n=10, iters=1)
+    optimizer.minimizer_pool_F = np.array([[3.0], [1.0], [2.0]])
+    optimizer.minimizer_pool = ['candidate_A', 'candidate_B', 'candidate_C']
+    optimizer.X_min = np.array([[3.0], [1.0], [2.0]])
+    optimizer.sort_min_pool()
+    assert_allclose(optimizer.minimizer_pool_F.ravel(), [1.0, 2.0, 3.0])
+    assert list(optimizer.minimizer_pool) == ['candidate_B', 'candidate_C', 'candidate_A']
+    assert_allclose(optimizer.X_min.ravel(), [1.0, 2.0, 3.0])


### PR DESCRIPTION
#### Reference issue
Closes gh-25838

#### What does this implement/fix?
This fixes a bug in `SHGO.sort_min_pool()` where `self.X_min` was not being reordered alongside `self.minimizer_pool` and `self.minimizer_pool_F`. 

Because `X_min` remained in raw discovery order while the other pool arrays were sorted by function value ascending, `minimise_pool()` passed mismatched `(x0, ind)` pairs (starting local searches from raw `X_min[0]` while labeling them with the sorted `minimizer_pool[0]`). This caused options like `local_iter=N` to evaluate arbitrary points instead of the best ones.

- Reorders `self.X_min` using `self.ind_f_min` inside `sort_min_pool()`.
- Adds a regression test ensuring `X_min` correctly tracks the sorted order of `minimizer_pool_F`.

#### Additional information
Verified locally using `spin test scipy.optimize.tests.test__shgo`.

#### AI Generation Disclosure
AI tools were used to assist in drafting the regression test structure, while the core bug analysis and fix were done manually.