### PR TITLE
BLD: bump NumPy C API version to gate deprecated API usage on

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -30,7 +30,7 @@ np_dep = declare_dependency(
   # Don't use the deprecated NumPy C API. Define this to a fixed version instead
   # of NPY_API_VERSION in order not to break compilation for released SciPy
   # versions when NumPy introduces a new deprecation.
-  compile_args: ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'],
+  compile_args: ['-DNPY_NO_DEPRECATED_API=NPY_2_0_API_VERSION'],
 )
 
 # Note: the undecorated `_pybind11_dep` is kept around, like `_numpy_dep`.


### PR DESCRIPTION
From 1.9 to 2.0; it is already clean, which isn't completely surprising - NumPy rarely deprecates C APIs, and we're not likely to introduce the use of new deprecated APIs.

This follows up on https://github.com/scipy/scipy/pull/26063#discussion_r3911218677.

#### AI Generation Disclosure

No AI tools used
