### PR TITLE
DOC: special: improve Mathieu functions documentation

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -635,7 +635,7 @@ universal functions):
    :toctree: generated/
 
    mathieu_even_coef -- Fourier coefficients for even Mathieu and modified Mathieu functions.
-   mathieu_odd_coef  -- Fourier coefficients for even Mathieu and modified Mathieu functions.
+   mathieu_odd_coef  -- Fourier coefficients for odd Mathieu and modified Mathieu functions.
 
 The following return both function and first derivative:
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1814,7 +1814,7 @@ def mathieu_odd_coef(m, q):
     Parameters
     ----------
     m : int
-        Order of Mathieu functions.  Must be non-negative.
+        Order of Mathieu functions.  Must be positive.
     q : float (>=0)
         Parameter of Mathieu functions.  Must be non-negative.
 
@@ -1872,7 +1872,7 @@ def mathieu_odd_coef(m, q):
     ``mathieu_sem(m, q, x)``.
 
     >>> plt.plot(x, y, 'k--', label="Fourier sum")
-    >>> se, _sce = mathieu_sem(m, q, x)
+    >>> se, _dse = mathieu_sem(m, q, x)
     >>> plt.plot(x, se, alpha=0.35, linewidth=3.5, label="mathieu_sem")
     >>> plt.grid(True)
     >>> plt.title(f'Mathieu Function $\\rm{{se_{m}}}(x, {q})$')

--- a/scipy/special/_mathieu.py
+++ b/scipy/special/_mathieu.py
@@ -9,9 +9,8 @@ _mathieu_cem_doc = (
     Even Mathieu function and its derivative.
 
     Returns the even Mathieu function, ``ce_m(x, q)``, of order `m` and
-    parameter `q` evaluated at the angular argument `x`, given in degrees.
-    Also returns the derivative with respect to the corresponding argument
-    in radians.
+    parameter `q` evaluated at `x`, given in degrees. Also returns the
+    derivative with respect to `x` expressed in radians.
 
     Parameters
     ----------
@@ -20,7 +19,7 @@ _mathieu_cem_doc = (
     q : array_like
         Parameter of the function.
     x : array_like
-        Angular argument of the function, *given in degrees, not radians*.
+        Argument of the function, *given in degrees, not radians*.
     out : tuple of ndarray, optional
         Optional output arrays for the function results.
 
@@ -29,7 +28,7 @@ _mathieu_cem_doc = (
     y : scalar or ndarray
         Value of the function.
     yp : scalar or ndarray
-        Derivative with respect to the angular argument in radians.
+        Derivative with respect to `x` expressed in radians.
 
     See Also
     --------
@@ -37,19 +36,22 @@ _mathieu_cem_doc = (
 
     Notes
     -----
-    Let :math:`\theta = \pi x/180` be the angular argument in radians. The even
-    Mathieu functions are the solutions to Mathieu's differential equation
+    Let :math:`x_\mathrm{rad} = \pi x/180` denote the input expressed in
+    radians. The even Mathieu functions are the solutions to Mathieu's
+    differential equation
 
     .. math::
 
-        \frac{d^2y}{d\theta^2} + (a_m - 2q \cos(2\theta))y = 0
+        \frac{d^2y}{dx_\mathrm{rad}^2}
+        + (a_m - 2q \cos(2x_\mathrm{rad}))y = 0
 
     for which the characteristic number :math:`a_m` (calculated with `mathieu_a`)
-    results in an even, periodic solution :math:`y(\theta)` with period 180 degrees
-    (for even :math:`m`) or 360 degrees (for odd :math:`m`).
+    results in an even, periodic solution :math:`y(x_\mathrm{rad})` with period
+    :math:`\pi` radians (180 degrees) for even :math:`m`, or :math:`2\pi`
+    radians (360 degrees) for odd :math:`m`.
 
-    The returned derivative `yp` is :math:`dy/d\theta`. To obtain the derivative
-    with respect to the degree-valued input `x`, multiply `yp` by
+    The returned derivative `yp` is :math:`dy/dx_\mathrm{rad}`. To obtain the
+    derivative with respect to the degree-valued input `x`, multiply `yp` by
     :math:`\pi/180`.
 
     References
@@ -98,9 +100,8 @@ _mathieu_sem_doc = (
     Odd Mathieu function and its derivative.
 
     Returns the odd Mathieu function, ``se_m(x, q)``, of order `m` and
-    parameter `q` evaluated at the angular argument `x`, given in degrees.
-    Also returns the derivative with respect to the corresponding argument
-    in radians.
+    parameter `q` evaluated at `x`, given in degrees. Also returns the
+    derivative with respect to `x` expressed in radians.
 
     Parameters
     ----------
@@ -109,7 +110,7 @@ _mathieu_sem_doc = (
     q : array_like
         Parameter of the function.
     x : array_like
-        Angular argument of the function, *given in degrees, not radians*.
+        Argument of the function, *given in degrees, not radians*.
     out : tuple of ndarray, optional
         Optional output arrays for the function results.
 
@@ -118,7 +119,7 @@ _mathieu_sem_doc = (
     y : scalar or ndarray
         Value of the function.
     yp : scalar or ndarray
-        Derivative with respect to the angular argument in radians.
+        Derivative with respect to `x` expressed in radians.
 
     See Also
     --------
@@ -126,20 +127,23 @@ _mathieu_sem_doc = (
 
     Notes
     -----
-    Let :math:`\theta = \pi x/180` be the angular argument in radians. Odd
-    Mathieu functions are the solutions to Mathieu's differential equation
+    Let :math:`x_\mathrm{rad} = \pi x/180` denote the input expressed in
+    radians. Odd Mathieu functions are the solutions to Mathieu's differential
+    equation
 
     .. math::
 
-        \frac{d^2y}{d\theta^2} + (b_m - 2q \cos(2\theta))y = 0
+        \frac{d^2y}{dx_\mathrm{rad}^2}
+        + (b_m - 2q \cos(2x_\mathrm{rad}))y = 0
 
     for which the characteristic number :math:`b_m` (calculated with `mathieu_b`)
-    results in an odd, periodic solution :math:`y(\theta)` with period 180 degrees
-    (for even :math:`m`) or 360 degrees (for odd :math:`m`).
+    results in an odd, periodic solution :math:`y(x_\mathrm{rad})` with period
+    :math:`\pi` radians (180 degrees) for even :math:`m`, or :math:`2\pi`
+    radians (360 degrees) for odd :math:`m`.
 
     For ``m = 0``, both outputs are zero. The returned derivative `yp` is
-    :math:`dy/d\theta`. To obtain the derivative with respect to the degree-valued
-    input `x`, multiply `yp` by :math:`\pi/180`.
+    :math:`dy/dx_\mathrm{rad}`. To obtain the derivative with respect to the
+    degree-valued input `x`, multiply `yp` by :math:`\pi/180`.
 
     References
     ----------

--- a/scipy/special/_mathieu.py
+++ b/scipy/special/_mathieu.py
@@ -9,26 +9,27 @@ _mathieu_cem_doc = (
     Even Mathieu function and its derivative.
 
     Returns the even Mathieu function, ``ce_m(x, q)``, of order `m` and
-    parameter `q` evaluated at `x` (given in degrees).  Also returns the
-    derivative with respect to `x` of ce_m(x, q)
+    parameter `q` evaluated at the angular argument `x`, given in degrees.
+    Also returns the derivative with respect to the corresponding argument
+    in radians.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a non-negative integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function.
     x : array_like
-        Argument of the function, *given in degrees, not radians*
+        Angular argument of the function, *given in degrees, not radians*.
     out : tuple of ndarray, optional
-        Optional output arrays for the function results
+        Optional output arrays for the function results.
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to the angular argument in radians.
 
     See Also
     --------
@@ -36,15 +37,20 @@ _mathieu_cem_doc = (
 
     Notes
     -----
-    The even Mathieu functions are the solutions to Mathieu's differential equation
+    Let :math:`\theta = \pi x/180` be the angular argument in radians. The even
+    Mathieu functions are the solutions to Mathieu's differential equation
 
     .. math::
 
-        \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
+        \frac{d^2y}{d\theta^2} + (a_m - 2q \cos(2\theta))y = 0
 
     for which the characteristic number :math:`a_m` (calculated with `mathieu_a`)
-    results in an even, periodic solution :math:`y(x)` with period 180 degrees
+    results in an even, periodic solution :math:`y(\theta)` with period 180 degrees
     (for even :math:`m`) or 360 degrees (for odd :math:`m`).
+
+    The returned derivative `yp` is :math:`dy/d\theta`. To obtain the derivative
+    with respect to the degree-valued input `x`, multiply `yp` by
+    :math:`\pi/180`.
 
     References
     ----------
@@ -91,27 +97,28 @@ _mathieu_sem_doc = (
 
     Odd Mathieu function and its derivative.
 
-    Returns the odd Mathieu function, se_m(x, q), of order `m` and
-    parameter `q` evaluated at `x` (given in degrees).  Also returns the
-    derivative with respect to `x` of se_m(x, q).
+    Returns the odd Mathieu function, ``se_m(x, q)``, of order `m` and
+    parameter `q` evaluated at the angular argument `x`, given in degrees.
+    Also returns the derivative with respect to the corresponding argument
+    in radians.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a non-negative integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function.
     x : array_like
-        Argument of the function, *given in degrees, not radians*.
+        Angular argument of the function, *given in degrees, not radians*.
     out : tuple of ndarray, optional
-        Optional output arrays for the function results
+        Optional output arrays for the function results.
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to the angular argument in radians.
 
     See Also
     --------
@@ -119,15 +126,20 @@ _mathieu_sem_doc = (
 
     Notes
     -----
-    Odd Mathieu functions are the solutions to Mathieu's differential equation
+    Let :math:`\theta = \pi x/180` be the angular argument in radians. Odd
+    Mathieu functions are the solutions to Mathieu's differential equation
 
     .. math::
 
-        \frac{d^2y}{dx^2} + (b_m - 2q \cos(2x))y = 0
+        \frac{d^2y}{d\theta^2} + (b_m - 2q \cos(2\theta))y = 0
 
     for which the characteristic number :math:`b_m` (calculated with `mathieu_b`)
-    results in an odd, periodic solution :math:`y(x)` with period 180 degrees
+    results in an odd, periodic solution :math:`y(\theta)` with period 180 degrees
     (for even :math:`m`) or 360 degrees (for odd :math:`m`).
+
+    For ``m = 0``, both outputs are zero. The returned derivative `yp` is
+    :math:`dy/d\theta`. To obtain the derivative with respect to the degree-valued
+    input `x`, multiply `yp` by :math:`\pi/180`.
 
     References
     ----------

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -10367,9 +10367,9 @@ const char *mathieu_modcem1_doc = R"(
     m : array_like
         Order of the function. Must be a non-negative integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function. Must be non-negative.
     x : array_like
-        Dimensionless argument of the function.
+        Argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results
 
@@ -10382,7 +10382,30 @@ const char *mathieu_modcem1_doc = R"(
 
     See Also
     --------
-    mathieu_modsem1
+    mathieu_a, mathieu_modsem1
+
+    Notes
+    -----
+    Replacing :math:`x` with :math:`\pm \mathrm{i}x` in Mathieu's equation gives
+    the modified Mathieu equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} - (a_m - 2q \cosh(2x))y = 0.
+
+    Here, :math:`a_m` is the characteristic number of the even Mathieu
+    function of order :math:`m`, calculated with `mathieu_a`.
+
+    `mathieu_modcem1` and `mathieu_modcem2` are linearly independent solutions
+    of this equation. For large `x`, the first- and second-kind solutions have
+    behavior analogous, up to normalization, to
+    :math:`J_m(2\sqrt{q}\cosh x)` and :math:`Y_m(2\sqrt{q}\cosh x)`,
+    respectively.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions, Section 28.20.
+           https://dlmf.nist.gov/28.20
 
     )";
 
@@ -10400,9 +10423,9 @@ const char *mathieu_modcem2_doc = R"(
     m : array_like
         Order of the function. Must be a non-negative integer.
     q : array_like
-        Parameter of the function.
+        Parameter of the function. Must be non-negative.
     x : array_like
-        Dimensionless argument of the function.
+        Argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results.
 
@@ -10415,7 +10438,30 @@ const char *mathieu_modcem2_doc = R"(
 
     See Also
     --------
-    mathieu_modsem2
+    mathieu_a, mathieu_modsem2
+
+    Notes
+    -----
+    Replacing :math:`x` with :math:`\pm \mathrm{i}x` in Mathieu's equation gives
+    the modified Mathieu equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} - (a_m - 2q \cosh(2x))y = 0.
+
+    Here, :math:`a_m` is the characteristic number of the even Mathieu
+    function of order :math:`m`, calculated with `mathieu_a`.
+
+    `mathieu_modcem1` and `mathieu_modcem2` are linearly independent solutions
+    of this equation. For large `x`, the first- and second-kind solutions have
+    behavior analogous, up to normalization, to
+    :math:`J_m(2\sqrt{q}\cosh x)` and :math:`Y_m(2\sqrt{q}\cosh x)`,
+    respectively.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions, Section 28.20.
+           https://dlmf.nist.gov/28.20
 
     )";
 
@@ -10433,9 +10479,9 @@ const char *mathieu_modsem1_doc = R"(
     m : array_like
         Order of the function. Must be a positive integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function. Must be non-negative.
     x : array_like
-        Dimensionless argument of the function.
+        Argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results
 
@@ -10448,7 +10494,30 @@ const char *mathieu_modsem1_doc = R"(
 
     See Also
     --------
-    mathieu_modcem1
+    mathieu_b, mathieu_modcem1
+
+    Notes
+    -----
+    Replacing :math:`x` with :math:`\pm \mathrm{i}x` in Mathieu's equation gives
+    the modified Mathieu equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} - (b_m - 2q \cosh(2x))y = 0.
+
+    Here, :math:`b_m` is the characteristic number of the odd Mathieu
+    function of order :math:`m`, calculated with `mathieu_b`.
+
+    `mathieu_modsem1` and `mathieu_modsem2` are linearly independent solutions
+    of this equation. For large `x`, the first- and second-kind solutions have
+    behavior analogous, up to normalization, to
+    :math:`J_m(2\sqrt{q}\cosh x)` and :math:`Y_m(2\sqrt{q}\cosh x)`,
+    respectively.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions, Section 28.20.
+           https://dlmf.nist.gov/28.20
 
     )";
 
@@ -10466,9 +10535,9 @@ const char *mathieu_modsem2_doc = R"(
     m : array_like
         Order of the function. Must be a positive integer.
     q : array_like
-        Parameter of the function.
+        Parameter of the function. Must be non-negative.
     x : array_like
-        Dimensionless argument of the function.
+        Argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results.
 
@@ -10481,7 +10550,30 @@ const char *mathieu_modsem2_doc = R"(
 
     See Also
     --------
-    mathieu_modcem2
+    mathieu_b, mathieu_modcem2
+
+    Notes
+    -----
+    Replacing :math:`x` with :math:`\pm \mathrm{i}x` in Mathieu's equation gives
+    the modified Mathieu equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} - (b_m - 2q \cosh(2x))y = 0.
+
+    Here, :math:`b_m` is the characteristic number of the odd Mathieu
+    function of order :math:`m`, calculated with `mathieu_b`.
+
+    `mathieu_modsem1` and `mathieu_modsem2` are linearly independent solutions
+    of this equation. For large `x`, the first- and second-kind solutions have
+    behavior analogous, up to normalization, to
+    :math:`J_m(2\sqrt{q}\cosh x)` and :math:`Y_m(2\sqrt{q}\cosh x)`,
+    respectively.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions, Section 28.20.
+           https://dlmf.nist.gov/28.20
 
     )";
 

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -10295,7 +10295,7 @@ const char *mathieu_a_doc = R"(
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a non-negative integer.
     q : array_like
         Parameter of the function
     out : ndarray, optional
@@ -10326,7 +10326,7 @@ const char *mathieu_b_doc = R"(
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a positive integer.
     q : array_like
         Parameter of the function
     out : ndarray, optional
@@ -10359,26 +10359,26 @@ const char *mathieu_modcem1_doc = R"(
     Even modified Mathieu function of the first kind and its derivative.
 
     Evaluates the even modified Mathieu function of the first kind,
-    ``Mc1m(x, q)``, and its derivative at `x` for order `m` and parameter
-    `q`.
+    :math:`\mathrm{Mc}_m^{(1)}(x, q)`, and its derivative at `x` for order
+    `m` and parameter `q`.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a non-negative integer.
     q : array_like
         Parameter of the function
     x : array_like
-        Argument of the function, *given in degrees, not radians*
+        Dimensionless argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to `x`.
 
     See Also
     --------
@@ -10392,26 +10392,26 @@ const char *mathieu_modcem2_doc = R"(
     Even modified Mathieu function of the second kind and its derivative.
 
     Evaluates the even modified Mathieu function of the second kind,
-    Mc2m(x, q), and its derivative at `x` (given in degrees) for order `m`
-    and parameter `q`.
+    :math:`\mathrm{Mc}_m^{(2)}(x, q)`, and its derivative at `x` for order
+    `m` and parameter `q`.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a non-negative integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function.
     x : array_like
-        Argument of the function, *given in degrees, not radians*
+        Dimensionless argument of the function.
     out : tuple of ndarray, optional
-        Optional output arrays for the function results
+        Optional output arrays for the function results.
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to `x`.
 
     See Also
     --------
@@ -10425,26 +10425,26 @@ const char *mathieu_modsem1_doc = R"(
     Odd modified Mathieu function of the first kind and its derivative.
 
     Evaluates the odd modified Mathieu function of the first kind,
-    Ms1m(x, q), and its derivative at `x` (given in degrees) for order `m`
-    and parameter `q`.
+    :math:`\mathrm{Ms}_m^{(1)}(x, q)`, and its derivative at `x` for order
+    `m` and parameter `q`.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a positive integer.
     q : array_like
         Parameter of the function
     x : array_like
-        Argument of the function, *given in degrees, not radians*
+        Dimensionless argument of the function.
     out : tuple of ndarray, optional
         Optional output arrays for the function results
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to `x`.
 
     See Also
     --------
@@ -10458,26 +10458,26 @@ const char *mathieu_modsem2_doc = R"(
     Odd modified Mathieu function of the second kind and its derivative.
 
     Evaluates the odd modified Mathieu function of the second kind,
-    Ms2m(x, q), and its derivative at `x` (given in degrees) for order `m`
-    and parameter q.
+    :math:`\mathrm{Ms}_m^{(2)}(x, q)`, and its derivative at `x` for order
+    `m` and parameter `q`.
 
     Parameters
     ----------
     m : array_like
-        Order of the function
+        Order of the function. Must be a positive integer.
     q : array_like
-        Parameter of the function
+        Parameter of the function.
     x : array_like
-        Argument of the function, *given in degrees, not radians*
+        Dimensionless argument of the function.
     out : tuple of ndarray, optional
-        Optional output arrays for the function results
+        Optional output arrays for the function results.
 
     Returns
     -------
     y : scalar or ndarray
-        Value of the function
+        Value of the function.
     yp : scalar or ndarray
-        Value of the derivative vs x
+        Derivative with respect to `x`.
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
[Discussion](https://discuss.scientific-python.org/t/proposal-switch-the-mathieu-functions-to-radians-for-scipy-2-0/2560/3) from @steppi and @brorson 

#### What does this implement/fix?
This PR tries to improve the various inconsistencies found in the documentation of Mathieu functions, the most important being that the derivatives of `mathieu_cem` and `mathieu_sem` are per radian, while the angular argument `x` is in degrees (I found this to be very confusing btw). Also, the modified Mathieu functions' argument is (as far as I can tell) dimensionless, while the current doc says it is in degrees.

#### Additional information
The following Python script highlights the confusion. It corresponds to the case m=1, q=0, for which `mathieu_cem` boils down to the `cos` function.

<details>

```python
import matplotlib.pyplot as plt
import numpy as np
from scipy.special import mathieu_cem

m = 1
q = 0

xs = np.linspace(0, 360, 1000)
y, yp = mathieu_cem(m, q, xs)

# Because xs is measured in degrees, this is dy/d(x in degrees).
yp_numerical = np.gradient(y, xs)

# SciPy returns dy/d(theta), where theta is the angle in radians.
# Convert it to a derivative per degree.
yp_per_degree = yp * np.pi / 180

fig, (ax1, ax2) = plt.subplots(
    2, 1, figsize=(8, 7), sharex=True, constrained_layout=True
)

ax1.plot(xs, y, label=r"$\mathrm{ce}_1(x, 0)$")
ax1.plot(xs, np.cos(np.radians(xs)), "--", label=r"$\cos(x)$")
ax1.set_ylabel("y")
ax1.set_title("Mathieu function and derivative unit mismatch")
ax1.grid()
ax1.legend()

ax2.plot(
    xs,
    yp,
    label="Returned derivative (per radian)",
    linewidth=2,
)
ax2.plot(
    xs,
    yp_numerical,
    "--",
    label="Numerical derivative w.r.t. degrees",
)
ax2.plot(
    xs,
    yp_per_degree,
    ":",
    linewidth=3,
    label=r"Returned derivative $\times\,\pi/180$",
)

ax2.set_xlabel("x (degrees)")
ax2.set_ylabel("derivative")
ax2.grid()
ax2.legend()

plt.show()
```
</details>
<img width="1623" height="1423" alt="output" src="https://github.com/user-attachments/assets/330bcd25-650e-4410-8718-c55303ea6c6f" />

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I first drafted the Python script while reviewing the Mathieu documentation and worked on improving the doc. I then asked Codex for a review and feedback, and worked with it to finish the PR.