### PR TITLE
BUG: stats.ttest_1samp: avoid variance range loss

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6320,8 +6320,13 @@ def ttest_1samp(a, popmean, axis=0, nan_policy="propagate", alternative="two-sid
     except ValueError as e:
         raise ValueError("`popmean.shape[axis]` must equal 1.") from e
     d = mean - popmean
-    v = _var(a, axis=axis, ddof=1)
-    denom = xp.sqrt(v / n)
+    # Scale the centered values before squaring: the variance can underflow
+    # or overflow even when the standard error is representable (gh-26113).
+    a_zero_mean = _demean(a, xp.expand_dims(mean, axis=axis), axis, xp=xp)
+    scale = xp.max(xp.abs(a_zero_mean), axis=axis, keepdims=True)
+    scale = xp.where(scale == 0, 1, scale)
+    v = xp.mean((a_zero_mean / scale)**2, axis=axis)
+    denom = xp.squeeze(scale, axis=axis) * xp.sqrt(v / df)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         t = xp.divide(d, denom)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4077,6 +4077,50 @@ class TestTTest_1samp:
         with pytest.raises(ValueError, match="nan_policy must be one of"):
             stats.ttest_1samp(x, 5.0, nan_policy='foobar')
 
+    @skip_xp_backends('jax.numpy', reason='needs stdtrit')
+    @pytest.mark.parametrize('dtype, exponent', [
+        ('float64', -600), ('float64', 0), ('float64', 600),
+        ('float32', -80), ('float32', 0), ('float32', 80),
+    ])
+    def test_scale_invariance(self, xp, dtype, exponent):
+        rtol = 5e-14 if dtype == 'float64' else 5e-6
+        dtype = getattr(xp, dtype)
+        cases = [
+            ([1, 2], 3., 0.20483276469913345, 0.5),
+            ([2, 3, 4], 3*np.sqrt(3), 1 - np.sqrt(27/29), 1/np.sqrt(3)),
+        ]
+
+        for a, statistic, pvalue, standard_error in cases:
+            a = xp.asarray(a, dtype=dtype)
+            ref = stats.ttest_1samp(a, 0.)
+            xp_assert_close(ref.statistic, xp.asarray(statistic, dtype=dtype),
+                            rtol=rtol)
+            xp_assert_close(ref.pvalue, xp.asarray(pvalue, dtype=dtype), rtol=rtol)
+            ref_ci = ref.confidence_interval()
+
+            scale = xp.asarray(2.**exponent, dtype=dtype)
+            res = stats.ttest_1samp(scale * a, 0.)
+            xp_assert_close(res.statistic, xp.asarray(statistic, dtype=dtype),
+                            rtol=rtol)
+            xp_assert_close(res.pvalue, xp.asarray(pvalue, dtype=dtype), rtol=rtol)
+            xp_assert_close(res._standard_error,
+                            xp.asarray(standard_error, dtype=dtype) * scale,
+                            rtol=rtol, atol=0)
+            ci = res.confidence_interval()
+            xp_assert_close(ci.low, ref_ci.low * scale, rtol=rtol, atol=0)
+            xp_assert_close(ci.high, ref_ci.high * scale, rtol=rtol, atol=0)
+
+        a = xp.asarray([[1, 2], [2, 3]], dtype=dtype)
+        popmean = xp.asarray([[0.5], [1.5]], dtype=dtype)
+        # Opposite scales in the same array require a separate scale per slice.
+        scales = xp.asarray([[2.**exponent], [2.**-exponent]], dtype=dtype)
+        a, popmean = scales * a, scales * popmean
+        for axis in (1, 0):
+            res = stats.ttest_1samp(a, popmean, axis=axis)
+            xp_assert_close(res.statistic, xp.full(2, 2., dtype=dtype), rtol=rtol)
+            xp_assert_close(res.pvalue,
+                            xp.full(2, 0.2951672353008665, dtype=dtype), rtol=rtol)
+            a, popmean = xp.permute_dims(a, (1, 0)), xp.permute_dims(popmean, (1, 0))
 
     @pytest.mark.filterwarnings("ignore:divide by zero encountered in divide")
     def test_1samp_alternative(self, xp):
@@ -5310,6 +5354,40 @@ class TestTTestRel:
         message = "nan_policy must be one of"
         with pytest.raises(ValueError, match=message):
             stats.ttest_rel(x, y, nan_policy='foobar')
+
+    @skip_xp_backends('jax.numpy', reason='needs stdtrit')
+    @pytest.mark.parametrize('dtype, exponent', [
+        ('float64', -600), ('float64', 0), ('float64', 600),
+        ('float32', -80), ('float32', 0), ('float32', 80),
+    ])
+    def test_scale_invariance(self, xp, dtype, exponent):
+        cases = [
+            ([1, 2], 3., 0.20483276469913345, 0.5),
+            ([2, 3, 4], 3*np.sqrt(3), 1 - np.sqrt(27/29), 1/np.sqrt(3)),
+        ]
+        rtol = 5e-14 if dtype == 'float64' else 5e-6
+        dtype = getattr(xp, dtype)
+
+        for a, statistic, pvalue, standard_error in cases:
+            a = xp.asarray(a, dtype=dtype)
+            b = xp.zeros(a.shape, dtype=dtype)
+            ref = stats.ttest_rel(a, b)
+            xp_assert_close(ref.statistic, xp.asarray(statistic, dtype=dtype),
+                            rtol=rtol)
+            xp_assert_close(ref.pvalue, xp.asarray(pvalue, dtype=dtype), rtol=rtol)
+            ref_ci = ref.confidence_interval()
+
+            scale = xp.asarray(2.**exponent, dtype=dtype)
+            res = stats.ttest_rel(scale * a, scale * b)
+            xp_assert_close(res.statistic, xp.asarray(statistic, dtype=dtype),
+                            rtol=rtol)
+            xp_assert_close(res.pvalue, xp.asarray(pvalue, dtype=dtype), rtol=rtol)
+            xp_assert_close(res._standard_error,
+                            xp.asarray(standard_error, dtype=dtype) * scale,
+                            rtol=rtol, atol=0)
+            ci = res.confidence_interval()
+            xp_assert_close(ci.low, ref_ci.low * scale, rtol=rtol, atol=0)
+            xp_assert_close(ci.high, ref_ci.high * scale, rtol=rtol, atol=0)
 
     def test_edge_cases(self, xp):
         # test zero division problem


### PR DESCRIPTION
**AI-assisted contribution:** The account holder approved sending this contribution for maintainer review. OpenAI Codex generated the implementation, regression tests, validation tooling and this description.

#### Reference issue

Closes gh-26113.

#### What does this implement/fix?

`ttest_1samp` and `ttest_rel` can return incorrect statistics, p-values and confidence intervals when squaring finite centered residuals overflows or underflows, even though the standard error is representable.

Compute the standard error from residuals normalized by their maximum absolute value along each reduction slice, then restore the scale after taking the square root. This avoids materializing the out-of-range variance. Zero-variance handling uses a safe internal divisor, and `ttest_rel` receives the correction through its existing delegation to `ttest_1samp`. The shared variance implementation and unrelated statistics functions are unchanged.

The regression tests cover float32/float64 scale extremes, one-sample and paired tests, NumPy and array-api-strict, standard errors, confidence intervals, and mixed tiny/huge slices with broadcast population means.

#### Additional information

Validation on a macOS arm64 source build:

- The new regressions demonstrated 16 failures before the production change.
- Affected t-test, axis/NaN-policy and masked-array checks: 211 passed, 9 skipped and 6 expected failures.
- 1,440 results compared with independent 100-digit mpmath references across both APIs, all alternatives, multiple sample sizes and extreme scaling factors.
- Project lint and `git diff --check` passed.

The correction covers representable means, centered residuals and standard errors. It does not redesign mean reduction or subtraction, address every variance consumer, or claim a performance improvement.

#### AI Generation Disclosure

OpenAI Codex was used to investigate the failure, implement the code and tests, execute builds and validation, inspect actual outputs, and prepare this PR description. The changed code, regression tests and this description are AI-generated under the account holder's direction. The numerical checks used independent reference calculations rather than treating passing test summaries as sufficient evidence. No claim of unaided authorship is made.
