### PR TITLE
ENH: special: add _iv_ratioinv

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -102,6 +102,7 @@ special_ufuncs = [
     "_invgauss_ppf",
     "_iv_ratio",
     "_iv_ratio_c",
+    "_iv_ratioinv",
     "_kolmogc",
     "_kolmogci",
     "_kolmogp",

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -235,6 +235,7 @@ extern const char *inv_boxcox1p_doc;
 extern const char *iv_doc;
 extern const char *iv_ratio_doc;
 extern const char *iv_ratio_c_doc;
+extern const char *iv_ratioinv_doc;
 extern const char *ive_doc;
 extern const char *j0_doc;
 extern const char *j1_doc;
@@ -1420,6 +1421,11 @@ _special_ufuncs_module_exec(PyObject *module)
         {static_cast<xsf::numpy::ff_f>(xsf::iv_ratio_c), static_cast<xsf::numpy::dd_d>(xsf::iv_ratio_c)}, "_iv_ratio_c",
         iv_ratio_c_doc);
     PyModule_AddObjectRef(module, "_iv_ratio_c", iv_ratio_c);
+
+    PyObject *iv_ratioinv = xsf::numpy::ufunc(
+        {static_cast<xsf::numpy::ff_f>(xsf::iv_ratioinv), static_cast<xsf::numpy::dd_d>(xsf::iv_ratioinv)},
+        "_iv_ratioinv", iv_ratioinv_doc);
+    PyModule_AddObjectRef(module, "_iv_ratioinv", iv_ratioinv);
 
     PyObject *ive = xsf::numpy::ufunc(
         {static_cast<xsf::numpy::ff_f>(xsf::cyl_bessel_ie), static_cast<xsf::numpy::dd_d>(xsf::cyl_bessel_ie),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -8522,6 +8522,55 @@ const char *iv_ratio_c_doc = R"(
 
     )";
 
+const char *iv_ratioinv_doc = R"(
+    _iv_ratioinv(v, r, out=None)
+
+    Internal function.
+
+    Return the nonnegative value `x` such that ``_iv_ratio(v, x) == r``.
+
+    Parameters
+    ----------
+    v : array_like of float
+        Order. Must be finite and `>= 0.5`.
+    r : array_like of float
+        Ratio. Must be between `0` and `1`, inclusive.
+    out : ndarray, optional
+        Optional output array for the function values.
+
+    Returns
+    -------
+    scalar or ndarray
+        The argument of `_iv_ratio`. The returned value is nonnegative.
+
+        If either `v` or `r` is `nan`, `nan` is returned. Otherwise, the
+        special values are:
+
+        - If `v < 0.5`, `v == +inf`, `r < 0`, or `r > 1`, set "domain"
+          error and return `nan`.
+        - If `r == 0`, return `0`.
+        - If `r == 1`, return `+inf`.
+
+    See Also
+    --------
+    _iv_ratio : ratio of modified Bessel functions of adjacent orders
+    _iv_ratio_c : complement of the ratio of modified Bessel functions of
+        adjacent orders
+
+    Notes
+    -----
+    The root is computed using Chandrupatla's algorithm. Initial bounds are
+    obtained by inverting bounds on ratios of modified Bessel functions from
+    [1]_. If these bounds do not bracket the root due to rounding error, a
+    monotonic bracketing algorithm is used as a fallback.
+
+    References
+    ----------
+    .. [1] Amos, D. E. (1974). "Computation of Modified Bessel Functions and
+           Their Ratios." Mathematics of Computation, 28(125):239-251.
+
+    )";
+
 const char *ive_doc = R"(
     ive(v, z, out=None)
 

--- a/scipy/special/tests/test_iv_ratio.py
+++ b/scipy/special/tests/test_iv_ratio.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_equal, assert_allclose
 from scipy.special._ufuncs import (
     _iv_ratio as iv_ratio,
     _iv_ratio_c as iv_ratio_c,
+    _iv_ratioinv as iv_ratioinv,
 )
 
 
@@ -247,3 +248,42 @@ class TestIvRatioC:
         t = x / v
         expected = 1 - t / (1 + np.hypot(1, t))
         assert_allclose(iv_ratio_c(v, x), expected, rtol=4e-16, atol=0)
+
+
+class TestIvRatioInv:
+
+    @pytest.mark.parametrize('v,x,r', [
+        (10, 100000, 0.9999050040375403),
+        (1, 0.1, 0.04993760398793892),
+        (0.5, 0.001, 0.0009999996666668),
+        (1000, 500, 0.23607911616885813),
+        (100, 1e-15, 5e-18),
+        (1e5, 5, 2.4999999984375157e-05),
+        (1e5, 1e5, 0.41421399130458997),
+        (1e5, 1e10, 0.999990000099999),
+        (0.5, 18.714973875118524, np.nextafter(1.0, 0.0)),
+        (0.5, np.finfo(float).tiny, np.finfo(float).tiny),
+    ])
+    def test_against_reference_values(self, v, x, r):
+        """The ratios were computed using mpmath with 1000 digits."""
+        assert_allclose(iv_ratioinv(v, r), x, rtol=1e-10, atol=0)
+
+    @pytest.mark.parametrize('v,r', [
+        (np.nan, 0.5),
+        (1, np.nan),
+    ])
+    def test_nan_propagation(self, v, r):
+        assert_equal(iv_ratioinv(v, r), np.nan)
+
+    @pytest.mark.parametrize('v,r', [
+        (0.4, 0.5),
+        (1, -1),
+        (1, 2),
+        (np.inf, 0.5),
+    ])
+    def test_domain_error(self, v, r):
+        assert_equal(iv_ratioinv(v, r), np.nan)
+
+    def test_domain_boundary(self):
+        assert_equal(iv_ratioinv(1, 0), 0)
+        assert_equal(iv_ratioinv(1, 1), np.inf)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Towards https://github.com/scipy/scipy/issues/20253.

#### What does this implement/fix?
Follow-up of https://github.com/scipy/xsf/pull/211. This PR adds the private special ufunc `_iv_ratioinv` following @dschmitz89's implementation at XSF. The tests try to match those of XSF.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex helped me with this PR.