### PR TITLE
MAINT: Fix annoying blue underscores in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,10 @@
 .. image:: https://img.shields.io/conda/dn/conda-forge/scipy.svg?label=Conda%20downloads
   :target: https://anaconda.org/conda-forge/scipy
 
-.. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
+.. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg?
   :target: https://stackoverflow.com/questions/tagged/scipy
 
-.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue.svg
+.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue.svg?
   :target: https://www.nature.com/articles/s41592-019-0686-2
 
 .. image:: https://insights.linuxfoundation.org/api/badge/health-score?project=scipy


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
The `README.rst` is rendered in a way that 2 blue underscores are placed between the badges at the top. This PR fixes this.

Before fixing:
<img width="1156" height="110" alt="image" src="https://github.com/user-attachments/assets/45c602af-7e80-4fec-8511-f7c902ba6463" />

After fixing:
<img width="1148" height="112" alt="image" src="https://github.com/user-attachments/assets/8fbcef1b-4ebe-4612-9628-defe561d4f42" />

**Used solution:**
GitHub seems to expect a parameter list at least for the svg case to render the badges properly. Thus, I simply added empty parameter lists to the ends of the URLs which are still valid. With this fix it works.
This fix should even still work if GitHub starts accepting svg URLs without ?, since using empty parameter lists is valid.
(Solved this problem for `scikit-learn` the same way: https://github.com/scikit-learn/scikit-learn/pull/33834)

#### AI Generation Disclosure
No AI tools used
