### PR TITLE
BLD: workaround for Cython reproducibility issue

### DIFF
--- a/scipy/linalg/tests/_cython_examples/meson.build
+++ b/scipy/linalg/tests/_cython_examples/meson.build
@@ -10,10 +10,7 @@ if not cy.version().version_compare('>=3.2.0')
   error('tests requires Cython >= 3.2.0')
 endif
 
-cython_args = []
-if cy.version().version_compare('>=3.1.0')
-  cython_args += ['-Xfreethreading_compatible=True']
-endif
+cython_args = ['-Xfreethreading_compatible=True']
 
 py3.extension_module(
   'extending',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -383,33 +383,32 @@ py3.install_sources(
 #_cython_tree = declare_dependency(sources: [
 _cython_tree = [fs.copyfile('__init__.py')]
 
-cython_args = ['-3', '--fast-fail', '--output-file', '@OUTPUT@', '--include-dir', '@BUILD_ROOT@', '@INPUT@']
-if cy.version().version_compare('>=3.1.0')
-  cython_args += ['-Xfreethreading_compatible=True']
-
-  cython_shared_src = custom_target(
-    install: false,
-    output: '_cyutility.c',
-    command: [
-      cython, '-3', '--fast-fail', '-Xfreethreading_compatible=True',
-      '--generate-shared=' + meson.current_build_dir()/'_cyutility.c'
-    ],
-  )
-
-  cython_shared_module = py3.extension_module('_cyutility',
-    cython_shared_src,
-    subdir: 'scipy',
-    cython_args: cython_args,
-    link_args: version_link_args,
-    install: true,
-    install_tag: 'python-runtime',
-  )
-
-  cython_args += ['--shared=scipy._cyutility']
-else
-  cython_shared_module = []
-endif
+cython_args = [
+  '-3', '--fast-fail',
+  '-Xfreethreading_compatible=True',
+  '--shared=scipy._cyutility',
+  '--output-file', '@OUTPUT@',
+  '--include-dir', '@BUILD_ROOT@', '@INPUT@'
+]
 cython_cplus_args = ['--cplus'] + cython_args
+
+cython_shared_src = custom_target(
+  install: false,
+  output: '_cyutility.c',
+  command: [
+    cython, '-3', '--fast-fail', '-Xfreethreading_compatible=True',
+    '--working', '@OUTDIR@', '--generate-shared=_cyutility.c'
+  ],
+)
+
+cython_shared_module = py3.extension_module('_cyutility',
+  cython_shared_src,
+  subdir: 'scipy',
+  cython_args: cython_args,
+  link_args: version_link_args,
+  install: true,
+  install_tag: 'python-runtime',
+)
 
 cython_gen = generator(cython,
   arguments : cython_args,

--- a/scipy/optimize/tests/_cython_examples/meson.build
+++ b/scipy/optimize/tests/_cython_examples/meson.build
@@ -10,10 +10,7 @@ if not cy.version().version_compare('>=3.2.0')
   error('tests requires Cython >= 3.2.0')
 endif
 
-cython_args = []
-if cy.version().version_compare('>=3.1.0')
-  cython_args += ['-Xfreethreading_compatible=True']
-endif
+cython_args = ['-Xfreethreading_compatible=True']
 
 py3.extension_module(
   'extending',

--- a/scipy/special/tests/_cython_examples/meson.build
+++ b/scipy/special/tests/_cython_examples/meson.build
@@ -10,10 +10,7 @@ if not cy.version().version_compare('>=3.2.0')
   error('tests requires Cython >= 3.2.0')
 endif
 
-cython_args = []
-if cy.version().version_compare('>=3.1.0')
-  cython_args += ['-Xfreethreading_compatible=True']
-endif
+cython_args = ['-Xfreethreading_compatible=True']
 
 py3.extension_module(
   'extending',


### PR DESCRIPTION
See [Cython PR 7977](https://github.com/cython/cython/pull/7977); this change to `--working` avoids the build directory leaking into the output. Which will help with build reproducibility; the `_cyutility` module is non-reproducible right now.

Also some cleanups, because the guards for old Cython versions are no longer needed - we require >=3.2 now.


#### AI Generation Disclosure

`scipy/meson.build` changes done by hand. Then used Codex Sol 5.6 for a consistency audit, which found the separate test extensions.