### PR TITLE
BUG: stats.Normal: preserve narrow interval log probabilities

### DIFF
--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -60,6 +60,28 @@ class Normal(ContinuousDistribution):
     def _logcdf_formula(self, x, *, mu, sigma, **kwargs):
         return StandardNormal._logcdf_formula(self, (x - mu)/sigma)
 
+    def _logcdf2_formula(self, x, y, **params):
+        out = np.asarray(self._logcdf2_subtraction(x, y, **params))
+        mask = np.isneginf(out.real) & np.isfinite(x) & np.isfinite(y) & (x != y)
+        if np.any(mask):
+            a, b = np.minimum(x, y)[mask], np.maximum(x, y)[mask]
+            width = b - a
+            params = {key: np.broadcast_to(val, mask.shape)[mask]
+                      for key, val in params.items()}
+
+            def integrand(t, a, width, **params):
+                return self._logpdf_dispatch(a + width*t, **params)
+
+            # Preserve the original width, even when its half underflows or
+            # separately standardized endpoints round to the same value.
+            integral = self._quadrature(integrand, limits=(0., 1.),
+                                        args=(a, width), params=params, log=True)
+            logmass = integral + np.log(width)
+            if np.iscomplexobj(out):
+                logmass = logmass + np.where(x[mask] > y[mask], np.pi*1j, 0j)
+            out[mask] = logmass
+        return out[()]
+
     def _cdf_formula(self, x, *, mu, sigma, **kwargs):
         return StandardNormal._cdf_formula(self, (x - mu)/sigma)
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -199,6 +199,21 @@ families = continuous_families + discrete_families
 
 
 class TestDistributions:
+    @pytest.mark.parametrize('mu, sigma, upper, logmass', [
+        (0., 1., 1e-20, -46.97064039308559),
+        (0., 1., np.nextafter(0., 1.), -745.3590104545859),
+        (-1e18, 1e8, 1., -5e19),
+    ])
+    def test_normal_narrow_interval(self, mu, sigma, upper, logmass):
+        # gh-26119: monotone-density integral bounds round to these log masses.
+        X = Normal(mu=mu, sigma=sigma)
+        # Mix failed subtraction with zero-width and ordinary intervals.
+        x = np.array([0., upper, 0., -np.inf])
+        y = np.array([upper, 0., 0., np.inf])
+        ref = np.array([logmass, logmass + np.pi*1j, -np.inf, 0.])
+        assert_allclose(X.logcdf(x, y), ref, rtol=2e-15)
+        assert_allclose(X.cdf(x, y), np.exp(ref).real, rtol=2e-14, atol=0)
+
     @pytest.mark.fail_slow(60)  # need to break up check_moment_funcs
     @settings(max_examples=20)
     @pytest.mark.parametrize('family', families)


### PR DESCRIPTION
#### Reference issue

Closes gh-26119.

#### What does this implement/fix?

Normal interval log probabilities can become negative infinity when endpoint probabilities round to the same value. Keep subtraction as the fast path, then use existing log-space quadrature only for that result with distinct finite bounds.

Integrating on a unit interval and adding the original log-width separately preserves intervals whose half-width underflows or whose standardized endpoints coincide. The fallback is confined to Normal, preserves reversed bounds, and also fixes the default two-bound CDF through its existing log/exp path.

Adds one parameterized regression for the three reported numerical cases, including reversed, zero-width, and infinite bounds. Existing tests are unchanged.

#### Additional information

All three regression cases fail on the original source. With the fix, 36 focused tests pass and SciPy-configured Ruff passes. Tests executed the modified Python module and current test file using prebuilt SciPy 1.18.0 binaries/infrastructure; a full upstream source build was not run.

This addresses complete cancellation to negative infinity, not all possible finite-result cancellation error. Explicit subtraction/quadrature methods retain their existing behavior.

#### AI Generation Disclosure

OpenAI Codex investigated the issue. I have reviewed.