### PR TITLE
MAINT: stats: drop duplicated 'be' in broadcast ValueError

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -917,7 +917,7 @@ def _set_invalid_nan(f):
             except ValueError as e:
                 message = (
                     f"The argument provided to `{self.__class__.__name__}"
-                    f".{method_name}` cannot be be broadcast to the same "
+                    f".{method_name}` cannot be broadcast to the same "
                     "shape as the distribution parameters.")
                 raise ValueError(message) from e
 


### PR DESCRIPTION
`_Parameterization.filtered` (`scipy/stats/_distribution_infrastructure.py`) raises a `ValueError` whose message reads "... cannot **be be** broadcast to the same ..." when parameterization shapes are incompatible. One word dropped; no behavior change.

**AI Generation Disclosure**: found and prepared with AI assistance (Claude); reviewed and submitted by @simpleqt.