### PR TITLE
BUG: linalg: prevent a segfault in `inv(f_order_sym_matrix, overwrite_a=True)`

### DIFF
--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -368,8 +368,13 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 if constexpr (!detail::type_traits<T>::is_complex) {
                     // Real: is_symm and is_herm are always equal
                     if (is_symm) {
-                        // try Cholesky first, fall back to sytrf if it fails
-                        slice_structure = St::POS_DEF;
+                        /*
+                         * If working on a copy (overwrite_a is False):
+                         *    try Cholesky first, fall back to sytrf if it fails
+                         * If working in-place, do the inversion in one go,
+                         *    (if Cholesky failed, it already destroyed the input)
+                         */
+                        slice_structure = overwrite_a ? St::SYM : St::POS_DEF ;
                     }
                     else {
                         slice_structure = St::GENERAL;
@@ -383,7 +388,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     else if (is_herm) {
                         // Hermitian (may also be symmetric if entries are real)
                         // try Cholesky first, fall back to hetrf if it fails
-                        slice_structure = St::POS_DEF;
+                        slice_structure = overwrite_a ? St::HER : St::POS_DEF ;
                     }
                     else {
                         // is_symm && !is_herm: complex symmetric, not hermitian

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -603,7 +603,14 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
                 if (is_herm || (is_symm && !detail::type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
-                    slice_structure = St::POS_DEF;
+                    if (!overwrite_a) {
+                        slice_structure = St::POS_DEF;
+                    }
+                    else {
+                        // working in-place: cannot try Cholesky, have to use the
+                        // right structure straight away
+                        slice_structure = is_symm ? St::SYM : St::HER;
+                    }
                 }
                 else if (is_symm && detail::type_traits<T>::is_complex) {
                     // complex symmetric, not hermitian

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1265,6 +1265,42 @@ class TestSolve:
         with pytest.raises(LinAlgError):
             solve(A, b, assume_a="banded")
 
+    def test_sym_overwrite(self):
+        # regression test for https://github.com/scipy/scipy/issues/26045
+        # the issue reported a segfault in `inv` due to a conspiracy between
+        # overwrite_a and try-except-Cholesky routine for a symmetric input;
+        # The same problem exists for solve---which we test for here.
+        a3 = np.asarray([[1, 2, 0], [2, 3, 0], [0, 0, 1]], dtype=float, order='F')
+        b3 = np.eye(3, dtype=float, order='F')
+
+        soln = solve(a3, b3, overwrite_a=True)
+        expected = np.asarray([[-3.,  2., -0.],
+                               [ 2., -1.,  0.],
+                               [ 0.,  0.,  1.]])
+        assert_allclose(soln, expected, atol=1e-14)
+
+        # make it complex symmetric
+        a3 = np.asarray([[1, 2, 0], [2, 3, 0], [0, 0, 1]], dtype=float, order='F')
+        b3 = np.eye(3, dtype=float, order='F')
+        a_s = a3 + 1j*a3.T
+
+        soln = solve(a_s, b3, overwrite_a=True)
+        expected = np.asarray([[-1.5+1.5j,  1. -1.j , -0. +0.j ],
+                               [ 1. -1.j , -0.5+0.5j,  0. +0.j ],
+                               [ 0. +0.j ,  0. +0.j ,  0.5-0.5j]])
+        assert_allclose(soln, expected, atol=1e-14)
+
+        # make it hermitian
+        a3 = np.asarray([[1, 2, 0], [2, 3, 0], [0, 0, 1]], dtype=float, order='F')
+        b3 = np.eye(3, dtype=float, order='F')
+        a_h = a3 + np.triu(a3)*1j - np.tril(a3)*1j
+
+        soln = solve(a_h, b3, overwrite_a=True)
+        expected = np.asarray([[-0.6-0.j ,  0.4+0.4j, -0. -0.j ],
+                               [ 0.4-0.4j, -0.2+0.j ,  0. -0.j ],
+                               [ 0. +0.j ,  0. +0.j ,  1. +0.j ]])
+        assert_allclose(soln, expected, atol=1e-14)
+
 
 class TestSolveTriangular:
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1755,6 +1755,26 @@ class TestInv:
         with pytest.raises(LinAlgError):
             inv(a, assume_a="diagonal")
 
+    def test_sym_overwrite_a(self):
+        # regression test for https://github.com/scipy/scipy/issues/26045
+        # setting overwrite_a makes it work in-place; for symmetric inputs this
+        # conflicts with trying Cholesky first.
+        a3 = np.asarray([[1, 2, 0], [2, 3, 0], [0, 0, 1]], order='F')
+        a3inv = inv(a3)
+
+        expected = np.asarray([[-3.,  2., -0.],
+                               [ 2., -1.,  0.],
+                               [ 0.,  0.,  1.]])
+        assert_allclose(a3inv, expected, atol=1e-14)
+
+        # the same bug triggers with a float `a` and an explicit overwrite_a=True
+        a3inv = inv(a3.astype(float), overwrite_a=True)
+        assert_allclose(a3inv, expected, atol=1e-14)
+
+        # for completeness, cover the complex input
+        a3inv = inv(a3.astype(complex), overwrite_a=True)
+        assert_allclose(a3inv, expected, atol=1e-14)
+
 
 class TestDet:
     def test_1x1_all_singleton_dims(self):


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-26045


#### What does this implement/fix?
<!--Please explain your changes.-->

`linalg.inv` does several optimizations internally, and two of them conspired to a segfault:
- for symmetric inputs, it first tries a Cholesky-based invert; if that fails (i.e. the input is symmetric but not positive definite), it falls back to the symmetric invese;
- for `overwrite_a`, it works in-place to save memory

Thus, for a symmetric input in the memory-saving mode, what happened was:

- we try `?potrf` in-place, and it overwrites the input matrix;
- if it failed, we need to restore the original input, but it's been destroyed already.

Therefore, in this PR we go straight to the symmetric inverse if `overwrite_a=True`.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai