### PR TITLE
TST: fix all test suite warnings visible in wheel build jobs

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -563,7 +563,9 @@ def test_maxiter_worsening(solver, xp):
                   [0.1112795288033368, 0j, 0j, -0.16127952880333785]])
     v = np.ones(4)
     dtype = xpx.default_dtype(xp)
-    A, v = (xp.asarray(arr, dtype=dtype) for arr in [A, v])
+    complex_dtype = xp.complex128 if dtype == xp.float64 else xp.complex64
+    A = xp.asarray(A, dtype=complex_dtype)
+    v = xp.asarray(v, dtype=dtype)
     best_error = np.inf
 
     # Unable to match the Fortran code tolerance levels with this example

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1101,13 +1101,9 @@ class _TestCommon:
                     dat = np.matrix(dat)
 
             for output_dtype in self.checked_dtypes:
-                # Skip problematic dtype combinations (complex to real, etc.)
-                # by catching exceptions when numpy itself fails
-                try:
-                    with np.errstate(all='raise'):
-                        _ = dat.sum(dtype=output_dtype)
-                except Exception:
-                    # Skip this combination if NumPy can't handle it
+                input_is_complex = np.isdtype(input_dtype, "complex floating")
+                output_is_complex = np.isdtype(output_dtype, "complex floating")
+                if input_is_complex and not output_is_complex:
                     continue
 
                 # Check axis=None

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -377,6 +377,9 @@ def nan_policy_1d(hypotest, data1d, unpacker, *args, n_outputs=2,
 @pytest.mark.filterwarnings('ignore:Invalid value encountered in:RuntimeWarning')
 # kstatvar, ttest_1samp, ttest_rel, ttest_ci, brunnermunzel, levene, bartlett
 @pytest.mark.filterwarnings('ignore:divide by zero encountered:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:One or more sample arguments is too small:'
+                            'RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:Mean of empty slice:RuntimeWarning')
 
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
@@ -414,6 +417,9 @@ if SCIPY_XSLOW:
     @pytest.mark.filterwarnings('ignore:Invalid value encountered in:RuntimeWarning')
     # kstatvar, ttest_1samp, ttest_rel, ttest_ci, brunnermunzel, levene, bartlett
     @pytest.mark.filterwarnings('ignore:divide by zero encountered:RuntimeWarning')
+    @pytest.mark.filterwarnings('ignore:One or more sample arguments is too small:'
+                                'RuntimeWarning')
+    @pytest.mark.filterwarnings('ignore:Mean of empty slice:RuntimeWarning')
 
     @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                               "paired", "unpacker"), axis_nan_policy_cases)

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -236,6 +236,7 @@ class TestUtils:
             reason="minimum_spanning_tree ignores zero distances (#18892)",
             strict=True,
     )
+    @pytest.mark.filterwarnings("ignore:Sample contains duplicate points:UserWarning")
     @pytest.mark.thread_unsafe
     def test_geometric_discrepancy_mst_with_zero_distances(self):
         sample = np.array([[0, 0], [0, 0], [0, 1]])


### PR DESCRIPTION
There are many warnings, but coming from a limited number of discrete tests:

```
    sparse/linalg/_isolve/tests/test_iterative.py::test_maxiter_worsening[gmres-numpy]
    sparse/linalg/_isolve/tests/test_iterative.py::test_maxiter_worsening[qmr-numpy]
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/_external/array_api_compat/numpy/_aliases.py:94: ComplexWarning: Casting complex values to real discards the imaginary part
        return np.array(obj, copy=copy, dtype=dtype, **kwargs)
    
    sparse/tests/test_64bit.py: 135 warnings
    sparse/tests/test_base.py: 66 warnings
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/numpy/_core/_methods.py:49: ComplexWarning: Casting complex values to real discards the imaginary part
        return umr_sum(a, axis, dtype, out, keepdims, initial, where)
    
    sparse/tests/test_64bit.py: 108 warnings
    sparse/tests/test_base.py: 54 warnings
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/sparse/_data.py:73: ComplexWarning: Casting complex values to real discards the imaginary part
        self.data.astype(dtype, casting=casting, copy=True),
    
    sparse/tests/test_64bit.py: 27 warnings
    sparse/tests/test_base.py: 6 warnings
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/sparse/_dia.py:167: ComplexWarning: Casting complex values to real discards the imaginary part
        self.data.astype(res_dtype), one, row_sums)

     sparse/tests/test_base.py::TestDOK::test_sum_dtype_pair_of_dtypes
    sparse/tests/test_base.py::TestDOK::test_sum_dtype_pair_of_dtypes
    sparse/tests/test_base.py::TestDOK::test_sum_dtype_pair_of_dtypes
    sparse/tests/test_base.py::TestDOKMatrix::test_sum_dtype_pair_of_dtypes
    sparse/tests/test_base.py::TestDOKMatrix::test_sum_dtype_pair_of_dtypes
    sparse/tests/test_base.py::TestDOKMatrix::test_sum_dtype_pair_of_dtypes
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/sparse/_dok.py:630: ComplexWarning: Casting complex values to real discards the imaginary part
        data = np.array(list(self._dict.values()), dtype=dtype)
    
    stats/tests/test_axis_nan_policy.py: 82 warnings
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/stats/_stats_py.py:11119: SmallSampleWarning: One or more sample arguments is too small; all returned values will be NaN. See documentation for sample size requirements.
        return gmean(x, weights=weights, axis=axis, keepdims=keepdims)
    
    stats/tests/test_axis_nan_policy.py: 163 warnings
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:3862: RuntimeWarning: Mean of empty slice
        return _methods._mean(a, axis=axis, dtype=dtype,
    
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-boxcox_llf-args86-kwds86-1-1-False-<lambda>]
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-boxcox_llf-args86-kwds86-1-1-False-<lambda>]
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-boxcox_llf-args86-kwds86-1-1-False-<lambda>]
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/stats/tests/test_axis_nan_policy.py:89: SmallSampleWarning: One or more sample arguments is too small; all returned values will be NaN. See documentation for sample size requirements.
        return stats._morestats._boxcox_llf(data, lmb=lmb, axis=axis)
    
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-yeojohnson_llf-args87-kwds87-1-1-False-<lambda>]
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-yeojohnson_llf-args87-kwds87-1-1-False-<lambda>]
    stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_fast[mixed-1-omit-yeojohnson_llf-args87-kwds87-1-1-False-<lambda>]
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/stats/tests/test_axis_nan_policy.py:95: SmallSampleWarning: One or more sample arguments is too small; all returned values will be NaN. See documentation for sample size requirements.
        return stats._morestats._yeojohnson_llf(data, lmb=lmb, axis=axis)
    
    stats/tests/test_qmc.py::TestUtils::test_geometric_discrepancy_mst_with_zero_distances
      /tmp/tmp.CXlppymQkC/venv/lib/python3.12/site-packages/scipy/stats/tests/test_qmc.py:242: UserWarning: Sample contains duplicate points.
        assert_allclose(qmc.geometric_discrepancy(sample, method='mst'), 0.5)

```

These have been emitted for a while, the log pollution is a little annoying. I tracked the `sparse` ones to gh-24496; I wanted to check because the try-except clause is unusual (and wrong). The others ones are more business as usual, just missing `filterwarnings`.


#### AI Generation Disclosure

I used Codex 5.6 Sol to find and fix up the right places. Had to iterate a bit on the `stats` and `sparse` ones, finished up by hand.
