### PR TITLE
BUG: optimize: defer trust-region subproblem creation

### DIFF
--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -255,12 +255,14 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # calculate the predicted value at the proposed point
         predicted_value = m(p)
 
-        # define the local approximation at the proposed point
         x_proposed = x + p
-        m_proposed = subproblem(x_proposed, fun, jac, hess, hessp, **subproblem_init_kw)
 
         # evaluate the ratio defined in equation (4.4)
-        actual_reduction = m.fun - m_proposed.fun
+        proposed_value = fun(x_proposed)
+        # Treat NaN trial values as rejected steps.
+        if np.isnan(proposed_value):
+            proposed_value = np.inf
+        actual_reduction = m.fun - proposed_value
         predicted_reduction = m.fun - predicted_value
         if predicted_reduction <= 0:
             warnflag = 2
@@ -276,7 +278,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # if the ratio is high enough then accept the proposed step
         if rho > eta:
             x = x_proposed
-            m = m_proposed
+            m = subproblem(x, fun, jac, hess, hessp, **subproblem_init_kw)
 
         # append the best guess, call back, increment the iteration count
         if return_all:

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -107,3 +107,23 @@ class TestTrustRegionSolvers:
         r = minimize(rosen, x0=self.x_opt, jac=rosen_der, hess=rosen_hess,
                      tol=1e-8, method='trust-exact')
         assert_allclose(self.x_opt, r['x'])
+
+    def test_trust_exact_rejects_nan_trial_point(self):
+        def fun(x):
+            return x[0] - np.log(x[0]) if x[0] > 0 else np.nan
+
+        def jac(x):
+            return np.array([1 - 1/x[0]])
+
+        def hess(x):
+            if x[0] <= 0:
+                raise ValueError("Hessian evaluated outside domain")
+            return np.array([[1/x[0]**2]])
+
+        result = minimize(
+            fun, [2.1], jac=jac, hess=hess, method='trust-exact', tol=1e-8,
+            options={'initial_trust_radius': 10, 'maxiter': 10}
+        )
+
+        assert result.success
+        assert_allclose(result.x, [1], atol=1e-8)


### PR DESCRIPTION
#### Reference issue

Closes gh-12503 

#### What does this implement/fix?

Trust-region solvers currently construct a subproblem at every proposed point before deciding to accept it. For the trust-exact, the construction evaluates the Hessian, wasting work for rejected steps and failing when a trial point lies outside the Hessian’s numerical domain. This change evaluates only the objective at the proposed point to compute the actual reduction, then creates the subproblem only after the step is accepted. It also treats a NaN trial objective as +inf, causing the step to be rejected and the trust radius to shrink.

#### AI Generation Disclosure

AI was used for drafting the test structure, but the implementation was written by hand.