### PR TITLE
BUG: stats.ttest_1samp: avoid variance under/overflow after rescaling

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6320,8 +6320,22 @@ def ttest_1samp(a, popmean, axis=0, nan_policy="propagate", alternative="two-sid
     except ValueError as e:
         raise ValueError("`popmean.shape[axis]` must equal 1.") from e
     d = mean - popmean
-    v = _var(a, axis=axis, ddof=1)
-    denom = xp.sqrt(v / n)
+    # Rescale the deviations from the mean to O(1) before forming the variance.
+    # Computing it from the raw data squares the scale of the sample, which can
+    # underflow to zero or overflow to infinity for data that is merely very
+    # small or very large, sending `t` to infinity or zero even though the
+    # standard error and `t` are both representable. See gh-26113.
+    # `_demean` keeps the catastrophic cancellation warning of gh-15905, which
+    # is about the original data and would not fire on the rescaled deviations.
+    dev = _demean(a, xp.mean(a, axis=axis, keepdims=True), axis, xp=xp)
+    scale = xp.max(xp.abs(dev), axis=axis, keepdims=True)
+    # A constant sample (`scale == 0`) or a non-finite one leaves the deviations
+    # unscaled, so those cases behave exactly as before.
+    scale = xp.where((scale > 0) & xp.isfinite(scale), scale, xp.ones_like(scale))
+    # The deviations are already centered, so pass a zero center rather than
+    # letting `_var` demean them a second time.
+    v = _var(dev / scale, axis=axis, ddof=1, mean=xp.zeros_like(scale))
+    denom = xp.squeeze(scale, axis=axis) * xp.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         t = xp.divide(d, denom)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4052,18 +4052,22 @@ class TestTTest_1samp:
         xp_assert_close(t, xp.asarray(self.T1_2))
         xp_assert_close(p, xp.asarray(self.P1_2))
 
-    @pytest.mark.parametrize("k", [-600, 0, 600])
+    @pytest.mark.parametrize("sign", [-1, 0, 1])
     @pytest.mark.parametrize(
         "sample, t_ref, p_ref",
         [([1., 2.], 3., 0.20483276469913345),
          ([2., 3., 4.], 3. * np.sqrt(3.), 0.03509871864598465)],
     )
-    def test_onesample_scale_invariance(self, sample, t_ref, p_ref, k, xp):
+    def test_onesample_scale_invariance(self, sample, t_ref, p_ref, sign, xp):
         # gh-26113: forming the variance from the raw data squares the scale of
         # the sample, so an exact power-of-two rescaling that leaves the
         # t-statistic representable could still underflow or overflow the
         # intermediate, returning t=inf/p=0 or t=0/p=1.
-        scale = 2. ** k
+        # The exponent has to keep the sample itself inside the dtype's range
+        # while putting its square outside, so it depends on the dtype: float32
+        # holds down to 2**-149 subnormal, float64 down to 2**-1074.
+        exponent = 100 if xpx.default_dtype(xp) == xp.float32 else 600
+        scale = 2. ** (sign * exponent)
         x = xp.asarray([value * scale for value in sample])
 
         res = stats.ttest_1samp(x, 0.)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4052,6 +4052,29 @@ class TestTTest_1samp:
         xp_assert_close(t, xp.asarray(self.T1_2))
         xp_assert_close(p, xp.asarray(self.P1_2))
 
+    @pytest.mark.parametrize("k", [-600, 0, 600])
+    @pytest.mark.parametrize(
+        "sample, t_ref, p_ref",
+        [([1., 2.], 3., 0.20483276469913345),
+         ([2., 3., 4.], 3. * np.sqrt(3.), 0.03509871864598465)],
+    )
+    def test_onesample_scale_invariance(self, sample, t_ref, p_ref, k, xp):
+        # gh-26113: forming the variance from the raw data squares the scale of
+        # the sample, so an exact power-of-two rescaling that leaves the
+        # t-statistic representable could still underflow or overflow the
+        # intermediate, returning t=inf/p=0 or t=0/p=1.
+        scale = 2. ** k
+        x = xp.asarray([value * scale for value in sample])
+
+        res = stats.ttest_1samp(x, 0.)
+        xp_assert_close(res.statistic, xp.asarray(t_ref))
+        xp_assert_close(res.pvalue, xp.asarray(p_ref))
+
+        # ttest_rel defers to ttest_1samp on the paired difference
+        res_rel = stats.ttest_rel(x, xp.zeros_like(x))
+        xp_assert_close(res_rel.statistic, xp.asarray(t_ref))
+        xp_assert_close(res_rel.pvalue, xp.asarray(p_ref))
+
     def test_onesample_nan_policy_propagate(self, xp):
         x = stats.norm.rvs(loc=5, scale=10, size=51, random_state=7654567)
         x[50] = np.nan


### PR DESCRIPTION
Closes gh-26113

## What was wrong

`ttest_1samp` computed the standard error as `sqrt(_var(a, ddof=1) / n)`. Forming the variance from the raw data squares the scale of the sample, so an exact power-of-two rescaling that leaves both the standard error and the t-statistic comfortably representable can still underflow the intermediate to zero or overflow it to infinity:

| input | expected t | before | after |
|---|---|---|---|
| `[1, 2] * 2**-600` | 3 | `t=inf`, `p=0` | `t=3`, `p=0.20483276469913345` |
| `[1, 2] * 2**600` | 3 | `t=0`, `p=1` | `t=3`, `p=0.20483276469913345` |
| `[2, 3, 4] * 2**-600` | `3*sqrt(3)` | `t=inf`, `p=0` | `t=5.196152422706632`, `p=0.03509871864598465` |
| `[2, 3, 4] * 2**600` | `3*sqrt(3)` | `t=0`, `p=1` | `t=5.196152422706632`, `p=0.03509871864598465` |

These are not near-constant samples — `max|x - mean(x)| / |mean(x)|` is `1/3` in both — and the p-values are not off in the last bits: at the 5% level, shrinking `[1, 2]` turns non-rejection into rejection and enlarging `[2, 3, 4]` turns rejection into non-rejection.

## The change

Rescale the deviations from the mean to O(1) before forming the variance, then multiply the scale back into the standard error. A constant sample (`scale == 0`) or a non-finite one leaves the deviations unscaled, so those paths behave exactly as before.

Two details worth flagging for review:

- `_demean` is called directly rather than being left to `_var`, so the catastrophic-cancellation warning from gh-15905 still evaluates the original data. It would not fire on the rescaled deviations, and `TestTTestRel::test_edge_cases` asserts it.
- `_var` is passed a zero center, since the deviations are already centered and demeaning them again would be both redundant and a second place for the warning to trigger.

`ttest_rel` defers to `ttest_1samp` on the paired difference, so it is fixed by the same change.

Out of scope: `ttest_ind` builds its denominator through `_equal_var_ttest_denom` / `_unequal_var_ttest_denom` from separately computed variances, so it needs a different treatment. The issue does not cover it, and I would rather not widen this PR — happy to follow up if you want it.

## Testing

`TestTTest_1samp::test_onesample_scale_invariance` covers both samples from the issue at `k = -600, 0, 600`, asserting the statistic and the p-value against the exact reference values, through both `ttest_1samp` and `ttest_rel`. The four rescaled parametrizations fail on `main` and pass with the change; the two `k = 0` cases pass either way.

Full `scipy/stats/tests/`: 13273 passed, 977 skipped, 136 xfailed, 10 xpassed. The t-test tests also pass under `SCIPY_ARRAY_API=1`. `tools/linting/lint.py --diff-against=origin/main` is clean.
