### PR TITLE
DOC: correct p_lb to slice index in ShortTimeFFT tutorial

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1529,9 +1529,9 @@ is marked by a light blue background. Per definition the zeroth slice
 (`m_num_mid`), here being the sample ``6//2=3``, is marked by the text "mid".
 By default the `stft` calculates all slices which have some overlap with the
 signal. Hence the first slice is at `p_min` = -1 with the lowest sample index
-being `k_min` = -5. The first sample index unaffected by a slice not sticking
-out to the left of the signal is :math:`p_{lb} = 2` and the first sample index
-unaffected by border effects is :math:`k_{lb} = 5`. The property
+being `k_min` = -5. The first slice index not sticking out to the left of the
+signal is :math:`p_{lb} = 2` and the first sample index unaffected by border
+effects is :math:`k_{lb} = 5`. The property
 `lower_border_end` returns the tuple :math:`(k_{lb}, p_{lb})`.
 
 The behavior at the end of the signal is depicted for a signal with


### PR DESCRIPTION
#### Reference issue

Towards gh-26031

#### What does this implement/fix?

The "Sliding Windows" section of the signal processing tutorial describes both
values returned by `ShortTimeFFT.lower_border_end` as a "sample index".

This does not match the implementation. The docstring of `lower_border_end`
says "First signal index and first slice index unaffected by pre-padding", and
the property returns `(k_ + self.m_num, q_ + 1)`, which is a sample index
followed by a slice counter. Throughout this tutorial section `p` denotes slice
indices and `k` denotes sample indices, so `p_lb` should read "slice index".

This PR corrects the wording for `p_lb` only.

#### Additional information

The issue also suggests reworking the `ShortTimeFFT` example to show how to
restrict the output range, and asks whether `p_lb = 2` should instead be `3`.
I have left both out of this PR to keep the change focused, and I have not
verified the numeric value myself.

#### AI Generation Disclosure

I used an AI assistant (Arena.ai Agent Mode) while preparing this pull request.
It helped me locate this issue, and helped me read `scipy/signal/_short_time_fft.py`
to confirm what `lower_border_end` returns. It also assisted with the git
workflow and with grammar editing this description.

I made the documentation change myself, verified it against the source, and I
understand and can explain the reasoning above. No code in this PR is AI
generated.