### PR TITLE
BUG: integrate: honor min_step in LSODA

### DIFF
--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -663,6 +663,27 @@ def test_max_step(num_parallel_threads):
                 assert_raises(RuntimeError, solver.step)
 
 
+def test_min_step(num_parallel_threads):
+    if num_parallel_threads > 1:
+        pytest.skip('LSODA does not allow for concurrent execution')
+
+    def fun(t, y):
+        return -0.5 * y
+
+    res = solve_ivp(fun, [1, 8], [1.0], min_step=0,
+                    method='LSODA', rtol=1e-7, atol=1e-9)
+    assert res.success
+    assert_equal(res.status, 0)
+
+    with pytest.warns(UserWarning):
+        res = solve_ivp(fun, [1, 8], [1.0], min_step=2,
+                        method='LSODA', rtol=1e-7, atol=1e-9)
+    assert not res.success
+    assert_equal(res.status, -1)
+
+    assert_raises(ValueError, LSODA, fun, 1, [1.0], 8, min_step=-1)
+
+
 def test_first_step(num_parallel_threads):
     rtol = 1e-3
     atol = 1e-6

--- a/scipy/integrate/src/lsoda.c
+++ b/scipy/integrate/src/lsoda.c
@@ -1707,6 +1707,7 @@ void lsoda(
             S->mxordn = mord[0];
             S->mxords = mord[1];
         }
+        S->hmin = hmin;
         // 60
 
         S->meth = 1;
@@ -1922,6 +1923,7 @@ void lsoda(
             S->hmxi = 0.0;
             hmin = 0.0;
         }
+        S->hmin = hmin;
         // 60
 
         S->lyh = 20;


### PR DESCRIPTION
#### Reference issue
Closes gh-25827.

#### What does this implement/fix?

`lsoda` parses and validates `min_step` as `hmin`, but the value was never stored in `S->hmin`, the persistent state field used during integration. Consequently, nonzero `min_step` values were silently ignored.

This PR stores the validated `hmin` value in `S->hmin` in both LSODA initialization paths.

#### Additional information

Added a regression test that covers a successful integration with the default `min_step=0`, as well as a rejection of negative `min_step` values.

#### AI Generation Disclosure

The code was written by hand, since it was a small fix. An AI assistant was used to review the test and suggest some improvements, and I used those to refine it.