### PR TITLE
MAINT: remove duplicated beta quantile wrapper

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -78,7 +78,6 @@ import textwrap
 
 special_ufuncs = [
     "_beta_pdf",
-    "_beta_ppf",
     "_binom_cdf",
     "_binom_isf",
     "_binom_pmf",

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -67,7 +67,6 @@
 // This allows the build process to generate a corresponding entry for scipy.special.cython_special.
 
 extern const char *_beta_pdf_doc;
-extern const char *_beta_ppf_doc;
 extern const char *_binom_cdf_doc;
 extern const char *_binom_isf_doc;
 extern const char *_binom_pmf_doc;
@@ -372,12 +371,6 @@ _special_ufuncs_module_exec(PyObject *module)
                            static_cast<xsf::numpy::ddd_d>(beta_pdf_double)},
                           "_beta_pdf", _beta_pdf_doc);
     PyModule_AddObjectRef(module, "_beta_pdf", _beta_pdf);
-
-    PyObject *_beta_ppf =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::fff_f>(beta_ppf_float),
-                           static_cast<xsf::numpy::ddd_d>(beta_ppf_double)},
-                          "_beta_ppf", _beta_ppf_doc);
-    PyModule_AddObjectRef(module, "_beta_ppf", _beta_ppf);
 
     PyObject *_binom_cdf =
         xsf::numpy::ufunc({static_cast<xsf::numpy::fff_f>(binom_cdf_float),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -17,25 +17,6 @@ const char *_beta_pdf_doc = R"(
 
     )";
 
-const char *_beta_ppf_doc = R"(
-    _beta_ppf(x, a, b)
-
-    Percent point function of beta distribution.
-
-    Parameters
-    ----------
-    x : array_like
-        Real-valued such that :math:`0 \leq x \leq 1`,
-        the upper limit of integration
-    a, b : array_like
-           Positive, real-valued parameters
-
-    Returns
-    -------
-    scalar or ndarray
-
-    )";
-
 const char *_binom_cdf_doc = R"(
     _binom_cdf(x, n, p)
 

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -222,9 +222,9 @@ ibetac_double(double a, double b, double x)
 }
 
 
-template<typename Real, typename Policy>
+template<typename Real>
 static inline
-Real ibeta_inv_wrap(Real a, Real b, Real p, const Policy& policy_)
+Real ibeta_inv_wrap(Real a, Real b, Real p)
 {
     Real y;
 
@@ -236,7 +236,7 @@ Real ibeta_inv_wrap(Real a, Real b, Real p, const Policy& policy_)
         return NAN;
     }
     try {
-        y = boost::math::ibeta_inv(a, b, p, policy_);
+        y = boost::math::ibeta_inv(a, b, p, SpecialPolicy());
     } catch (const std::domain_error& e) {
         sf_error("betaincinv", SF_ERROR_DOMAIN, NULL);
         y = NAN;
@@ -256,13 +256,13 @@ Real ibeta_inv_wrap(Real a, Real b, Real p, const Policy& policy_)
 float
 ibeta_inv_float(float a, float b, float p)
 {
-    return ibeta_inv_wrap(a, b, p, SpecialPolicy());
+    return ibeta_inv_wrap(a, b, p);
 }
 
 double
 ibeta_inv_double(double a, double b, double p)
 {
-    return ibeta_inv_wrap(a, b, p, SpecialPolicy());
+    return ibeta_inv_wrap(a, b, p);
 }
 
 template<typename Real>
@@ -669,30 +669,6 @@ double
 beta_pdf_double(double x, double a, double b)
 {
     return beta_pdf_wrap(x, a, b);
-}
-
-template<typename Real>
-Real beta_ppf_wrap(const Real x, const Real a, const Real b)
-{
-    typedef boost::math::policies::policy<
-        boost::math::policies::domain_error<boost::math::policies::ignore_error >,
-        boost::math::policies::overflow_error<boost::math::policies::user_error >,
-        boost::math::policies::evaluation_error<boost::math::policies::user_error >,
-        boost::math::policies::promote_double<false > > BetaPolicyForStats;
-
-    return ibeta_inv_wrap(a, b, x, BetaPolicyForStats());
-}
-
-float
-beta_ppf_float(float x, float a, float b)
-{
-    return beta_ppf_wrap(x, a, b);
-}
-
-double
-beta_ppf_double(double x, double a, double b)
-{
-    return beta_ppf_wrap(x, a, b);
 }
 
 template<typename Real>

--- a/scipy/special/tests/test_boost_ufuncs.py
+++ b/scipy/special/tests/test_boost_ufuncs.py
@@ -20,7 +20,6 @@ test_data = [
     (scu._beta_pdf, (0.5, 2, 3), 1.5),
     (scu._beta_pdf, (0, 1, 5), 5.0),
     (scu._beta_pdf, (1, 5, 1), 5.0),
-    (scu._beta_ppf, (0.5, 5., 5.), 0.5),  # gh-21303
     (scu._binom_cdf, (1, 3, 0.5), 0.5),
     (scu._binom_pmf, (1, 4, 0.5), 0.25),
     (scu._hypergeom_cdf, (2, 3, 5, 6), 0.5),

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -781,7 +781,7 @@ class beta_gen(rv_continuous):
         return sc.betainccinv(a, b, x)
 
     def _ppf(self, q, a, b):
-        return scu._beta_ppf(q, a, b)
+        return sc.betaincinv(a, b, q)
 
     def _stats(self, a, b):
         a_plus_b = a + b


### PR DESCRIPTION
#### Reference issue
Closes #21725

#### What does this implement/fix?
This PR does some house keeping in special's boost wrappers.

So far, we had two versions of the inverse incomplete beta function: one for `betaincinv` in `special` and one for the beta quantile in `stats`. The `stats` version ignores all boost errors while the `special` one does not. This was done to circumvent a segfault in https://github.com/scipy/scipy/issues/14606.

Since then, the boost devs have gone to great lengths to improve the incomplete beta and its inverse for large inputs. The improvements enable to simply use `betaincinv` for the beta distribution as all tests pass.

#### AI Generation Disclosure
No AI.
