### PR TITLE
MAINT: linalg/pinvh: use low-level batching of eigh

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1685,7 +1685,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
     maxS = np.max(np.abs(s), initial=0., axis=-1, keepdims=True)
 
     atol = 0. if atol is None else atol
-    rtol = max(a.shape) * np.finfo(t).eps if (rtol is None) else rtol
+    rtol = max(a.shape[-2:]) * np.finfo(t).eps if (rtol is None) else rtol
 
     if (atol < 0.) or (rtol < 0.):
         raise ValueError("atol and rtol values must be positive.")

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1611,7 +1611,6 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True):
         return B
 
 
-@_apply_over_batch(('a', 2), signature=_pinv_signature)
 def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
           check_finite=True):
     """
@@ -1623,7 +1622,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
 
     Parameters
     ----------
-    a : (N, N) array_like
+    a : (..., N, N) array_like
         Real symmetric or complex hermetian matrix to be pseudo-inverted
 
     atol : float, optional
@@ -1649,7 +1648,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
 
     Returns
     -------
-    B : (N, N) ndarray
+    B : (..., N, N) ndarray
         The pseudo-inverse of matrix `a`.
     rank : int
         The effective rank of the matrix.  Returned if `return_rank` is True.
@@ -1683,7 +1682,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
     a = _asarray_validated(a, check_finite=check_finite)
     s, u = _decomp.eigh(a, lower=lower, check_finite=False, driver='ev')
     t = u.dtype.char.lower()
-    maxS = np.max(np.abs(s), initial=0.)
+    maxS = np.max(np.abs(s), initial=0., axis=-1, keepdims=True)
 
     atol = 0. if atol is None else atol
     rtol = max(a.shape) * np.finfo(t).eps if (rtol is None) else rtol
@@ -1694,13 +1693,12 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
     val = atol + maxS * rtol
     above_cutoff = (abs(s) > val)
 
-    psigma_diag = 1.0 / s[above_cutoff]
-    u = u[:, above_cutoff]
-
-    B = (u * psigma_diag) @ u.conj().T
+    psigma_diag = np.zeros_like(s)
+    np.divide(1.0, s, where=above_cutoff, out=psigma_diag)
+    B = (u * psigma_diag[..., None, :]) @ u.conj().mT
 
     if return_rank:
-        return B, len(psigma_diag)
+        return B, np.count_nonzero(above_cutoff, axis=-1)
     else:
         return B
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2611,6 +2611,9 @@ class TestPinvSymmetric:
         a_pinv = pinvh(a)
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
+        aa = np.stack([a, 2*a])
+        assert_equal(pinv(aa), np.stack([pinv(aa[0]), pinv(aa[1])]))
+
     def test_native_list_argument(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
         a = np.dot(a, a.T)
@@ -2652,6 +2655,26 @@ class TestPinvSymmetric:
         # adiff1 and adiff2 should be elevated to ~1e-4 due to mismatch
         assert_allclose(norm(adiff1), 1e-4, rtol=0.1)
         assert_allclose(norm(adiff2), 1e-4, rtol=0.1)
+
+    def test_rank(self):
+        a = np.diag([0, 1, 2])
+        a_p, rank = pinvh(a, return_rank=True)
+        assert rank == 2
+        assert_allclose(
+            a_p,
+            np.asarray([[0. , 0. , 0. ],
+                        [0. , 1. , 0. ],
+                        [0. , 0. , 0.5]]),
+            atol=1e-15
+        )
+
+        aa = np.stack([a, 2*a, np.diag([1, 2, 3])])
+        _, rank = pinvh(aa, return_rank=True)
+        assert_equal(rank, np.asarray([2, 2, 3]))
+
+        aaa = np.stack([aa, aa])
+        _, rank = pinvh(aaa, return_rank=True)
+        assert_equal(rank, np.asarray([[2, 2, 3], [2, 2, 3]]))
 
     @pytest.mark.parametrize('dt', [float, np.float32, complex, np.complex64])
     def test_empty(self, dt):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/pull/26087#discussion_r3944572751

#### What does this implement/fix?
<!--Please explain your changes.-->

Found in gh-26087: `linalg.pinvh` is decorated with `apply_over_batch` even though it internally calls `eigh`, which now handles batched inputs natively. Thus, remove the decorator and tweak filtering out zero eigenvalues to account for  batches. 

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai
