### PR TITLE
DOC: add Examples to signal.residuez and signal.invresz

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3472,6 +3472,39 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     See Also
     --------
     invresz, residue, unique_roots
+
+    Examples
+    --------
+    The following example computes the partial-fraction
+    expansion of b(z) / a(z):
+
+    >>> import numpy as np
+    >>> from scipy import signal
+    >>> b = np.array([1, 0.3])
+    >>> a = np.array([1, -0.75, 0.125])
+    >>> r, p, k = signal.residuez(b, a)
+    >>> r
+    array([-2.2,  3.2])
+    >>> p
+    array([0.25, 0.5 ])
+
+    There is no direct term here, so `k` is empty:
+
+    >>> k
+    array([], dtype=float64)
+
+    Get `b` and `a` back with `invresz`:
+
+    >>> signal.invresz(r, p, k)
+    (array([1. , 0.3]), array([ 1.   , -0.75 ,  0.125]))
+
+    An example where `k` is not empty:
+
+    >>> b = np.array([2, -1, 0.1])
+    >>> a = np.array([1, -0.5])
+    >>> r, p, k = signal.residuez(b, a)
+    >>> k
+    array([ 1.6, -0.2])
     """
     b = np.asarray(b)
     a = np.asarray(a)
@@ -3607,6 +3640,35 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     --------
     residuez, unique_roots, invres
 
+    Examples
+    --------
+    The following example builds b(z) / a(z) back from its
+    partial-fraction expansion:
+
+    >>> import numpy as np
+    >>> from scipy import signal
+    >>> r = np.array([-2.2, 3.2])
+    >>> p = np.array([0.25, 0.5])
+    >>> k = np.array([])
+    >>> b, a = signal.invresz(r, p, k)
+    >>> b
+    array([1. , 0.3])
+    >>> a
+    array([ 1.   , -0.75 ,  0.125])
+
+    Use `residuez` to get back the expansion:
+
+    >>> signal.residuez(b, a)
+    (array([-2.2,  3.2]), array([0.25, 0.5 ]), array([], dtype=float64))
+
+    A non-empty `k` adds the direct term:
+
+    >>> r = np.array([0.4])
+    >>> p = np.array([0.5])
+    >>> k = np.array([1.6, -0.2])
+    >>> b, a = signal.invresz(r, p, k)
+    >>> b
+    array([ 2. , -1. ,  0.1])
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3503,6 +3503,8 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     >>> b = np.array([2, -1, 0.1])
     >>> a = np.array([1, -0.5])
     >>> r, p, k = signal.residuez(b, a)
+    >>> r, p
+    (array([0.4]), array([0.5]))
     >>> k
     array([ 1.6, -0.2])
     """

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3667,8 +3667,8 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     >>> p = np.array([0.5])
     >>> k = np.array([1.6, -0.2])
     >>> b, a = signal.invresz(r, p, k)
-    >>> b
-    array([ 2. , -1. ,  0.1])
+    >>> b, a
+    (array([ 2. , -1. ,  0.1]), array([ 1. , -0.5]))
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)


### PR DESCRIPTION
#### Reference issue
gh-7168

#### What does this implement/fix?
signal.residuez and signal.invresz did not have any Examples section. This adds an Examples section to each and shows what the function returns with the given parameters. Since the two are inverses of each other, each section also shows the result being reversed with the complementary function.

#### Additional information
This PR only modifies documentation.

#### AI Generation Disclosure
Claude was used to search the codebase and to understand these functions fully. The examples were written by me.