### PR TITLE
BUG: cluster.hierarchy.fcluster: reject t < 1 for maxclust criteria

### DIFF
--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -2579,6 +2579,10 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
     n = Z.shape[0] + 1
     T = np.zeros((n,), dtype='i')
 
+    if criterion in ('maxclust', 'maxclust_monocrit') and t < 1:
+        raise ValueError(f"'{criterion}' needs 't', the maximum number of "
+                         f"clusters, to be at least 1; got {t}.")
+
     if monocrit is not None:
         monocrit = np.asarray(monocrit, order='C', dtype=np.float64)
 

--- a/scipy/cluster/hierarchy/tests/test_hierarchy.py
+++ b/scipy/cluster/hierarchy/tests/test_hierarchy.py
@@ -350,6 +350,19 @@ class TestFcluster:
         assert_array_equal(fcluster(Z, t=5, criterion="maxclust"),
                            xp.asarray([1, 2, 3]))
 
+    @make_xp_test_case(single, maxdists)
+    @pytest.mark.parametrize("criterion", ["maxclust", "maxclust_monocrit"])
+    @pytest.mark.parametrize("t", [0, -1, 0.5])
+    def test_fcluster_maxclust_t_less_than_one_gh_21206(self, t, criterion, xp):
+        # No threshold can give fewer than one cluster, so the search for one
+        # ran off the end of the criterion array and the result was whatever
+        # happened to be in memory there.
+        y = xp.asarray([[1.], [4.], [5.], [9.]])
+        Z = single(y)
+        kwargs = {'monocrit': maxdists(Z)} if 'monocrit' in criterion else {}
+        with assert_raises(ValueError, match="at least 1"):
+            fcluster(Z, t=t, criterion=criterion, **kwargs)
+
 
 @make_xp_test_case(leaders)
 class TestLeaders:


### PR DESCRIPTION
#### Reference issue

Closes gh-21206.

#### What does this implement/fix?

`fcluster` with `criterion="maxclust"` and `t=0` gives a different answer depending on what
is in memory , instead of complaining .

`cluster_maxclust_monocrit` ends with `MC[upper_idx]` , but `MC` only holds `n-1` values ,
so the last legal index is `n-2` . `upper_idx` starts at `n-1` and only comes down when a
threshold gives few enough clusters . testing `i = n-2` always puts the whole tree into one
cluster , so that test only fails when `max_nc < 1` . in that one case `upper_idx` is never
lowered and `MC[n-1]` is read one past the end of the array .

`_hierarchy.pyx` is compiled with `boundscheck=False` , so nothing catches it and the cutoff
is whatever happens to sit in that memory . with `t=0` on six points the result is six
singleton clusters . passing an `MC` one slot longer with a known value in slot `n-1` changes
the answer , which is what showed where it was reading from .

no `t` can ever produce fewer than one cluster , so the input is rejected instead . that
removes the only path that reaches the read rather than hiding it . `t >= 1` is unchanged ,
and `distance` and `inconsistent` still take `t=0` .

#### Additional information

`t=0.5` is rejected too , it truncated to zero and reached the same line . `t=1.5` still
works .

six new cases cover `maxclust` and `maxclust_monocrit` for `t` of 0 , -1 and 0.5 . they fail
on main with "DID NOT RAISE ValueError" . `pytest scipy/cluster/` gives 225 passed , 6
skipped .

#### AI Generation Disclosure

i used claude code ( claude opus 5 ) to help look into the cause and to draft the patch and
the test . i went over the change myself , confirmed the out of bounds read , and ran the
tests locally .