### PR TITLE
DOC: correct p_lb to slice index in ShortTimeFFT tutorial

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1529,9 +1529,9 @@ is marked by a light blue background. Per definition the zeroth slice
 (`m_num_mid`), here being the sample ``6//2=3``, is marked by the text "mid".
 By default the `stft` calculates all slices which have some overlap with the
 signal. Hence the first slice is at `p_min` = -1 with the lowest sample index
-being `k_min` = -5. The first sample index unaffected by a slice not sticking
-out to the left of the signal is :math:`p_{lb} = 2` and the first sample index
-unaffected by border effects is :math:`k_{lb} = 5`. The property
+being `k_min` = -5. The first slice index not sticking out to the left of the
+signal is :math:`p_{lb} = 2` and the first sample index unaffected by border
+effects is :math:`k_{lb} = 5`. The property
 `lower_border_end` returns the tuple :math:`(k_{lb}, p_{lb})`.
 
 The behavior at the end of the signal is depicted for a signal with


### PR DESCRIPTION
Towards #26031

The "Sliding Windows" tutorial described both values returned by
`ShortTimeFFT.lower_border_end` as a "sample index". The property docstring
states "First signal index and first slice index unaffected by pre-padding",
and the implementation returns `(k_ + self.m_num, q_ + 1)` — a sample index
and a slice index. Throughout the section `p` denotes slice indices and `k`
sample indices, so `p_lb` should read "slice index".

The issue also reports that the `ShortTimeFFT` example would be clearer if it
showed how to restrict the output range, and questions whether `p_lb = 2`
should be `3`. I've left both out of this PR to keep the change focused —
happy to follow up separately.