### PR TITLE
BUG: spatial.ConvexHull: improve input validation to prevent segfault

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2492,7 +2492,7 @@ class ConvexHull(_QhullUser):
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if points.ndim != 2:
-            raise ValueError("Input `points` array must have 2 dimensions.")
+            raise ValueError("Input `points` array must be of shape (npoints, ndim).")
 
         if qhull_options is None:
             qhull_options = b""

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2491,6 +2491,9 @@ class ConvexHull(_QhullUser):
             raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
+        if points.ndim != 2:
+            raise ValueError("Input `points` array must have 2 dimensions.")
+
         if qhull_options is None:
             qhull_options = b""
             if points.shape[1] >= 5:

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -611,6 +611,11 @@ class TestConvexHull:
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.ConvexHull, masked_array)
 
+    @pytest.mark.parametrize("points", [np.ones((5,)), np.ones((5, 1, 3))])
+    def test_points_wrong_dim_fails(self, points):
+        with pytest.raises(ValueError, match="have 2 dimensions"):
+            qhull.ConvexHull(points)
+
     def test_array_with_nans_fails(self):
         points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.ConvexHull, points_with_nan)

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -613,7 +613,7 @@ class TestConvexHull:
 
     @pytest.mark.parametrize("points", [np.ones((5,)), np.ones((5, 1, 3))])
     def test_points_wrong_dim_fails(self, points):
-        with pytest.raises(ValueError, match="have 2 dimensions"):
+        with pytest.raises(ValueError, match="shape"):
             qhull.ConvexHull(points)
 
     def test_array_with_nans_fails(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #26136
#### What does this implement/fix?
<!--Please explain your changes.-->
Raises an error when input isn't 2D
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai