### PR TITLE
MAINT: remove old Cython cruft

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -109,11 +109,6 @@ def _toint64(x):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def _weightedrankedtau(const ordered[:] x, const ordered[:] y, intp_t[:] rank, weigher, bool additive):
-    # y_local and rank_local (declared below) are a work-around for a Cython
-    # bug; see gh-16718.  When we can require Cython 3.0, y_local and
-    # rank_local can be removed, and the closure weigh() can refer directly
-    # to y and rank.
-    cdef const ordered[:] y_local = y
     cdef intp_t i, first
     cdef float64_t t, u, v, w, s, sq
     cdef int64_t n = np.int64(len(x))
@@ -131,8 +126,6 @@ def _weightedrankedtau(const ordered[:] x, const ordered[:] y, intp_t[:] rank, w
         rank = np.empty(n, dtype=np.intp)
         rank[...] = perm[::-1]
         _invert_in_place(rank)
-
-    cdef intp_t[:] rank_local = rank
 
     # weigh joint ties
     first = 0
@@ -182,28 +175,28 @@ def _weightedrankedtau(const ordered[:] x, const ordered[:] y, intp_t[:] rank, w
         cdef float64_t weight, residual
 
         if length == 1:
-            return weigher(rank_local[perm[offset]])
+            return weigher(rank[perm[offset]])
         length0 = length // 2
         length1 = length - length0
         middle = offset + length0
         residual = weigh(offset, length0)
         weight = weigh(middle, length1) + residual
-        if y_local[perm[middle - 1]] < y_local[perm[middle]]:
+        if y[perm[middle - 1]] < y[perm[middle]]:
             return weight
 
         # merging
         i = j = k = 0
 
         while j < length0 and k < length1:
-            if y_local[perm[offset + j]] <= y_local[perm[middle + k]]:
+            if y[perm[offset + j]] <= y[perm[middle + k]]:
                 temp[i] = perm[offset + j]
-                residual -= weigher(rank_local[temp[i]])
+                residual -= weigher(rank[temp[i]])
                 j += 1
             else:
                 temp[i] = perm[middle + k]
-                exchanges_weight[0] += weigher(rank_local[temp[i]]) * (
+                exchanges_weight[0] += weigher(rank[temp[i]]) * (
                     length0 - j) + residual if additive else weigher(
-                    rank_local[temp[i]]) * residual
+                    rank[temp[i]]) * residual
                 k += 1
             i += 1
 


### PR DESCRIPTION
#### What does this implement/fix?
This PR cleans up a pre Cython 3.0 workaround (see https://github.com/scipy/scipy/issues/16718).  Found this accidentally when looking at that file.

#### Additional information
This function will likely be added to `xsf` in future but I think this is still helpful to simplify the function in the meanwhile.

#### AI Generation Disclosure
Gemini Flash applied the quite mechanical fix.
