### PR TITLE
BUG: fix fftconvolve/oaconvolve 'same' mode dropping broadcast dimensions

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -577,7 +577,14 @@ def _apply_conv_mode(ret, s1, s2, mode, axes, xp):
     if mode == "full":
         return xp_copy(ret, xp=xp)
     elif mode == "same":
-        return xp_copy(_centered(ret, s1), xp=xp)
+        # In the "same" mode the output has the shape of s1 along the
+        # convolved axes. For axes not involved in the convolution the
+        # batch (broadcast) dimensions of the full result must be
+        # preserved; s1 only carries the shape of the first input along
+        # those axes (which may be 1 before broadcasting), so take them
+        # from the full result instead (gh-21876).
+        shape = [ret.shape[a] if a not in axes else s1[a] for a in range(ret.ndim)]
+        return xp_copy(_centered(ret, shape), xp=xp)
     elif mode == "valid":
         shape_valid = [ret.shape[a] if a not in axes else s1[a] - s2[a] + 1
                        for a in range(ret.ndim)]

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -577,12 +577,6 @@ def _apply_conv_mode(ret, s1, s2, mode, axes, xp):
     if mode == "full":
         return xp_copy(ret, xp=xp)
     elif mode == "same":
-        # In the "same" mode the output has the shape of s1 along the
-        # convolved axes. For axes not involved in the convolution the
-        # batch (broadcast) dimensions of the full result must be
-        # preserved; s1 only carries the shape of the first input along
-        # those axes (which may be 1 before broadcasting), so take them
-        # from the full result instead (gh-21876).
         shape = [ret.shape[a] if a not in axes else s1[a] for a in range(ret.ndim)]
         return xp_copy(_centered(ret, shape), xp=xp)
     elif mode == "valid":

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -452,20 +452,23 @@ def _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False):
         The second input, possible swapped with the first input.
     axes : list of ints
         Axes over which to compute the FFTs.
+    all_axes : list of ints
+        All axes over which the convolution is computed, before
+        removing axes with a size of 1 in either input.
 
     """
     s1 = in1.shape
     s2 = in2.shape
     noaxes = axes is None
 
-    _, axes = _init_nd_shape_and_axes(in1, shape=None, axes=axes)
+    _, all_axes = _init_nd_shape_and_axes(in1, shape=None, axes=axes)
 
-    if not noaxes and not len(axes):
+    if not noaxes and not len(all_axes):
         raise ValueError("when provided, axes cannot be empty")
 
     # Axes of length 1 can rely on broadcasting rules for multiply,
     # no fft needed.
-    axes = [a for a in axes if s1[a] != 1 and s2[a] != 1]
+    axes = [a for a in all_axes if s1[a] != 1 and s2[a] != 1]
 
     if sorted_axes:
         axes.sort()
@@ -480,7 +483,7 @@ def _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False):
         # Convolution is commutative; order doesn't have any effect on output.
         in1, in2 = in2, in1
 
-    return in1, in2, axes
+    return in1, in2, axes, all_axes
 
 
 def _freq_domain_conv(xp, in1, in2, axes, shape, calc_fast_len=False):
@@ -549,7 +552,7 @@ def _freq_domain_conv(xp, in1, in2, axes, shape, calc_fast_len=False):
     return ret
 
 
-def _apply_conv_mode(ret, s1, s2, mode, axes, xp):
+def _apply_conv_mode(ret, s1, s2, mode, axes, xp, all_axes):
     """Calculate the convolution result shape based on the `mode` argument.
 
     Returns the result sliced to the correct size for the given mode.
@@ -567,6 +570,9 @@ def _apply_conv_mode(ret, s1, s2, mode, axes, xp):
         See the documentation `fftconvolve` for more information.
     axes : list of ints
         Axes over which to compute the convolution.
+    all_axes : list of ints
+        All axes over which the convolution is computed, before
+        removing axes with a size of 1 in either input.
 
     Returns
     -------
@@ -577,7 +583,8 @@ def _apply_conv_mode(ret, s1, s2, mode, axes, xp):
     if mode == "full":
         return xp_copy(ret, xp=xp)
     elif mode == "same":
-        shape = [ret.shape[a] if a not in axes else s1[a] for a in range(ret.ndim)]
+        shape = [s1[a] if a in all_axes else ret.shape[a]
+                 for a in range(ret.ndim)]
         return xp_copy(_centered(ret, shape), xp=xp)
     elif mode == "valid":
         shape_valid = [ret.shape[a] if a not in axes else s1[a] - s2[a] + 1
@@ -702,8 +709,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     elif xp_size(in1) == 0 or xp_size(in2) == 0:  # empty arrays
         return xp.asarray([], device=xp_device(in1))
 
-    in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes,
-                                          sorted_axes=False)
+    in1, in2, axes, all_axes = _init_freq_conv_axes(in1, in2, mode, axes,
+                                                    sorted_axes=False)
 
     s1 = in1.shape
     s2 = in2.shape
@@ -713,7 +720,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     ret = _freq_domain_conv(xp, in1, in2, axes, shape, calc_fast_len=True)
 
-    return _apply_conv_mode(ret, s1, s2, mode, axes, xp=xp)
+    return _apply_conv_mode(ret, s1, s2, mode, axes, xp=xp, all_axes=all_axes)
 
 
 def _calc_oa_lens(s1, s2):
@@ -951,15 +958,15 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     elif in1.shape == in2.shape:  # Equivalent to fftconvolve
         return fftconvolve(in1, in2, mode=mode, axes=axes)
 
-    in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes,
-                                          sorted_axes=True)
+    in1, in2, axes, all_axes = _init_freq_conv_axes(in1, in2, mode, axes,
+                                                    sorted_axes=True)
 
     s1 = in1.shape
     s2 = in2.shape
 
     if not axes:
         ret = in1 * in2
-        return _apply_conv_mode(ret, s1, s2, mode, axes, xp)
+        return _apply_conv_mode(ret, s1, s2, mode, axes, xp, all_axes)
 
     # Calculate this now since in1 is changed later
     shape_final = [None if i not in axes else
@@ -975,7 +982,9 @@ def oaconvolve(in1, in2, mode="full", axes=None):
 
     # Fall back to fftconvolve if there is only one block in every dimension.
     if in1_step == s1 and in2_step == s2:
-        return fftconvolve(in1, in2, mode=mode, axes=axes)
+        # pass the unfiltered axes so 'same' mode keeps the size of the
+        # first input along convolved axes of size 1
+        return fftconvolve(in1, in2, mode=mode, axes=all_axes)
 
     # Figure out the number of steps and padding.
     # This would get too complicated in a list comprehension.
@@ -1065,7 +1074,7 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     slice_final = tuple([slice(islice) for islice in shape_final])
     ret = ret[slice_final]
 
-    return _apply_conv_mode(ret, s1, s2, mode, axes, xp)
+    return _apply_conv_mode(ret, s1, s2, mode, axes, xp, all_axes)
 
 
 def _numeric_arrays(arrays, kinds='buifc', xp=None):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1179,6 +1179,19 @@ class TestAllFreqConvolves:
                            match="all axes must be unique"):
             convapproach([1], [2], axes=[0, 0])
 
+    def test_same_mode_preserves_broadcast_dimensions(self, convapproach, xp):
+        # gh-21876: in 'same' mode the output has the shape of the first
+        # input along the convolved axes, while broadcast dimensions not
+        # involved in the convolution must be taken from the full result.
+        a = xp.reshape(xp.arange(100), (1, 100))
+        b = xp.reshape(xp.arange(70), (7, 10))
+        res = convapproach(a, b, axes=1, mode='same')
+        xp_assert_equal(res.shape, (7, 100))
+        for i in range(7):
+            ref = convapproach(a[0], b[i], mode='same')
+            xp_assert_close(res[i], ref)
+
+
 
 @skip_xp_backends(np_only=True, reason="assertions may differ on backends")
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1191,6 +1191,16 @@ class TestAllFreqConvolves:
             ref = convapproach(a[0], b[i], mode='same')
             xp_assert_close(res[i], ref)
 
+        # along a convolved axis the output keeps the size of the first
+        # input even when it is 1; a size-1 axis not involved in the
+        # convolution is broadcast
+        xp_assert_equal(convapproach(xp.arange(1), xp.arange(50),
+                                     mode='same').shape, (1,))
+        xp_assert_equal(convapproach(xp.arange(50), xp.arange(1),
+                                     mode='same').shape, (50,))
+        xp_assert_equal(convapproach(xp.ones((1, 1)), xp.ones((5, 7)),
+                                     mode='same').shape, (1, 1))
+
 
 
 @skip_xp_backends(np_only=True, reason="assertions may differ on backends")


### PR DESCRIPTION
## Proposed changes

`fftconvolve`/`oaconvolve` with `mode='same'` and broadcast inputs along
axes not involved in the convolution (e.g. `(1, 100)` convolved with
`(7, 10)` along `axes=1`) returned an output of shape `(1, 100)`
instead of `(7, 100)`, contrary to the documented behaviour ("the
output is the same size as in").

The cause is in `_apply_conv_mode`, which centered the full result
using the shape of the first input. That shape only carries the
pre-broadcast size along the batch dimensions, so the centering cut
those dimensions back down to the first input's size.

The batch dimensions are now taken from the full result, matching the
way the `valid` branch already builds its target shape. Behaviour is
unchanged when no broadcasting takes place.

Fixes #21876.

## Checklist

- [x] I am familiar with the [contributing guidelines](https://scipy.org/doc/faq.html#is-scipy-open-for-contributions).
