### PR TITLE
BUG: linalg: correct return dtypes

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -749,12 +749,12 @@ def solve_toeplitz(c_or_cr, b, check_finite=True):
 
 @_apply_over_batch(('c', 1), ('r', 1), ('b', '1|2'))
 def _solve_toeplitz(c, r, b, check_finite):
-    r, c, b, dtype, b_shape = _validate_args_for_toeplitz_ops(
+    r, c, b, _, b_shape = _validate_args_for_toeplitz_ops(
         (c, r), b, check_finite, keep_b_shape=True)
 
-    # accommodate empty arrays
+    # accommodate empty arrays, it is sufficient to check the size of `b`
     if b.size == 0:
-        return np.empty_like(b)
+        return np.empty(b_shape, dtype=b.dtype)
 
     # Form a 1-D array of values to be used in the matrix, containing a
     # reversed copy of r[1:], followed by c.
@@ -1833,7 +1833,7 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
                          'LAPACK documentation for the xGEBAL error codes.')
 
     # Separate the permutations from the scalings and then convert to int
-    scaling = np.ones_like(ps, dtype=float)
+    scaling = np.ones_like(ps, dtype=B.dtype)
     scaling[lo:hi+1] = ps[lo:hi+1]
 
     # gebal uses 1-indexing
@@ -1925,8 +1925,8 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
     if (enforce_square and is_not_square) or b.shape[0] != r.shape[0]:
         raise ValueError('Incompatible dimensions.')
 
-    is_cmplx = np.iscomplexobj(r) or np.iscomplexobj(c) or np.iscomplexobj(b)
-    dtype = np.complex128 if is_cmplx else np.float64
+    dtype = np.promote_types(np.promote_types(r.dtype, c.dtype), b.dtype)
+    dtype = np.float64 if np.isdtype(dtype, "integral") else dtype
     r, c, b = (np.asarray(i, dtype=dtype) for i in (r, c, b))
 
     if b.ndim == 1 and not keep_b_shape:

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -107,6 +107,9 @@ def expm_frechet(A, E, method=None, compute_expm=True, check_finite=True):
         raise ValueError('expected E to be a square matrix')
     if A.shape != E.shape:
         raise ValueError('expected A and E to be the same shape')
+    if A.size == 0:
+        res_dtype = np.float64 if np.isdtype(A.dtype, "integral") else A.dtype
+        return np.empty(A.shape, res_dtype), np.empty(A.shape, res_dtype)
     if method is None:
         method = 'SPS'
     if method == 'SPS':
@@ -232,7 +235,7 @@ def _diff_pade9(A, E, ident):
 def expm_frechet_algo_64(A, E):
     n = A.shape[0]
     s = None
-    ident = np.identity(n)
+    ident = np.identity(n, dtype=A.dtype)
     A_norm_1 = scipy.linalg.norm(A, 1)
     m_pade_pairs = (
             (3, _diff_pade3),
@@ -346,7 +349,7 @@ def expm_frechet_kronform(A, method=None, check_finite=True):
         raise ValueError('expected a square matrix')
 
     n = A.shape[0]
-    ident = np.identity(n)
+    ident = np.identity(n, dtype=A.dtype)
     cols = []
     for i in range(n):
         for j in range(n):
@@ -405,6 +408,10 @@ def expm_cond(A, check_finite=True):
         A = np.asarray(A)
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')
+    if A.size == 0:
+        return np.empty(
+            (), dtype=np.float64 if np.isdtype(A.dtype, "integral") else A.dtype
+        )
 
     X = scipy.linalg.expm(A)
     K = expm_frechet_kronform(A, check_finite=False)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -11,7 +11,7 @@ from scipy._lib._util import (check_random_state, rng_integers,
 __all__ = ['clarkson_woodruff_transform']
 
 
-def cwt_matrix(n_rows, n_columns, rng=None):
+def cwt_matrix(n_rows, n_columns, rng=None, dtype=int):
     r"""
     Generate a matrix S which represents a Clarkson-Woodruff transform.
 
@@ -31,6 +31,8 @@ def cwt_matrix(n_rows, n_columns, rng=None):
         `numpy.random.Generator` is created using entropy from the
         operating system. Types other than `numpy.random.Generator` are
         passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+    dtype : dtype, optional
+        The dtype of the array, default is `int`.
 
     Returns
     -------
@@ -48,7 +50,7 @@ def cwt_matrix(n_rows, n_columns, rng=None):
     rng = check_random_state(rng)
     rows = rng_integers(rng, 0, n_rows, n_columns)
     cols = np.arange(n_columns+1)
-    signs = rng.choice([1, -1], n_columns)
+    signs = rng.choice([1, -1], n_columns).astype(dtype)
     S = csc_array((signs, rows, cols), shape=(n_rows, n_columns))
     return S
 
@@ -185,7 +187,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
         message = "Batch support for sparse arrays is not available."
         raise NotImplementedError(message)
 
-    S = cwt_matrix(sketch_size, input_matrix.shape[-2], rng=rng)
+    S = cwt_matrix(
+        sketch_size, input_matrix.shape[-2], rng=rng, dtype=input_matrix.dtype
+    )
     if input_matrix.ndim <= 2:
         # transposes are cheap and ensure output class matches input_matrix
         return (input_matrix.T @ S.T).T

--- a/scipy/linalg/_solve_toeplitz.pyx
+++ b/scipy/linalg/_solve_toeplitz.pyx
@@ -1,13 +1,15 @@
 # Author: Robert T. McGibbon, December 2014
 #
 # cython: boundscheck=False, wraparound=False, cdivision=True
-from numpy import zeros, asarray, complex128, float64
+from numpy import zeros, asarray, complex64, complex128, float32, float64
 from numpy.linalg import LinAlgError
-from numpy cimport complex128_t, float64_t
+from numpy cimport complex64_t, complex128_t, float32_t, float64_t
 
 
 cdef fused dz:
+    float32_t
     float64_t
+    complex64_t
     complex128_t
 
 
@@ -48,8 +50,12 @@ def levinson(const dz[::1] a, const dz[::1] b):
     # http://jblevins.org/mirror/amiller/toeplitz.f90
     # Released under a Public domain declaration.
 
-    if dz is float64_t:
+    if dz is float32_t:
+        dtype = float32
+    elif dz is float64_t:
         dtype = float64
+    elif dz is complex64_t:
+        dtype = complex64
     else:
         dtype = complex128
 

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -226,7 +226,7 @@ def _solve_discrete_lyapunov_direct(a, q):
     """
 
     lhs = np.kron(a, a.conj())
-    lhs = np.eye(lhs.shape[0]) - lhs
+    lhs = np.eye(lhs.shape[0], dtype=a.dtype) - lhs
     x = solve(lhs, q.flatten())
 
     return np.reshape(x, q.shape)
@@ -239,7 +239,7 @@ def _solve_discrete_lyapunov_bilinear(a, q):
     This function is called by the `solve_discrete_lyapunov` function with
     `method=bilinear`. It is not supposed to be called directly.
     """
-    eye = np.eye(a.shape[0])
+    eye = np.eye(a.shape[0], dtype=a.dtype)
     aH = a.conj().transpose()
     aHI_inv = inv(aH + eye)
     b = np.dot(aH - eye, aHI_inv)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -3006,6 +3006,29 @@ class TestMatrix_Balance:
         assert scale.dtype == scale_n.dtype
         assert perm.dtype == perm_n.dtype
 
+    @pytest.mark.parametrize("dtype",
+        [int, np.float32, np.float64, np.complex64, np.complex128]
+    )
+    @pytest.mark.parametrize("n", [0, 5])
+    def test_shape_dtype(self, dtype, n):
+        rng = np.random.default_rng(seed=12345)
+        atol = 1e-6 if dtype in [np.float32, np.complex64] else 1e-14
+
+        a = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=(n, n))
+
+        a = a.astype(dtype)
+
+        res_dtype = np.float64 if dtype is int else dtype
+        b, t = matrix_balance(a)
+
+        assert_allclose(b, solve(t, a @ t), atol=atol)
+        assert b.dtype == res_dtype
+        assert b.shape == (n, n)
+        assert t.dtype == res_dtype
+        assert t.shape == (n, n)
+
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestDTypes:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -997,6 +997,29 @@ class TestExpmFrechet:
         assert_allclose(sps_expm, blockEnlarge_expm)
         assert_allclose(sps_frechet, blockEnlarge_frechet)
 
+    @pytest.mark.parametrize("dtype", [
+        int, np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [0, 5])
+    @pytest.mark.parametrize("method", ["SPS", "blockEnlarge"])
+    def test_shape_dtype(self, dtype, n, method):
+        rng = np.random.default_rng(seed=12345)
+
+        a = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=(n, n))
+        a = a.astype(dtype)
+        q = np.eye(n, dtype=dtype)
+
+        expm_a, expm_frechet_ae = expm_frechet(a, q, method=method)
+        res_dtype = np.float64 if dtype is int else dtype
+
+        assert expm_a.dtype == res_dtype
+        assert expm_a.shape == (n, n)
+        assert expm_frechet_ae.dtype == res_dtype
+        assert expm_frechet_ae.shape == (n, n)
+
+
 
 def _help_expm_cond_search(A, A_norm, X, X_norm, eps, p):
     p = np.reshape(p, A.shape)
@@ -1084,6 +1107,22 @@ class TestExpmConditionNumber:
             # eps times the condition number kappa.
             # In the limit as eps approaches zero it should never be greater.
             assert_array_less(p_best_relerr, (1 + 2*eps) * eps * kappa)
+
+    @pytest.mark.parametrize("dtype", [
+        int, np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [0, 5])
+    def test_shape_dtype(self, dtype, n):
+        rng = np.random.default_rng(seed=12345)
+
+        a = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=(n, n))
+        a = a.astype(dtype)
+
+        cond = expm_cond(a)
+        assert np.shape(cond) == ()
+        assert cond.dtype == np.float64 if dtype is int else np.finfo(dtype).dtype
 
 
 class TestKhatriRao:

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 from numpy.testing import assert_, assert_equal
+import pytest
+
 from scipy.linalg import clarkson_woodruff_transform
 from scipy.linalg._sketches import cwt_matrix
 from scipy.sparse import issparse, random_array
@@ -48,6 +50,24 @@ class TestClarksonWoodruffTransform:
                     A, self.n_sketch_rows, seed=seed
                 )
                 assert_(sketch.shape == (self.n_sketch_rows, self.n_cols))
+
+    @pytest.mark.parametrize("dtype", [
+        int, np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [0, 2, 5])
+    def test_shape_dtype(self, dtype, n):
+        rng = np.random.default_rng(seed=12345)
+        n_rows = 1
+
+        a = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=(n, n))
+        a = a.astype(dtype)
+
+        sketch = clarkson_woodruff_transform(a, n_rows)
+
+        assert sketch.shape == (n_rows, n)
+        assert sketch.dtype == dtype
 
     def test_seed_returns_identical_transform_matrix(self):
         for seed in self.seeds:

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -135,3 +135,41 @@ def test_empty(dt_c, dt_b):
     assert x1.shape == (0, 0)
     assert x1.dtype == x.dtype
 
+@pytest.mark.parametrize("dt_c", [int, float, np.float32, complex, np.complex64])
+@pytest.mark.parametrize("dt_r", [int, float, np.float32, complex, np.complex64])
+@pytest.mark.parametrize("dt_b", [int, float, np.float32, complex, np.complex64])
+@pytest.mark.parametrize("n", [0, 5])
+@pytest.mark.parametrize("nrhs", [0, 1, 2])
+def test_shape_dtype(dt_c, dt_r, dt_b, n, nrhs):
+    rng = np.random.default_rng(seed=12345)
+
+    ## Setup
+    c = rng.normal(size=(n,))
+    if np.issubdtype(dt_c, np.complexfloating):
+        c = c + 1j * rng.normal(size=(n,))
+    c = c.astype(dt_c)
+
+    r = rng.normal(size=(n,))
+    if np.issubdtype(dt_r, np.complexfloating):
+        r = r + 1j * rng.normal(size=(n,))
+    r = r.astype(dt_r)
+
+    shape_b = (n,) if nrhs == 0 else (n, nrhs)
+    b = rng.normal(size=shape_b)
+    if np.issubdtype(dt_b, np.complexfloating):
+        b = b + 1j * rng.normal(size=shape_b)
+    b = b.astype(dt_b)
+
+    ## Compute solutions
+    a = toeplitz(c, r)
+    ref = solve(a, b, assume_a="general")
+    res = solve_toeplitz((c, r), b)
+
+    ## Check solutions
+    res_dtype = np.promote_types(np.promote_types(dt_c, dt_r), dt_b)
+    res_dtype = np.float64 if np.isdtype(res_dtype, "integral") else res_dtype
+    atol = 1e-6 if res_dtype in [np.float32, np.complex64] else 1e-14
+
+    assert res.dtype == res_dtype
+    assert res.shape == shape_b
+    assert_allclose(res, ref, atol=atol)

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -134,6 +134,34 @@ class TestSolveLyapunov:
         assert res.shape == (0, 0)
         assert res.dtype == ref.dtype
 
+    @pytest.mark.parametrize("dtype_a",
+        [int, np.float32, np.float64, np.complex64, np.complex128]
+    )
+    @pytest.mark.parametrize("dtype_q",
+        [int, np.float32, np.float64, np.complex64, np.complex128]
+    )
+    @pytest.mark.parametrize("n", [0, 5])
+    @pytest.mark.parametrize("method", ["direct", "bilinear"])
+    def test_shape_dtyp_discrete(self, dtype_a, dtype_q, n, method):
+        rng = np.random.default_rng(seed=12345)
+        common_dtype = np.promote_types(dtype_a, dtype_q)
+        res_dtype = np.float64 if np.isdtype(common_dtype, "integral") else common_dtype
+        atol = 5e-6
+
+        a = rng.normal(size=(n, n))
+        q = rng.normal(size=(n, n))
+        if np.issubdtype(dtype_a, np.complexfloating):
+            a = a + 1j * rng.normal(size=(n, n))
+        if np.issubdtype(dtype_q, np.complexfloating):
+            q = q + 1j * rng.normal(size=(n, n))
+
+        a = a.astype(dtype_a)
+        q = q.astype(dtype_q)
+
+        x = solve_discrete_lyapunov(a, q, method=method)
+        assert_allclose(a @ x @ np.conj(a.T) - x + q, np.zeros((n, n)), atol=atol)
+        assert x.dtype == res_dtype
+
 
 class TestSolveContinuousAre:
     mat6 = _load_data('carex_6_data.npz')


### PR DESCRIPTION
#### Reference issue
Towards #25964 

#### What does this implement/fix?
Corrects return dtypes for several functions and adds some tests for all functions listed in the reference issue except for `fractional_matrix_power` since that one is quite tough to properly audit. Perhaps it is best to leave that for a follow-up since a quick attempt revealed that quite a lot of changes were needed and did not even cover all possible cases.

The added tests always at least check the shapes and dtypes of the return arguments. Where possible they also check whether the behavior is correct, but when the docs did not mention how exactly the return arguments should relate to the input this was not done. This applies for example to `clarkson_woodruff_transform` and `expm_frechet`.

#### Additional information
Some CI failures are expected:
- For `solve_toeplitz` it used to be the case that the arrays were always cast to either `float64` or `complex128`. This is now corrected to cast to `cdsz`, but does not explicitly guard against other exotic cases such as `float16`/`complex256` leading to some CI failures in `test_deprecations` since the cython code is not implemented to deal with this. Probably the best way to resolve this is to add the "normal" sequence of `_deprecate_dtypes -> _normalize_lapack_dtype` and probably adjust those tests accordingly?
- For `solve_discrete_lyapunov` I am getting some failures locally for `n=5` due to (excessively) large mismatches, but this seems to also be present on main so this might be something that warrants its own issue?

Furthermore, the testsuite for `solve_toeplitz` might now be excessively large.

#### AI Generation Disclosure
No AI