### PR TITLE
DOC/DEV: suppress `stats.mstats` deprecation warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -186,6 +186,11 @@ warnings.filterwarnings(
     message=r'.*py:obj reference target not found: scipy.misc.*',
     category=Warning,
 )
+warnings.filterwarnings(
+    'ignore',
+    message=r'.*`scipy.stats.mstats` is deprecated.*',
+    category=DeprecationWarning,
+)
 
 # See https://github.com/sphinx-doc/sphinx/issues/12589
 suppress_warnings = [


### PR DESCRIPTION
[docs only]

This fixes:

```
/Users/lucascolley/ghq/github.com/scipy/scipy/.pixi/envs/docs/lib/python3.14/site-packages/sphinx/ext/autosummary/__init__.py:774:
DeprecationWarning: `scipy.stats.mstats` is deprecated as of SciPy 2.0.0
and will be removed in SciPy 2.4.0. See function documentation for
alternatives.
```