### PR TITLE
MAINT: stats: use `_iv_ratioinv`

### DIFF
--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -260,6 +260,7 @@ _cospi: np.ufunc
 _ellip_harm: np.ufunc
 _gen_harmonic: np.ufunc
 _igam_fac: np.ufunc
+_iv_ratioinv: np.ufunc
 _kolmogc: np.ufunc
 _kolmogci: np.ufunc
 _kolmogp: np.ufunc

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11366,31 +11366,7 @@ class vonmises_gen(rv_continuous):
                 # some large kappa such that r[0](kappa) = 1.0 numerically.
                 return 1e16
             elif r > 0:
-                def solve_for_kappa(kappa):
-                    return sc.i1e(kappa)/sc.i0e(kappa) - r
-
-                # The bounds of the root of r[0](kappa) = r are derived from
-                # selected bounds of r[0](x) given in [1, Eq. 11 & 16].  See
-                # gh-20102 for details.
-                #
-                # [1] Amos, D. E. (1973).  Computation of Modified Bessel
-                #     Functions and Their Ratios.  Mathematics of Computation,
-                #     28(125): 239-251.
-                lower_bound = r/(1-r)/(1+r)
-                upper_bound = 2*lower_bound
-
-                # The bounds are violated numerically for certain values of r,
-                # where solve_for_kappa evaluated at the bounds have the same
-                # sign.  This indicates numerical imprecision of i1e()/i0e().
-                # Return the violated bound in this case as it's more accurate.
-                if solve_for_kappa(lower_bound) >= 0:
-                    return lower_bound
-                elif solve_for_kappa(upper_bound) <= 0:
-                    return upper_bound
-                else:
-                    root_res = root_scalar(solve_for_kappa, method="brentq",
-                                           bracket=(lower_bound, upper_bound))
-                    return root_res.root
+                return scu._iv_ratioinv(1, r)
             else:
                 # if the provided floc is very far from the circular mean,
                 # the mean resultant length r can become negative.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -9,6 +9,7 @@ import scipy.linalg
 from scipy._lib import doccer
 from scipy.special import (gammaln, psi, multigammaln, xlogy, entr, betaln,
                            ive, loggamma)
+from scipy.special._ufuncs import _iv_ratioinv
 from scipy import special
 import scipy._external.array_api_extra as xpx
 from scipy._lib._util import check_random_state
@@ -18,7 +19,6 @@ from ._discrete_distns import binom
 from . import _covariance, _rcont
 from ._qmvnt import _qmvt, _qmvn, _qauto
 from ._circstats import directional_stats
-from scipy.optimize import root_scalar
 
 __all__ = ['multivariate_normal',
            'matrix_normal',
@@ -7610,20 +7610,8 @@ class vonmises_fisher_gen(multi_rv_generic):
         mu = dirstats.mean_direction
         r = dirstats.mean_resultant_length
 
-        # kappa is the solution to the equation:
-        # r = I[dim/2](kappa) / I[dim/2 -1](kappa)
-        #   = I[dim/2](kappa) * exp(-kappa) / I[dim/2 -1](kappa) * exp(-kappa)
-        #   = ive(dim/2, kappa) / ive(dim/2 -1, kappa)
-
         halfdim = 0.5 * dim
-
-        def solve_for_kappa(kappa):
-            bessel_vals = ive([halfdim, halfdim - 1], kappa)
-            return bessel_vals[0]/bessel_vals[1] - r
-
-        root_res = root_scalar(solve_for_kappa, method="brentq",
-                               bracket=(1e-8, 1e9))
-        kappa = root_res.root
+        kappa = _iv_ratioinv(halfdim, r)
         return mu, kappa
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #20253
Follow-up of https://github.com/scipy/scipy/pull/26067

#### What does this implement/fix?
Replace existing code with the new ufunc `_iv_ratioinv`. I had to add a np.ufunc entry for `_iv_ratioinv` as pyrefly was complaining.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Asked Codex to check.