### PR TITLE
DOC/DEV: fix long-time warnings about `stats.{Logistic, Uniform}`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -307,6 +307,8 @@ autosummary_generate = True
 autosummary_filename_map = {
     "scipy.signal.czt": "czt-function",
     "scipy.signal.ShortTimeFFT.t": "scipy.signal.ShortTimeFFT.t.lower",
+    "scipy.stats.logistic": "scipy.stats.logistic.lower",
+    "scipy.stats.uniform": "scipy.stats.uniform.lower",
 }
 
 


### PR DESCRIPTION
This fixes warnings like

```
/Users/lucascolley/ghq/github.com/scipy/scipy/build-install/usr/lib/python3.14/site-packages/scipy/stats/__init__.py:docstring of scipy.stats:479:<autosummary>:1: WARNING: py:obj reference target not found: scipy.stats.Logistic [ref.obj]
/Users/lucascolley/ghq/github.com/scipy/scipy/build-install/usr/lib/python3.14/site-packages/scipy/stats/__init__.py:docstring of scipy.stats:479:<autosummary>:1: WARNING: py:obj reference target not found: scipy.stats.Uniform [ref.obj]
/Users/lucascolley/ghq/github.com/scipy/scipy/doc/source/release/1.15.0-notes.rst:260: WARNING: py:obj reference target not found: scipy.stats.Uniform [ref.obj]
/Users/lucascolley/ghq/github.com/scipy/scipy/doc/source/release/1.15.0-notes.rst:266: WARNING: py:obj reference target not found: scipy.stats.Uniform [ref.obj]
/Users/lucascolley/ghq/github.com/scipy/scipy/doc/source/release/1.17.0-notes.rst:228: WARNING: py:obj reference target not found: scipy.stats.Logistic [ref.obj]
```

which showed on case-insensitive file systems.

[docs only]

#### AI Generation Disclosure
Fix found by claude