### PR TITLE
CI: add `pkgconf` to the dependency groups for scipy-openblas on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           # 2.0.0 is currently our oldest supported NumPy version
           python -m pip install numpy==2.0.0 --group build --group dev-cli --group test-core --group openblas32
-          python -m pip install -r requirements/pkgconf.txt
 
       - name: Build
         run: |
@@ -123,7 +122,6 @@ jobs:
         run: |
           # `numpy<2.4.3` pin is due to np.linalg.solve crash, see gh-24774
           python -m pip install "numpy<2.4.3" --group build --group dev-cli --group test-core --group openblas32
-          python -m pip install -r requirements/pkgconf.txt
 
       - name: Build
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,12 @@ coverage = [
     "pytest-cov",
 ]
 openblas32 = [
-    "scipy-openblas32==0.3.34.0.0"
+    "scipy-openblas32==0.3.34.0.0",
+    'pkgconf==2.5.1.post1; sys_platform == "win32"',
 ]
 openblas64 = [
-    "scipy-openblas64==0.3.34.0.0"
+    "scipy-openblas64==0.3.34.0.0",
+    'pkgconf==2.5.1.post1; sys_platform == "win32"',
 ]
 bench = [
     # 0.6.6 regressed per-benchmark overhead ~7x, which pushes the CircleCI

--- a/requirements/pkgconf.txt
+++ b/requirements/pkgconf.txt
@@ -1,1 +1,0 @@
-pkgconf==2.5.1.post1

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -48,7 +48,4 @@ fi
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
     python -m pip install -r $PROJECT_DIR/requirements/delvewheel_requirements.txt
-    # pkgconf - carries out the role of pkg-config.
-    # Alternative is pkgconfiglite that you have to install with choco
-    python -m pip install -r $PROJECT_DIR/requirements/pkgconf.txt
 fi


### PR DESCRIPTION
This removes one of the last requirements files, which is needed to include `pkgconf` in the pinned dependencies workflow on the `scipy-release` repo. And it's a good idea anyway.

`pkgconf` is installed from PyPI only on Windows, because there is no other good way to get a pkg-config installed on Windows. These two always go hand in hand, also for release wheel builds.


#### AI Generation Disclosure

Used Claude Sonnet for a local check of completeness, after writing the code by hand.
