### PR TITLE
BUG: optimize.milp: don't mutate options dict and partially enable xfailed test

### DIFF
--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -136,7 +136,7 @@ def _milp_iv(c, integrality, bounds, constraints, options):
     indptr, indices, data = A.indptr, A.indices, A.data.astype(np.float64)
 
     # options IV
-    options = options or {}
+    options = dict(options) if options else {}
     supported_options = {'disp', 'presolve', 'time_limit', 'node_limit',
                          'mip_rel_gap'}
     unsupported_options = set(options).difference(supported_options)

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -3,13 +3,14 @@ Unit test for Mixed Integer Linear Programming
 """
 import re
 import sys
+import copy
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
 from .test_linprog import magic_square
-from scipy.optimize import milp, Bounds, LinearConstraint
+from scipy.optimize import milp, Bounds, LinearConstraint, OptimizeWarning
 from scipy import sparse
 
 
@@ -75,20 +76,21 @@ def test_milp_iv():
         milp([1, 2, 3], bounds=([1, 2, 3], [set(), 4, 5]))
 
 
-@pytest.mark.xfail(run=False,
-                   reason="Needs to be fixed in `_highs_wrapper`")
 def test_milp_options(capsys):
-    # run=False now because of gh-16347
     message = "Unrecognized options detected: {'ekki'}..."
     options = {'ekki': True}
     with pytest.warns(RuntimeWarning, match=message):
-        milp(1, options=options)
+        with pytest.warns(OptimizeWarning):
+            milp(1, options=options)
 
     A, b, c, numbers, M = magic_square(3)
     options = {"disp": True, "presolve": False, "time_limit": 0.05}
+    options_to_pass = copy.deepcopy(options)
     res = milp(c=c, constraints=(A, b, b), bounds=(0, 1), integrality=1,
-               options=options)
+               options=options_to_pass)
+    assert options_to_pass == options
 
+    pytest.xfail("Needs to be fixed in `_highs_wrapper`, gh-16347")
     captured = capsys.readouterr()
     assert "Presolve is switched off" in captured.out
     assert "Time Limit Reached" in captured.out


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #26095
#### What does this implement/fix?
<!--Please explain your changes.-->
Prevents the options dict from being mutated
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI