### PR TITLE
CI: remove delvewheel requirements file, it's provided by cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -149,11 +149,11 @@ jobs:
       #     echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
-          CIBW_ENABLE: cpython-freethreading cpython-prerelease
+          CIBW_ENABLE: cpython-prerelease
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/requirements/delvewheel_requirements.txt
+++ b/requirements/delvewheel_requirements.txt
@@ -1,2 +1,0 @@
-delvewheel==1.11.1 ; sys_platform == 'win32'
-wheel

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -44,8 +44,3 @@ shutil.copytree(srcdir, os.path.join("$pkgconf_path", "lib"))
 EOF
     fi
 fi
-
-# cibuildwheel doesn't install delvewheel by default
-if [[ $RUNNER_OS == "Windows" ]]; then
-    python -m pip install -r $PROJECT_DIR/requirements/delvewheel_requirements.txt
-fi


### PR DESCRIPTION
That change happened in cibuildwheel 4.0.0, see [cibuildwheel#2831](https://github.com/pypa/cibuildwheel/pull/2831) and [its 4.0.0 changelog entry](https://cibuildwheel.pypa.io/en/stable/changelog/#v400).

We were behind in the `cibuildwheel` version in wheels.yml, so bump that to 4.1.1, same as it already is in emscripten.yml (I avoided a larger set of action bumps with gha-action, that's for a separate PR).

This is a follow-up to gh-26104. This is the very last requirements file - glad to see those gone:)


#### AI Generation Disclosure

All code written by hand, only used Claude for a sanity check before triggering CI.