### PR TITLE
BUG:stats.kruskal: count the samples before promoting them

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3933,11 +3933,12 @@ def f_oneway(*samples, axis=0, equal_var=True):
 
     """
     xp = array_namespace(*samples)
-    samples = xp_promote(*samples, force_floating=True, xp=xp)
 
     if len(samples) < 2:
         raise TypeError('at least two inputs are required;'
                         f' got {len(samples)}.')
+
+    samples = xp_promote(*samples, force_floating=True, xp=xp)
 
     # ANOVA on N groups, each in its own array
     num_groups = len(samples)
@@ -8686,11 +8687,13 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
 
     """
     xp = array_namespace(*samples)
-    samples = xp_promote(*samples, force_floating=True, xp=xp)
 
+    # `xp_promote` returns a bare array for one argument, whose len is its rows.
     num_groups = len(samples)
     if num_groups < 2:
         raise ValueError("Need at least two groups in stats.kruskal()")
+
+    samples = xp_promote(*samples, force_floating=True, xp=xp)
 
     lengths = [sample.shape[-1] for sample in samples]
     if any(lengths) < 1:  # Only needed for `test_axis_nan_policy`

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8053,10 +8053,10 @@ class TestFOneWay:
             xp_assert_equal(result.pvalue, xp.asarray(xp.nan))
 
     @skip_xp_backends('dask.array', reason='lazy->reduced input validation')
-    @pytest.mark.parametrize('args', [(), ([1, 2, 3],)])
+    @pytest.mark.parametrize('args', [(), ([1, 2, 3],), ([[1, 2], [3, 4]],)])
     def test_too_few_inputs(self, args, xp):
         args = [xp.asarray(arg) for arg in args]
-        message = "At least two samples are required..."
+        message = "at least two inputs are required|At least two samples are required"
         with pytest.raises(TypeError, match=message):
             stats.f_oneway(*args)
 
@@ -8186,6 +8186,13 @@ class TestKruskal:
         message = r"Need at least two groups in stats.kruskal\(\)"
         with pytest.raises(ValueError, match=message):
             stats.kruskal()
+
+    @skip_xp_backends('dask.array', reason='lazy->reduced input validation')
+    @pytest.mark.parametrize('shape', [(3,), (3, 5)])
+    def test_one_sample(self, shape, xp):
+        message = r"Need at least two groups in stats.kruskal\(\)"
+        with pytest.raises(ValueError, match=message):
+            stats.kruskal(xp.ones(shape))
 
 
 @make_xp_test_case(stats.combine_pvalues)


### PR DESCRIPTION

#### Reference issue

None; found while reading the array-API promotion path.

#### What does this implement/fix?

`kruskal` and `f_oneway` take `len(samples)` after `xp_promote`, which returns a
bare array for a lone argument, so the length read is that array's rows. A single
2-D sample is accepted rather than refused: for a 3x5 `X`, `kruskal(X)` returns
exactly `kruskal(*X.T)`. A 1-D one clears the guard and raises `IndexError` at
`sample.shape[-1]` where the docstring promises `ValueError`. Counting before the
promotion fixes both, as `obrientransform` already does.

#### Additional information

These are the only two sites in `scipy/stats` taking `len()` of the name
`xp_promote` assigned.

#### AI Generation Disclosure

Claude Code was used as an assistant: it helped locate the ordering, wrote a
first version of the patch and the tests, and ran the suite. I read every line,
built SciPy from source, confirmed each new test fails without the change, and
ran `scipy/stats/tests` in full. This description is my own. I am responsible for
the contribution and can explain it.
