### PR TITLE
ENH: stats.kstat: build the power sums without repeated exponentiation

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -324,7 +324,17 @@ def kstat(data, n=2, *, axis=None):
 
     N = _count_nonmasked(data, axis, xp=xp)
 
-    S = [None] + [xp.sum(data**k, axis=axis) for k in range(1, n + 1)]
+    # Build the power sums from multiplications rather than a general power for
+    # each order: ``data**1`` only reproduces ``data``, and the square can be
+    # reused for the cube and the fourth power.
+    S = [None, xp.sum(data, axis=axis)]
+    if n >= 2:
+        data2 = data * data
+        S.append(xp.sum(data2, axis=axis))
+    if n >= 3:
+        S.append(xp.sum(data2 * data, axis=axis))
+    if n >= 4:
+        S.append(xp.sum(data2 * data2, axis=axis))
     if n == 1:
         return S[1] * 1.0/N
     elif n == 2:


### PR DESCRIPTION
Reference issue

Closes gh-26070.

What does this implement/fix?

Previously, kstat built its power sums by calculating a general power for every order. For example, kstat(x, 4) would calculate x**1, x**2, x**3, and x**4, which creates and reduces four separate temporaries. In particular, x**1 still goes through the backend power operation even though it just returns x.

This change avoids that unnecessary work. The first power sum is now calculated by summing data directly, and the square is reused when calculating the third and fourth power sums. The existing array-API dispatch is preserved, so this does not introduce a NumPy-only path.

I benchmarked only the power-sum construction, since the decorators used by kstat dominate the runtime for small inputs and hide the actual improvement.

n | size | before | after | speedup
1 | 10,000 | 21.6 us | 4.1 us | 5.27x
1 | 1,000,000 | 3023.0 us | 337.8 us | 8.95x
2 | 10,000 | 28.1 us | 10.4 us | 2.71x
2 | 1,000,000 | 5015.8 us | 2896.6 us | 1.73x
3 | 10,000 | 213.9 us | 17.7 us | 12.09x
3 | 1,000,000 | 25602.3 us | 5643.9 us | 4.54x
4 | 10,000 | 394.0 us | 29.5 us | 13.35x
4 | 1,000,000 | 48385.6 us | 8968.4 us | 5.40x

Accuracy

Since changing the order of floating-point operations can affect rounding, I also checked whether this optimization introduced any meaningful numerical differences.

I compared the results against power sums accumulated using math.fsum over 300 random cases, with n from 1 to 4 and input sizes from 5 to 5000.

dtype | before | after
float32 | 3.26e-04 | 3.26e-04
float64 | 1.48e-11 | 2.22e-11

For float32, the worst relative error was unchanged. For float64, the worst case increased from 1.48e-11 to 2.22e-11. Both are still around five orders of magnitude above machine epsilon, and the error seems to be dominated by cancellation in the existing k-statistic expression rather than by how the power sums are constructed.

I did not find a case where this difference had a meaningful effect on the result, but I wanted to include the comparison here rather than leave the numerical difference for review to discover.

I also compared the old and new implementations directly for float64, float32, and int64, with sizes from 5 to 5000, n from 1 to 4, and the 2-D axis= path.

The relevant tests pass:

pytest --pyargs scipy.stats.tests.test_morestats
554 passed, 5 skipped

pytest --pyargs scipy.stats.tests.test_morestats -k kstat
13 passed

As with gh-26083, I was unable to build SciPy locally because I do not have a usable Fortran toolchain on Windows. I therefore applied the change to an installed SciPy 1.18.1 and ran the relevant tests and checks there. I also confirmed that the kstat implementation matched main before making the change, and verified with inspect.getsource that the modified implementation was actually being used.

CI will provide the full build and test validation.

AI Generation Disclosure

AI was used only to help format and clean up the code and presentation of this PR and to format this comment. The implementation, optimization approach, benchmarking, accuracy analysis, equivalence checks, and testing were all done by me. I reviewed the final changes and verified the results myself.
