### PR TITLE
BLD: restore `COMP_{LINK_}ARGS` to `__config__.py`

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -594,6 +594,14 @@ foreach name, compiler : compilers
   conf_data.set(name + '_COMP_LINKER_ID', compiler.get_linker_id())
   conf_data.set(name + '_COMP_VERSION', compiler.version())
   conf_data.set(name + '_COMP_CMD_ARRAY', ', '.join(compiler.cmd_array()))
+  conf_data.set(name + '_COMP_ARGS', ', '.join(
+      get_option(name.to_lower() + '_args')
+    )
+  )
+  conf_data.set(name + '_COMP_LINK_ARGS', ', '.join(
+      get_option(name.to_lower() + '_link_args')
+    )
+  )
 endforeach
 # Add `pythran` information if present
 if use_pythran


### PR DESCRIPTION
This is a partial reversion of gh-25236, reintroducing a path which was mistakenly dropped as Fortran-only. It addresses the following warning visible in the Meson build logs:

```
../scipy/meson.build:639: WARNING: The variable(s) 'CPP_COMP_ARGS',
'CPP_COMP_LINK_ARGS', 'CYTHON_COMP_ARGS', 'CYTHON_COMP_LINK_ARGS',
'C_COMP_ARGS', 'C_COMP_LINK_ARGS' in the input file 'scipy/__config__.py.in'
are not present in the given configuration data.
```

[skip circle]