### PR TITLE
fix: LSODA now stores hmin into S->hmin so min_step is honoured (gh-25827)

### DIFF
--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -1314,3 +1314,33 @@ def test_initial_maxstep():
                                             method_order,
                                             rtol, atol)
             assert_equal(max_step, step_with_max)
+
+
+def test_lsoda_min_step_honored():
+    # Regression test for gh-25827: LSODA silently ignored min_step because
+    # the local hmin variable was never written to S->hmin in lsoda.c.
+    # When min_step is large enough, LSODA must return status=-1 (step size
+    # too small) after far fewer function evaluations than the unconstrained run.
+    nfe = [0]
+
+    def f(t, y):
+        nfe[0] += 1
+        return -0.5 * y
+
+    # Unconstrained baseline
+    nfe[0] = 0
+    sol0 = solve_ivp(f, [1, 8], [1.0], t_eval=np.linspace(1, 8, 10),
+                     method="LSODA", rtol=1e-7, atol=1e-9)
+    nfe_unconstrained = nfe[0]
+    assert sol0.success
+
+    # With a large min_step the solver must hit the step-too-small condition
+    nfe[0] = 0
+    sol1 = solve_ivp(f, [1, 8], [1.0], t_eval=np.linspace(1, 8, 10),
+                     method="LSODA", rtol=1e-7, atol=1e-9,
+                     min_step=5, max_step=np.inf)
+    # Before the fix min_step was ignored and nfe matched the unconstrained run.
+    assert not sol1.success, "LSODA should fail when min_step forces too-large steps"
+    assert nfe[0] < nfe_unconstrained, (
+        f"min_step ignored: used {nfe[0]} evals, same as unconstrained ({nfe_unconstrained})"
+    )

--- a/scipy/integrate/src/lsoda.c
+++ b/scipy/integrate/src/lsoda.c
@@ -1707,6 +1707,7 @@ void lsoda(
             S->mxordn = mord[0];
             S->mxords = mord[1];
         }
+        S->hmin = hmin;
         // 60
 
         S->meth = 1;
@@ -1922,6 +1923,7 @@ void lsoda(
             S->hmxi = 0.0;
             hmin = 0.0;
         }
+        S->hmin = hmin;
         // 60
 
         S->lyh = 20;


### PR DESCRIPTION
## Problem

`solve_ivp(..., method='LSODA', min_step=x)` has no effect — the solver ignores the `min_step` argument entirely and takes steps as small as it likes.

## Root cause

In `scipy/integrate/src/lsoda.c`, the local variable `hmin` is parsed from the options and validated, but is never written to the LSODA state struct field `S->hmin`. All downstream step-size comparisons read `S->hmin`, which stays at its zero-initialised value, so the constraint is silently dropped.

Two assignment sites were missing — one in the initial-state branch and one in the re-initialisation branch:

```c
// Both branches previously:
hmin = <validated value>;
// 60
S->meth = 1;  // S->hmin never set  ← bug

// After:
hmin = <validated value>;
S->hmin = hmin;   // ← fix
// 60
S->meth = 1;
```

## Test

`test_lsoda_min_step_honored` in `test_ivp.py`: sets `min_step=5` on a problem whose natural step size is much smaller, asserts the solver fails (step would violate tolerance with such a coarse step) and that fewer function evaluations are made than the unconstrained run.

Closes gh-25827