### PR TITLE
BUG: stats.Normal: avoid intermediate standardization overflow

### DIFF
--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -13,6 +13,17 @@ from scipy.stats._distribution_infrastructure import (
 __all__ = ['Normal', 'Logistic', 'Uniform', 'Binomial']
 
 
+def _normal_standardize(x, mu, sigma):
+    with np.errstate(over='ignore'):
+        difference = x - mu
+    # Divide first only when finite operands overflow during subtraction.
+    return xpx.apply_where(
+        np.isinf(difference) & np.isfinite(x) & np.isfinite(mu),
+        (x, mu, sigma, difference),
+        lambda x, mu, sigma, difference: x/sigma - mu/sigma,
+        lambda x, mu, sigma, difference: difference/sigma)
+
+
 class Normal(ContinuousDistribution):
     r"""Normal distribution with prescribed mean and standard deviation.
 
@@ -52,22 +63,24 @@ class Normal(ContinuousDistribution):
         super().__init__(mu=mu, sigma=sigma, **kwargs)
 
     def _logpdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._logpdf_formula(self, (x - mu)/sigma) - np.log(sigma)
+        return StandardNormal._logpdf_formula(
+            self, _normal_standardize(x, mu, sigma)) - np.log(sigma)
 
     def _pdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._pdf_formula(self, (x - mu)/sigma) / sigma
+        return StandardNormal._pdf_formula(
+            self, _normal_standardize(x, mu, sigma)) / sigma
 
     def _logcdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._logcdf_formula(self, (x - mu)/sigma)
+        return StandardNormal._logcdf_formula(self, _normal_standardize(x, mu, sigma))
 
     def _cdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._cdf_formula(self, (x - mu)/sigma)
+        return StandardNormal._cdf_formula(self, _normal_standardize(x, mu, sigma))
 
     def _logccdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._logccdf_formula(self, (x - mu)/sigma)
+        return StandardNormal._logccdf_formula(self, _normal_standardize(x, mu, sigma))
 
     def _ccdf_formula(self, x, *, mu, sigma, **kwargs):
-        return StandardNormal._ccdf_formula(self, (x - mu)/sigma)
+        return StandardNormal._ccdf_formula(self, _normal_standardize(x, mu, sigma))
 
     def _icdf_formula(self, x, *, mu, sigma, **kwargs):
         return StandardNormal._icdf_formula(self, x) * sigma + mu

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -199,6 +199,21 @@ families = continuous_families + discrete_families
 
 
 class TestDistributions:
+    @pytest.mark.parametrize('method', ['pdf', 'logpdf', 'cdf', 'logcdf',
+                                      'ccdf', 'logccdf'])
+    def test_normal_standardization_overflow(self, method):
+        # gh-26120: subtraction can overflow even when (x - mu)/sigma is finite.
+        largest = np.finfo(np.float64).max
+        X = Normal(mu=[-largest, largest, largest],
+                   sigma=[largest, largest, 0.5])
+        x = [largest/2, -largest/2, largest]
+        ref = getattr(Normal(), method)([1.5, -1.5, 0.])
+        if method == 'pdf':
+            ref /= X.sigma
+        elif method == 'logpdf':
+            ref -= np.log(X.sigma)
+        assert_allclose(getattr(X, method)(x), ref, rtol=1e-14, atol=0)
+
     @pytest.mark.fail_slow(60)  # need to break up check_moment_funcs
     @settings(max_examples=20)
     @pytest.mark.parametrize('family', families)


### PR DESCRIPTION
#### Reference issue

Closes gh-26120.

#### What does this implement/fix?

Normal standardization can overflow in `x - mu` even when division by `sigma` would produce a finite result. Use a shared private helper in the six PDF/CDF formulas to divide first only where subtraction of finite inputs overflows. Ordinary inputs retain the existing arithmetic; equal large inputs with a small scale avoid an unsafe unconditional rewrite.

Adds one parameterized regression across the six methods, covering both overflow directions and the equal-input case. Existing tests are unchanged.

#### Additional information

All six regression cases fail on the original source. With the fix, 38 focused tests pass and SciPy-configured Ruff passes. Tests executed the modified Python module and current test file using prebuilt SciPy 1.18.0 binaries/infrastructure; a full upstream source build was not run.

#### AI Generation Disclosure

OpenAI Codex investigated the issue. I have reviewed.