### PR TITLE
DOC: add estimate_rank examples

### DIFF
--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -934,6 +934,27 @@ def estimate_rank(A, eps, rng=None):
     -------
     int
         Estimated matrix rank.
+
+    Examples
+    --------
+    Estimate the numerical rank of a Hilbert matrix.
+
+    >>> import numpy as np
+    >>> from scipy.linalg import hilbert
+    >>> from scipy.linalg.interpolative import estimate_rank
+    >>> from scipy.sparse.linalg import aslinearoperator
+
+    >>> A = hilbert(300)
+    >>> estimate_rank(A, eps=1e-3, rng=np.random.default_rng(44))
+    12
+
+    Different algorithms are used for arrays and linear operators, so the
+    estimated ranks may differ. The same matrix can be provided as a
+    ``LinearOperator``:
+
+    >>> L = aslinearoperator(A)
+    >>> estimate_rank(L, eps=1e-3, rng=np.random.default_rng(44))
+    5
     """
     from scipy.sparse.linalg import LinearOperator
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Towards gh-7168

#### What does this implement/fix?
Example added to `scipy.linalg.interpolative.estimate_rank` to demonstrate numerical rank estimation on a Hilbert matrix.

#### Additional information
The example demonstrates `estimate_rank` with both a NumPy array and a `LinearOperator`. It also highlights that the estimated rank can differ because different algorithms are used for these input types.

#### AI Generation Disclosure
ChatGPT was used to learn about the `estimate_rank` function, understand the SciPy codebase, debug the local and test environment, and review the documentation change.
The submitted documentation example was written by me and its behavior was verified locally against the SciPy development build.
