### PR TITLE
docs: drop duplicated words in stats/integrate docstrings

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -1091,7 +1091,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is is performed using a 21-point Gauss-Kronrod
+        several types. The integration is performed using a 21-point Gauss-Kronrod
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1086,7 +1086,7 @@ The dimensions of this matrix are inferred from the shape of `rowcov` and
 
 `rowcov` and `colcov` can be two-dimensional array_likes specifying the
 covariance matrices directly. Alternatively, a one-dimensional array will
-be be interpreted as the entries of a diagonal matrix, and a scalar or
+be interpreted as the entries of a diagonal matrix, and a scalar or
 zero-dimensional array will be interpreted as this value times the
 identity matrix.
 """
@@ -1557,7 +1557,7 @@ The dimensions of this matrix are inferred from the shape of `row_spread` and
 
 `row_spread` and `col_spread` can be two-dimensional array_likes specifying the
 spread matrices directly. Alternatively, a one-dimensional array will
-be be interpreted as the entries of a diagonal matrix, and a scalar or
+be interpreted as the entries of a diagonal matrix, and a scalar or
 zero-dimensional array will be interpreted as this value times the
 identity matrix.
 """

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -680,7 +680,7 @@ def estimated_cdf(x, y, *, method='linear',
     3. ``closest_observation``: ``m = -1/2`` and
        ``g = 1 - int((index == j) & (j%2 == 1))``
 
-    When all the data in ``x`` are unique, `estimated_cdf` and `quantile` are are
+    When all the data in ``x`` are unique, `estimated_cdf` and `quantile` are
     inverses of one another within a certain domain.
     Although `quantile` with ``method='linear'`` is invertible over the whole domain
     of ``p`` from ``0`` to ``1``, this is not true of other methods.


### PR DESCRIPTION
Four duplicated-word typos in docstrings, three of them in `scipy.stats`:

- `integrate/_quadpack_py.py` (`nquad` routine table): "The integration **is is** performed"
- `stats/_multivariate.py` (the shared callparams note template used by `MatrixNormal`, copy-pasted into the `matrix_normal_distribution` variant at :1560): "will **be be** interpreted"
- `stats/_quantile.py` (`estimated_cdf` Notes): "`quantile` and `estimated_cdf` **are are** inverses"

**AI Generation Disclosure**: this fix was found and prepared with AI assistance (Claude, via an automated docs-audit pass); reviewed and submitted by @simpleqt.