### PR TITLE
DOC: remove API reference links from the User Guide index

### DIFF
--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -17,45 +17,45 @@ each subpackage along with some general application notes.
 .. _NumPy: https://numpy.org
 
 The following table lists the subpackages SciPy provides. The left column contains the
-names which link to their :doc:`../reference/index` whereas the right column provides a
-description and links to the corresponding chapter of this User Guide (if available):
+subpackage names, whereas the right column provides a description and links to the
+corresponding chapter of this User Guide (if available):
 
 .. list-table::
     :header-rows: 1
 
-    * - Subpackage (link to API reference)
+    * - Subpackage
       - Description (link to User Guide chapter)
-    * - :doc:`scipy.cluster <../reference/cluster>`
+    * - ``scipy.cluster``
       - Clustering algorithms
-    * - :doc:`scipy,constants <../reference/constants>`
+    * - ``scipy.constants``
       - Physical and mathematical constants
-    * - :doc:`scipy.differentiate <../reference/differentiate>`
+    * - ``scipy.differentiate``
       - Finite difference differentiation tools
-    * - :doc:`scipy.fft <../reference/fft>`
+    * - ``scipy.fft``
       - :doc:`./fft`
-    * - :doc:`scipy.fftpack <../reference/fftpack>`
+    * - ``scipy.fftpack``
       - Fast Fourier Transform routines (legacy)
-    * - :doc:`scipy.integrate <../reference/integrate>`
+    * - ``scipy.integrate``
       - :doc:`./integrate`
-    * - :doc:`scipy.interpolate <../reference/interpolate>`
+    * - ``scipy.interpolate``
       - :doc:`./interpolate`
-    * - :doc:`scipy.io <../reference/io>`
+    * - ``scipy.io``
       - :doc:`./io`
-    * - :doc:`scipy.linalg <../reference/linalg>`
+    * - ``scipy.linalg``
       - :doc:`./linalg`
-    * - :doc:`scipy.ndimage <../reference/ndimage>`
+    * - ``scipy.ndimage``
       - :doc:`./ndimage`
-    * - :doc:`scipy.optimize <../reference/optimize>`
+    * - ``scipy.optimize``
       - :doc:`./optimize`
-    * - :doc:`scipy.signal <../reference/signal>`
+    * - ``scipy.signal``
       - :doc:`./signal`
-    * - :doc:`scipy.sparse <../reference/sparse>`
+    * - ``scipy.sparse``
       - :doc:`./sparse`
-    * - :doc:`scipy.spatial <../reference/spatial>`
+    * - ``scipy.spatial``
       - :doc:`./spatial`
-    * - :doc:`scipy.special <../reference/special>`
+    * - ``scipy.special``
       - :doc:`./special`
-    * - :doc:`scipy.stats <../reference/stats>`
+    * - ``scipy.stats``
       - :doc:`./stats`
 
 


### PR DESCRIPTION
Closes gh-22485.

On the [User Guide index](https://docs.scipy.org/doc/scipy/tutorial/index.html#user-guide), the subpackage name in the left column of the table links to that module's **API reference**, while the link to the User Guide chapter sits in the right column. The module name is the more prominent target, so a reader looking for the tutorial tends to click it and land on the reference page instead.

This was the outcome agreed in gh-22485 ("let's go even further and just remove links to module API reference from this page"). It was addressed once before, but the links returned with the documentation restructuring in gh-25642, and the issue was reopened.

This PR renders the subpackage names as literal text, so the only links in the table are the User Guide chapters in the right column:

```rst
    * - Subpackage
      - Description (link to User Guide chapter)
    * - ``scipy.cluster``
      - Clustering algorithms
    * - ``scipy.fft``
      - :doc:`./fft`
```

Double backticks match the markup already used for module names on the per-module tutorial pages, so the names still render as code.

Also included:

- The sentence introducing the table described the left column as linking to the API reference; it now describes the column as it is.
- The header cell no longer reads "Subpackage (link to API reference)".
- Fixes a typo in the table: `scipy,constants` → `scipy.constants`.

The API reference remains reachable from the top-level navigation and from each User Guide chapter, so nothing is orphaned by this change.
