### PR TITLE
TST: bump rtol in `test_morestats.py::TestBoxcoxNormmax::test_nan_policy`

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2857,7 +2857,7 @@ class NormmaxTest:
 
         res = transform_normmax(x, nan_policy='omit')
         ref = transform_normmax(x[~np.isnan(x)])
-        np.testing.assert_allclose(res, ref)
+        np.testing.assert_allclose(res, ref, rtol=1.5e-7)
 
 
 class TestBoxcoxNormmax(NormmaxTest):


### PR DESCRIPTION
Bumps a test tolerance that causes [intermittent failures](https://github.com/scipy/scipy-release/actions/runs/34041445643/job/101536292067#step:8:4776) in the wheel builds on macos_x86_64