### PR TITLE
MAINT: stats.kstest: fix use of cdf='norm' with args

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8229,8 +8229,7 @@ def _parse_kstest_args(data1, data2, args, N):
         rvsfunc = data1
 
     if isinstance(data2, str):
-        special_distributions = {'norm': special.ndtr}
-        cdf = special_distributions.get(data2, getattr(distributions, data2).cdf)
+        cdf = getattr(distributions, data2).cdf
         data2 = None
     elif callable(data2):
         cdf = data2
@@ -8248,7 +8247,9 @@ def _kstest_n_samples(kwargs):
 
 @xp_capabilities(skip_backends=[('dask.array', 'no rankdata')],
                  jax_jit=False, cpu_only=True,  # see ks_1samp/ks_2samp
-                 marray=True)
+                 marray=True,
+                 extra_note="String arguments are compatible only "
+                            "with the NumPy backend.")
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4647,7 +4647,7 @@ class TestKSTest:
     """Tests kstest and ks_1samp agree with K-S various sizes, alternatives, modes."""
 
     def _test_kstest_and_ks1samp(self, x, alternative, mode='auto', decimal=14):
-        result = stats.kstest(x, 'norm', alternative=alternative, mode=mode)
+        result = stats.kstest(x, special.ndtr, alternative=alternative, mode=mode)
         result_1samp = stats.ks_1samp(x, special.ndtr,
                                       alternative=alternative, mode=mode)
         xp_assert_close(result.statistic, result_1samp.statistic)
@@ -4707,7 +4707,20 @@ class TestKSTest:
         xp_assert_equal(res.statistic_location, ref.statistic_location)
         xp_assert_equal(res.statistic_sign, ref.statistic_sign)
 
-    # missing: no test that uses *args
+    @skip_xp_backends(np_only=True, reason='string `cdf` incompatible with other xp')
+    def test_gh25448(self):
+        # gh-25448 reported a failure with with `cdf='norm'` + use of `args`
+        rng = np.random.default_rng(254482544825448)
+        x = rng.normal(size=100)
+        loc, scale = stats.norm.fit(x)
+        ref = stats.kstest(x, lambda x: special.ndtr((x-loc)/scale))
+
+        res = stats.kstest(x, "norm", args=(loc, scale))
+        xp_assert_close(res.statistic, ref.statistic)
+
+        res = stats.kstest(x, lambda x, u, s: special.ndtr((x-u)/s),
+                           args=(loc, scale))
+        xp_assert_close(res.statistic, ref.statistic)
 
 
 @make_xp_test_case(stats.ks_1samp)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4707,8 +4707,7 @@ class TestKSTest:
         xp_assert_equal(res.statistic_location, ref.statistic_location)
         xp_assert_equal(res.statistic_sign, ref.statistic_sign)
 
-    @skip_xp_backends(np_only=True, reason='string `cdf` incompatible with other xp')
-    def test_gh25448(self):
+    def test_gh25448(self):  # string `cdf` incompatible with other xp
         # gh-25448 reported a failure with with `cdf='norm'` + use of `args`
         rng = np.random.default_rng(254482544825448)
         x = rng.normal(size=100)


### PR DESCRIPTION
#### Reference issue
Closes gh-25448

#### What does this implement/fix?
gh-25448 reported that using `kstest` with `cdf='norm'` and `args` caused a failure. This fixes the bug.

#### Additional information
There are some larger issues (not to mention that the KS test is essentially superseded by more powerful tests):
- `kstest` doesn't currently work with the first argument as a string or callable (with or without `args`)
- The usefulness of allowing `rvs` to be a callable/string with an array for CDF is questionable
- When both `rvs` and `cdf` are both strings/callables, it is essentially just a test for inconsistency between RVS and CDF functions/methods, which is pretty unusual for `scipy.stats` to offer in a public function
- Utility aside, allowing the two arguments to be any combination of numbers, strings, or callables is probably too flexible
- Even with this PR, the function is missing a lot of tests

I think we agreed that combining conceptually different kinds tests based on superficial similarity (e.g. the name associated with the statistic) is not actually very convenient, so personally, I'd prefer eliminating this function (and keep just `ks_1samp` and `ks_2samp`) rather than trying to fix it.

#### AI Generation Disclosure
No AI