### PR TITLE
BLD: optimize: highspy: replace pybind11 with nanobind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ pip-wheel-metadata
 installdir/
 .mesonpy/
 .wraplock
+subprojects/nanobind-*
+subprojects/robin-map-*
 
 # doit
 ######

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -42,6 +42,8 @@ pybind11_dep = declare_dependency(
   compile_args: cpp.get_supported_arguments('-Wno-unused-template'),
 )
 
+nanobind_dep = dependency('nanobind')
+
 # Pythran include directory and build flags
 if use_pythran
   # This external-property may not be needed if we can use the native include

--- a/scipy/optimize/_highspy/_highs_wrapper.py
+++ b/scipy/optimize/_highspy/_highs_wrapper.py
@@ -327,7 +327,9 @@ def check_option(highs_inst, option, value):
         if not hoptmanager.check_double_option(option, value):
             return -1, "Invalid option value."
     if expected_type is int:
-        if not hoptmanager.check_int_option(option, value):
+        # enum instances (e.g. HighsDebugLevel)
+        # must be converted explicitly to int
+        if not hoptmanager.check_int_option(option, int(value)):
             return -1, "Invalid option value."
 
     if expected_type is None:

--- a/scipy/optimize/_highspy/highs_options.cpp
+++ b/scipy/optimize/_highspy/highs_options.cpp
@@ -1,12 +1,15 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#define NB_DOMAIN highspy
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 #include <map>
 #include <mutex>
 
 #include "lp_data/HighsOptions.h"
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 class HighsOptionsManager {
 public:
@@ -66,9 +69,9 @@ private:
   }
 };
 
-PYBIND11_MODULE(_highs_options, m, py::mod_gil_not_used()) {
-  py::class_<HighsOptionsManager>(m, "HighsOptionsManager")
-      .def(py::init<>())
+NB_MODULE(_highs_options, m) {
+  nb::class_<HighsOptionsManager>(m, "HighsOptionsManager")
+      .def(nb::init<>())
       .def("get_option_type",
            [](const HighsOptionsManager &manager, const std::string &name) {
              const auto &lookup = manager.get_record_type_lookup().find(name);
@@ -91,7 +94,7 @@ PYBIND11_MODULE(_highs_options, m, py::mod_gil_not_used()) {
              try {
                return self.check_option<OptionRecordInt, int>(name, value);
              } catch (const std::exception &e) {
-               py::print("Exception caught in check_int_option:", e.what());
+               nb::print(("Exception caught in check_int_option: " + std::string(e.what())).c_str());
                return false;
              }
            })
@@ -101,7 +104,7 @@ PYBIND11_MODULE(_highs_options, m, py::mod_gil_not_used()) {
             try {
               return self.check_option<OptionRecordDouble, double>(name, value);
             } catch (const std::exception &e) {
-              py::print("Exception caught in check_double_option:", e.what());
+              nb::print(("Exception caught in check_double_option: " + std::string(e.what())).c_str());
               return false;
             }
           })
@@ -112,7 +115,7 @@ PYBIND11_MODULE(_highs_options, m, py::mod_gil_not_used()) {
                return self.check_option<OptionRecordString, std::string>(name,
                                                                          value);
              } catch (const std::exception &e) {
-               py::print("Exception caught in check_string_option:", e.what());
+               nb::print(("Exception caught in check_string_option: " + std::string(e.what())).c_str());
                return false;
              }
            });

--- a/scipy/optimize/_highspy/meson.build
+++ b/scipy/optimize/_highspy/meson.build
@@ -55,7 +55,7 @@ _highs_dep = declare_dependency(
     include_directories: highs_incdirs,
 )
 
-scipy_highspy_dep = [pybind11_dep, _highs_dep, thread_dep, atomic_dep]
+scipy_highspy_dep = [nanobind_dep, _highs_dep, thread_dep, atomic_dep]
 
 py3.install_sources(
     ['__init__.py', '_highs_wrapper.py'],

--- a/scipy/optimize/tests/meson.build
+++ b/scipy/optimize/tests/meson.build
@@ -23,6 +23,7 @@ py3.install_sources([
     'test_direct.py',
     'test_extending.py',
     'test_hessian_update_strategy.py',
+    'test_highspy.py',
     'test_isotonic_regression.py',
     'test_lbfgsb_hessinv.py',
     'test_lbfgsb_setulb.py',

--- a/scipy/optimize/tests/test_highspy.py
+++ b/scipy/optimize/tests/test_highspy.py
@@ -1,0 +1,238 @@
+"""
+Tests for the scipy.optimize._highspy._core bindings (the nanobind-based
+wrapper around the HiGHS C++ library).
+
+These exercise the low-level binding surface directly (as opposed to the
+public scipy.optimize.linprog/milp APIs), since it is easy for a C++/Python
+binding layer to have lifetime, refcounting, or type-marshalling bugs that
+don't show up through the higher-level solvers.
+"""
+import gc
+import sys
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from scipy.optimize import linprog, milp, LinearConstraint, Bounds, OptimizeWarning
+import scipy.optimize._highspy._core as _core
+
+
+def _build_solved_highs():
+    h = _core._Highs()
+    lp = _core.HighsLp()
+    lp.num_col_ = 2
+    lp.num_row_ = 2
+    lp.col_cost_ = np.array([1.0, 1.0])
+    lp.col_lower_ = np.array([0.0, 0.0])
+    lp.col_upper_ = np.array([_core.kHighsInf, _core.kHighsInf])
+    lp.row_lower_ = np.array([-_core.kHighsInf, -_core.kHighsInf])
+    lp.row_upper_ = np.array([10.0, 15.0])
+    lp.sense_ = _core.ObjSense.kMinimize
+    lp.offset_ = 0.0
+    mat = _core.HighsSparseMatrix()
+    mat.format_ = _core.MatrixFormat.kColwise
+    mat.num_col_ = 2
+    mat.num_row_ = 2
+    mat.start_ = [0, 2, 4]
+    mat.index_ = [0, 1, 0, 1]
+    mat.value_ = [1.0, 1.0, 2.0, 1.0]
+    lp.a_matrix_ = mat
+    model = _core.HighsModel()
+    model.lp_ = lp
+    h.passModel(model)
+    h.setOptionValue("output_flag", False)
+    h.run()
+    return h
+
+
+class TestHighsCoreModelBuilding:
+    def test_pass_model_via_objects(self):
+        h = _core._Highs()
+        lp = _core.HighsLp()
+        lp.num_col_ = 2
+        lp.num_row_ = 1
+        lp.col_cost_ = np.array([1.0, 2.0])
+        lp.col_lower_ = np.array([0.0, 0.0])
+        lp.col_upper_ = np.array([10.0, 10.0])
+        lp.row_lower_ = np.array([-_core.kHighsInf])
+        lp.row_upper_ = np.array([10.0])
+        lp.sense_ = _core.ObjSense.kMinimize
+        mat = _core.HighsSparseMatrix()
+        mat.format_ = _core.MatrixFormat.kColwise
+        mat.num_col_ = 2
+        mat.num_row_ = 1
+        mat.start_ = [0, 1, 2]
+        mat.index_ = [0, 0]
+        mat.value_ = [1.0, 1.0]
+        lp.a_matrix_ = mat
+        model = _core.HighsModel()
+        model.lp_ = lp
+
+        assert h.passModel(model) == _core.HighsStatus.kOk
+        assert h.run() == _core.HighsStatus.kOk
+
+    def test_pass_model_via_raw_arrays(self):
+        h = _core._Highs()
+        status = h.passModel(
+            2, 1, 2, 0,
+            int(_core.MatrixFormat.kColwise), int(_core.MatrixFormat.kColwise),
+            int(_core.ObjSense.kMinimize), 0.0,
+            np.array([1.0, 2.0]), np.array([0.0, 0.0]), np.array([10.0, 10.0]),
+            np.array([-_core.kHighsInf]), np.array([10.0]),
+            np.array([0, 1, 2], dtype=np.int32), np.array([0, 0], dtype=np.int32),
+            np.array([1.0, 1.0]),
+            np.array([], dtype=np.int32), np.array([], dtype=np.float64),
+            np.array([], dtype=np.int32), np.array([], dtype=np.int32),
+        )
+        assert status == _core.HighsStatus.kOk
+        assert h.run() == _core.HighsStatus.kOk
+
+
+class TestHighsOptionTypeDispatch:
+    def test_linprog_mixed_option_types(self):
+        # exercise bool, float, int, string, and enum-valued options in one
+        # call, covering every branch of _highs_wrapper.py's check_option().
+        # "random_seed", "log_file", and "highs_debug_level" are not among
+        # linprog(method="highs")'s named kwargs, so they are passed through
+        # verbatim to HiGHS with a warning -- that pass-through path (and the
+        # enum -> int conversion in check_option) is exactly what's under
+        # test here.
+        options = {
+            "presolve": True,
+            "time_limit": 30.5,
+            "random_seed": 1,
+            "log_file": "",
+            "highs_debug_level": _core.HighsDebugLevel.kHighsDebugLevelNone,
+        }
+        with pytest.warns(OptimizeWarning, match="Unrecognized options"):
+            res = linprog([1, 2], A_ub=[[1, 1]], b_ub=[10],
+                          bounds=[(0, 10), (0, 10)], method="highs",
+                          options=options)
+        assert res.success
+        assert_allclose(res.fun, 0.0, atol=1e-9)
+
+    def test_milp_mixed_option_types(self):
+        options = {
+            "presolve": True,
+            "time_limit": 30.0,
+            "mip_rel_gap": 0.001,
+        }
+        constraints = LinearConstraint([[1, 1]], -np.inf, 10)
+        bounds = Bounds([0, 0], [10, 10])
+        res = milp([-1, -2], constraints=constraints, bounds=bounds,
+                   integrality=[1, 1], options=options)
+        assert res.success
+
+
+def test_col_cost_getter_returns_numpy_array():
+    # Regression test: HighsLp.col_cost_ (backed by make_readonly_ptr) must
+    # come back as a real, usable numpy array, not a bare DLPack capsule.
+    lp = _core.HighsLp()
+    lp.num_col_ = 3
+    lp.col_cost_ = np.array([1.0, 2.0, 3.0])
+    arr = np.asarray(lp.col_cost_)
+    assert_allclose(arr, [1.0, 2.0, 3.0])
+
+
+def test_get_basis_inverse_row_numeric():
+    # Regression test for the nanobind port's to_ndarray()-based return
+    # values: the returned array must be numerically correct and usable
+    # as a plain numpy array.
+    h = _build_solved_highs()
+    status, row0 = h.getBasisInverseRow(0)
+    assert status == _core.HighsStatus.kOk
+    assert_allclose(np.asarray(row0), [1.0, 0.0], atol=1e-9)
+
+    status, row1 = h.getBasisInverseRow(1)
+    assert status == _core.HighsStatus.kOk
+    assert_allclose(np.asarray(row1), [0.0, 1.0], atol=1e-9)
+
+
+def test_uaf_col_cost_property_survives_parent_deletion():
+    # Use-after-free regression test: HighsLp.col_cost_'s getter is backed
+    # by nb::rv_policy::reference_internal (make_readonly_ptr), which is
+    # supposed to keep the parent HighsLp alive for as long as the returned
+    # array is alive. Run this in a loop with gc.collect() to raise the
+    # odds of catching a real UAF if that lifetime tie is ever broken.
+    results = []
+    for i in range(200):
+        lp = _core.HighsLp()
+        lp.num_col_ = 4
+        lp.col_cost_ = np.array([i * 1.0, i * 2.0, i * 3.0, i * 4.0])
+        arr = lp.col_cost_
+        del lp
+        gc.collect()
+        results.append((i, arr))
+
+    for i, arr in results:
+        assert_allclose(np.asarray(arr), [i * 1.0, i * 2.0, i * 3.0, i * 4.0])
+
+
+def test_set_callback_none_clears_callback():
+    h = _core._Highs()
+    assert h.setCallback(None, None) == _core.HighsStatus.kOk
+
+
+def test_set_callback_fires_with_correct_user_data_and_refcounting():
+    class UserData:
+        def __init__(self, tag):
+            self.tag = tag
+            self.calls = 0
+
+    h = _build_solved_highs()
+    ud = UserData("hello-world")
+    received = []
+
+    def callback(cb_type, msg, data_out, data_in, user_data):
+        received.append(user_data.tag)
+        user_data.calls += 1
+
+    assert h.setCallback(callback, ud) == _core.HighsStatus.kOk
+    h.startCallback(int(_core.cb.HighsCallbackType.kCallbackLogging))
+    h.setOptionValue("output_flag", True)
+    h.run()
+    h.stopCallback(int(_core.cb.HighsCallbackType.kCallbackLogging))
+    h.setCallback(None, None)
+    del h, callback
+    gc.collect()
+
+    assert len(received) > 0
+    assert all(tag == "hello-world" for tag in received)
+    assert ud.calls == len(received)
+
+
+def test_set_callback_repeated_create_destroy_loop():
+    # Repeated create/destroy of Highs + callback + user data, to catch
+    # reference-counting leaks or crashes that a single call wouldn't show.
+    tags = []
+    for i in range(30):
+        h = _build_solved_highs()
+        ud = object()
+        rc0 = sys.getrefcount(ud)
+
+        def callback(cb_type, msg, data_out, data_in, user_data, _i=i, _tags=tags):
+            _tags.append(_i)
+
+        h.setCallback(callback, ud)
+        h.startCallback(int(_core.cb.HighsCallbackType.kCallbackLogging))
+        h.setOptionValue("output_flag", True)
+        h.run()
+        h.stopCallback(int(_core.cb.HighsCallbackType.kCallbackLogging))
+        h.setCallback(None, None)
+        del h, callback
+        gc.collect()
+        rc1 = sys.getrefcount(ud)
+        assert rc1 <= rc0 + 2, f"refcount grew unexpectedly at iter {i}: {rc0} -> {rc1}"
+
+    assert len([t for t in tags if t is not None]) > 0
+
+
+def test_enum_valued_option_via_linprog():
+    # A recent fix (int(value) in check_option()) relies on bound enums
+    # supporting int conversion when passed as an options= dict value.
+    with pytest.warns(OptimizeWarning, match="Unrecognized options"):
+        res = linprog([1, 2], bounds=[(0, 10), (0, 10)], method="highs",
+                      options={"highs_debug_level":
+                               _core.HighsDebugLevel.kHighsDebugLevelCheap})
+    assert res.success

--- a/subprojects/nanobind.wrap
+++ b/subprojects/nanobind.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = nanobind-2.12.0
+source_url = https://github.com/wjakob/nanobind/archive/refs/tags/v2.12.0.tar.gz
+source_filename = nanobind-2.12.0.tar.gz
+source_hash = 01f1f0cd0398743c18f33d07ae36ad410bd7f4a1e90683b508504de897d6e629
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/nanobind_2.12.0-1/get_source/nanobind-2.12.0.tar.gz
+patch_filename = nanobind_2.12.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/nanobind_2.12.0-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/nanobind_2.12.0-1/nanobind_2.12.0-1_patch.zip
+patch_hash = 4b8158bdb359218bcfb7a5b4459fbfa5919171d9ea2400de3a84cf9ab7c7308b
+wrapdb_version = 2.12.0-1
+
+[provide]
+dependency_names = nanobind

--- a/subprojects/robin-map.wrap
+++ b/subprojects/robin-map.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = robin-map-1.4.0
+source_url = https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.0.tar.gz
+source_filename = robin-map-1.4.0.tar.gz
+source_hash = 7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c
+patch_filename = robin-map_1.4.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/robin-map_1.4.0-1/get_patch
+patch_hash = feb14b6752b7d439fb2f3ee968e595a9a3de00ef8cb029488af2ceb4f504b95d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/robin-map_1.4.0-1/robin-map-1.4.0.tar.gz
+wrapdb_version = 1.4.0-1
+
+[provide]
+robin-map = robin_map_dep


### PR DESCRIPTION
#### Reference issue
Towards gh-19878.

#### What does this implement/fix?
- 227519ae1d7ce2131ecfdda139da19d70e747e51 is from gh-24995 — the build system setup for using nanobind
- 974e05a422b2efb3712d6912a302610fafa1ec06 is a drafted conversion away from pybind11 to nanobind for highspy
- 7c480810f4f69d23e6f0f938aae2528afc0398ca are some tests from Claude which we can take/modify/leave

#### Additional information
The bulk of the changes are in the subproject — view them at https://github.com/scipy/HiGHS/pull/74.

`pixi run test -s optimize` passes for me locally.

#### AI Generation Disclosure
Edits drafted by Claude code during the following conversation: https://gist.github.com/lucascolley/2c33fab3c0f8cf3a565b9c02d753dd22. I made some extra revisions aside from the logged input in the conversation, including:
- adding some references to the nanobind docs in comments
- getting rid of overly verbose LLM comments