### PR TITLE
ENH: spatial.distance.hamming: use count_nonzero for the unweighted path

### DIFF
--- a/scipy/spatial/distance/_distance.py
+++ b/scipy/spatial/distance/_distance.py
@@ -702,7 +702,10 @@ def hamming(u, v, w=None):
             raise ValueError("'w' should have the same length as 'u' and 'v'.")
         w = w / w.sum()
         return np.dot(u_ne_v, w)
-    return np.mean(u_ne_v)
+    if u_ne_v.size == 0:
+        # preserve the nan that np.mean returns for an empty input
+        return np.mean(u_ne_v)
+    return np.count_nonzero(u_ne_v) / u_ne_v.size
 
 
 def jaccard(u, v, w=None):

--- a/scipy/spatial/distance/tests/test_distance.py
+++ b/scipy/spatial/distance/tests/test_distance.py
@@ -1468,6 +1468,22 @@ class TestSomeDistanceFunctions:
             dist = weuclidean(x, y)
             assert math.isclose(dist, math.sqrt(5.0), abs_tol=1.5e-7)
 
+    def test_hamming(self):
+        for x, y in self.cases:
+            # x and y differ in two of their three positions
+            assert math.isclose(hamming(x, y), 2.0 / 3.0, abs_tol=1.5e-7)
+
+        assert hamming([1, 0, 0], [0, 1, 0]) == 2.0 / 3.0
+        assert hamming([1, 0, 0], [1, 0, 0]) == 0.0
+
+        # weighted case
+        assert math.isclose(
+            hamming([1, 0, 0], [0, 1, 0], w=[1.0, 2.0, 3.0]), 0.5, abs_tol=1.5e-7
+        )
+
+        # an empty input has no positions to compare, and yields nan
+        assert np.isnan(hamming([], []))
+
     def test_sqeuclidean(self):
         for x, y in self.cases:
             dist = wsqeuclidean(x, y)


### PR DESCRIPTION
Closes #26071.

The unweighted branch of `hamming` ended with `np.mean(u != v)`. For a boolean array the mean is just the fraction of `True` values, so counting them and dividing by the size gives the same result without the sum and division over a temporary float array that `np.mean` performs.

`np.mean` returns `nan` for an empty input, which a plain `0 / 0` would not reproduce, so that case stays on the original path.

Benchmarks, comparing the full function before and after so that validation overhead is included on both sides rather than timing the bare expression:

| n | bool | int64 | float64 |
| --- | --- | --- | --- |
| 1,000 | 3.6x | 3.6x | 2.9x |
| 100,000 | 8.4x | 3.3x | 4.3x |
| 1,000,000 | 9.9x | 3.6x | 4.6x |

For example, `bool` at n=1,000,000 goes from 1775 us to 180 us per call.

The gain is largest for `bool` because that is where `np.mean`'s conversion to a float temporary costs the most relative to the comparison itself.

Testing:

I checked equivalence rather than assuming it: 23 cases spanning `bool`, `int64` and `float64`, lengths 0 through 1001, weighted and unweighted, comparing the old and new implementations for exact equality. No mismatches, including the empty case where both return `nan`.

`hamming` had no direct test of its own, so this adds one covering the unweighted, weighted, identical-input and empty-input cases. The empty case is the one that matters most here, since it guards the branch this change introduces.

```
pytest --pyargs scipy.spatial.tests.test_distance   ->  464 passed, 6 skipped
```

One caveat on how that was run, so the number is not read as more than it is. SciPy does not build on this machine (no usable Fortran toolchain), so rather than skip verification I applied the change to an installed SciPy 1.18.1 and ran the suite against it. I confirmed 1.18.1's `hamming` body is identical to the one on `main` before doing so, and confirmed the patch was actually live via `inspect.getsource`. The new test's assertions were run the same way. CI will exercise both properly against `main`.
