### PR TITLE
ENH: interpolate.make_smoothing_spline: support GCV algorithm for user defined knots

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2982,13 +2982,11 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     n = y.shape[0]
 
     def _gcv(lam):
-        try:
-            c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, compute_trace=True,
-            )
-        except LinAlgError:
-            # numerically singular for this lam
-            return np.inf
+        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg, 
+        # use it to estimate rcond of the banded system before solving
+        c, tr = _solve_smoothing_spline_coefficients(
+            xtwx_banded, lam, omega, xtwy, compute_trace=True,
+        )
         rss = np.sum(w * np.square(y - X @ c)) / n
         return rss / (1 - tr / n) ** 2
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2582,8 +2582,8 @@ def _compute_b_inv(A):
 
     Notes
     -----
-    The algorithm is based on the cholesky decomposition and, therefore,
-    in case matrix ``A`` is close to not positive defined, the function
+    The algorithm is based on the Cholesky decomposition and, therefore,
+    in case matrix ``A`` is close to not positive definite, the function
     raises LinalgError.
 
     Both matrices ``A`` and ``B`` are stored in LAPACK banded storage.
@@ -2935,7 +2935,7 @@ def _penalty_matrix_banded(t):
        ``t[p:p+3]``: zero at ``t[p]``, one at ``t[p+1]``, zero at
        ``t[p+2]``.
     3. ``Omega = C.T @ R @ C``, returned in LAPACK symmetric
-       lower-banded storage of shape ``(4, m)``, ``m = len(t) - 4``, as
+       upper-banded storage of shape ``(4, m)``, ``m = len(t) - 4``, as
        accepted by ``scipy.linalg.solveh_banded``.
 
     ``Omega`` depends on ``t`` only (no data enters), is symmetric
@@ -2967,19 +2967,11 @@ def _penalty_matrix_banded(t):
     omega = C.T @ R @ C
     omega_banded = np.zeros((4, m))
     for i in range(4):
-        # Convert to LAPACK symmetric lower-banded storage,
+        # Convert to LAPACK symmetric upper-banded storage,
         # as accepted by solveh_banded.
-        omega_banded[i, : m - i] = omega.diagonal(-i)
+        omega_banded[3 - i, i:] = omega.diagonal(i)
 
     return omega_banded
-
-def _lower_to_upper_banded(ab):
-    """Reorder LAPACK lower-banded symmetric storage into upper-banded."""
-    m = ab.shape[1]
-    upper = np.zeros_like(ab)
-    for d in range(ab.shape[0]):
-        upper[-1 - d, d:] = ab[d, :m - d]
-    return upper
 
 
 def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
@@ -2988,12 +2980,12 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
-    xtwx_upper = _lower_to_upper_banded(xtwx_banded)
 
     def _gcv(lam):
         try:
             c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, xtwx_upper=xtwx_upper)
+                xtwx_banded, lam, omega, xtwy, compute_trace=True,
+            )
         except LinAlgError:
             # numerically singular for this lam
             return np.inf
@@ -3008,16 +3000,16 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         xtwx_upper=None):
+                                         compute_trace=False):
     _lhs = XtWX_banded + lam * omega
-    c = solveh_banded(_lhs, XtWy, lower=True)
-    if xtwx_upper is None:
+    c = solveh_banded(_lhs, XtWy, lower=False)
+    if not compute_trace:
         return c, None
     # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
     # 7-banded, so only the central bands of the inverse are needed
     # (Hutchinson & de Hoog, upper-banded storage).
-    b_banded = _compute_b_inv(_lower_to_upper_banded(_lhs))
-    tr = b_banded * xtwx_upper
+    b_banded = _compute_b_inv(_lhs)
+    tr = b_banded * XtWX_banded
     tr[:-1] *= 2
     return c, tr.sum()
 
@@ -3099,9 +3091,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     XtWy = X.T @ (w * y)
     XtWX_banded = np.zeros((4, m))
     for i in range(4):
-        # Convert to LAPACK symmetric lower-banded storage,
+        # Convert to LAPACK symmetric upper-banded storage,
         # as accepted by solveh_banded.
-        XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
+        XtWX_banded[3 - i, i:] = XtWX.diagonal(i)
     if lam is None:
         lam = _make_smoothing_spline_user_knots_gcv(
             XtWX_banded, X, y, w, XtWy, omega)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2975,14 +2975,20 @@ def _penalty_matrix_banded(t):
 
 
 def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
-    """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
+    """Select lam by minimizing the GCV criterion over the dimensionless
+    s = log10(lam / r), r = tr(X^T W X) / tr(Omega), so the fixed search
+    window is scale-free."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
 
+    # `r` is the factor which upon division makes `lam`
+    # dimensionless.
+    r = xtwx_banded[3, :].sum() / omega[3, :].sum()
+
     def _gcv(lam):
-        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg, 
+        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg,
         # use it to estimate rcond of the banded system before solving
         c, tr = _solve_smoothing_spline_coefficients(
             xtwx_banded, lam, omega, xtwy, compute_trace=True,
@@ -2991,10 +2997,13 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
         return rss / (1 - tr / n) ** 2
 
     def _gcv_log(s):
-        return _gcv(10 ** s)
+        return _gcv(r * 10 ** s)
 
-    res = minimize_scalar(_gcv_log, bounds=(-14, 9), method="bounded")
-    lam_hat = 10 ** res.x
+    # The bounds of `log(lam/r)` are (eps, 1/eps) where `eps`
+    # is the machine precision 2.2 * 1e-16, hence (-15, 15) is
+    # strictly in the live area for the bounds.
+    res = minimize_scalar(_gcv_log, bounds=(-15, 15), method="bounded")
+    lam_hat = r * 10 ** res.x
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,10 +2973,31 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(x, y, w, t, axis, *, xp, device=None):
-    """Generalized Cross Validation (GCV) computation path for unequal knot
-    vectors and data points."""
-    pass
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
+    """Compute the appropriate smoothing parameter `lam` for cubic smoothing splines."""
+    # Implementation decisions detailed in the following companion report:
+    # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
+    n = y.shape[0]
+    def _gcv(lam):
+        c, tr = _solve_smoothing_spline_coefficients(
+            xtwx_banded, lam, omega, xtwy, gcv=True)
+        rss = np.sum(w * np.square(y - x @ c)) / n
+        return rss / (1 - tr / n) ** 2
+
+    def _gcv_log(s):
+        return _gcv(10 ** s)
+
+    res = minimize_scalar(_gcv_log, bounds=(-14, 9), method="bounded")
+    lam_hat = 10 ** res.x
+    return lam_hat
+
+def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy, gcv=False):
+    _lhs = XtWX_banded + lam * omega
+    c = solveh_banded(_lhs, XtWy, lower=True)
+    if gcv:
+        tr = np.sum((_lhs @ XtWX_banded).diagonal(0))
+        return (c, tr)
+    return c, None
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -2990,17 +3011,14 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     symmetric, so the system is solved with a banded Cholesky factorization.
     Assumes ``x``, ``y`` and ``w`` are already validated by the caller.
     """
-    if lam is None:
-        return _make_smoothing_spline_user_knots_gcv(
-            x, y, w, t, axis, xp, device=device
-        )
-    if np.ndim(lam) != 0:
-        raise NotImplementedError(
-            "`lam` must be a scalar (or a 0-d array) when `t` is provided; "
-            f"got an array of shape {np.shape(lam)}."
-        )
-    if lam < 0.:
-        raise ValueError('Regularization parameter should be non-negative')
+    if lam is not None:
+        if np.ndim(lam) != 0:
+            raise NotImplementedError(
+                "`lam` must be a scalar (or a 0-d array) when `t` is provided; "
+                f"got an array of shape {np.shape(lam)}."
+            )
+        if lam < 0.:
+            raise ValueError('Regularization parameter should be non-negative')
     if np.ndim(y) > 1:
         raise NotImplementedError(
             "batched `y` is not supported with user-provided knots yet; "
@@ -3062,8 +3080,10 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         # Convert to LAPACK symmetric lower-banded storage,
         # as accepted by solveh_banded.
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
+    if lam is None:
+        lam = _make_smoothing_spline_user_knots_gcv(XtWX_banded, XtWy)
     try:
-        c = solveh_banded(XtWX_banded + lam * omega, XtWy, lower=True)
+        c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:
         # why only the two extremes of lam can fail: companion report,
         # Sec. 15 FAQ 1 (link in make_smoothing_spline)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,20 +2973,31 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
+def _lower_to_upper_banded(ab):
+    """Reorder LAPACK lower-banded symmetric storage into upper-banded."""
+    m = ab.shape[1]
+    upper = np.zeros_like(ab)
+    for d in range(ab.shape[0]):
+        upper[-1 - d, d:] = ab[d, :m - d]
+    return upper
+
+
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
+    xtwx_upper = _lower_to_upper_banded(xtwx_banded)
+
     def _gcv(lam):
         try:
             c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, compute_trace=True)
+                xtwx_banded, lam, omega, xtwy, xtwx_upper=xtwx_upper)
         except LinAlgError:
             # numerically singular for this lam
             return np.inf
-        rss = np.sum(w * np.square(y - x @ c)) / n
+        rss = np.sum(w * np.square(y - X @ c)) / n
         return rss / (1 - tr / n) ** 2
 
     def _gcv_log(s):
@@ -2997,21 +3008,15 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         compute_trace=False):
+                                         xtwx_upper=None):
     _lhs = XtWX_banded + lam * omega
     c = solveh_banded(_lhs, XtWy, lower=True)
-    if not compute_trace:
+    if xtwx_upper is None:
         return c, None
     # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
     # 7-banded, so only the central bands of the inverse are needed
-    # (Hutchinson & de Hoog); convert lower- to upper-banded storage.
-    m = XtWX_banded.shape[1]
-    lhs_upper = np.zeros_like(_lhs)
-    xtwx_upper = np.zeros_like(XtWX_banded)
-    for d in range(4):
-        lhs_upper[3 - d, d:] = _lhs[d, :m - d]
-        xtwx_upper[3 - d, d:] = XtWX_banded[d, :m - d]
-    b_banded = _compute_b_inv(lhs_upper)
+    # (Hutchinson & de Hoog, upper-banded storage).
+    b_banded = _compute_b_inv(_lower_to_upper_banded(_lhs))
     tr = b_banded * xtwx_upper
     tr[:-1] *= 2
     return c, tr.sum()
@@ -3165,9 +3170,9 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, t=None, axis=0):
         repeated 4 times (clamped), and interior knots may repeat only to
         multiplicity 2 (higher multiplicity would allow kinks or jumps,
         for which the penalty :math:`\int (f'')^2` is not defined).
-        ``t`` can only be passed when ``lam``
-        is given explicitly. Default is None, in which case a clamped knot
-        vector at the data sites is used,
+        If ``lam`` is not given, it is selected automatically by
+        generalized cross-validation. Default is None, in which case a
+        clamped knot vector at the data sites is used,
         ``t = np.r_[[x[0]]*3, x, [x[-1]]*3]``.
     axis : int, optional
         The data axis. Default is zero.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,6 +2973,10 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
+def _make_smoothing_spline_user_knots_gcv(x, y, w, t, axis, *, xp, device=None):
+    """Generalized Cross Validation (GCV) computation path for unequal knot
+    vectors and data points."""
+    pass
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -2987,9 +2991,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     Assumes ``x``, ``y`` and ``w`` are already validated by the caller.
     """
     if lam is None:
-        raise NotImplementedError(
-            "automatic GCV selection of `lam` is not supported with user knots, "
-            "pass `lam` explicitly")
+        return _make_smoothing_spline_user_knots_gcv(
+            x, y, w, t, axis, xp, device=device
+        )
     if np.ndim(lam) != 0:
         raise NotImplementedError(
             "`lam` must be a scalar (or a 0-d array) when `t` is provided; "

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,14 +2973,16 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
-    """Compute the appropriate smoothing parameter `lam` for cubic smoothing splines."""
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
+                                          xtwx_dense):
+    """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
+    # Eq. (32)
     n = y.shape[0]
     def _gcv(lam):
         c, tr = _solve_smoothing_spline_coefficients(
-            xtwx_banded, lam, omega, xtwy, gcv=True)
+            xtwx_banded, lam, omega, xtwy, xtwx_dense=xtwx_dense)
         rss = np.sum(w * np.square(y - x @ c)) / n
         return rss / (1 - tr / n) ** 2
 
@@ -2991,13 +2993,17 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     lam_hat = 10 ** res.x
     return lam_hat
 
-def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy, gcv=False):
+def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
+                                         xtwx_dense=None):
     _lhs = XtWX_banded + lam * omega
-    c = solveh_banded(_lhs, XtWy, lower=True)
-    if gcv:
-        tr = np.sum((_lhs @ XtWX_banded).diagonal(0))
-        return (c, tr)
-    return c, None
+    if xtwx_dense is None:
+        return solveh_banded(_lhs, XtWy, lower=True), None
+    # factor once, then reuse it for the coefficients and for
+    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]  (solve, don't invert)
+    cb = cholesky_banded(_lhs, lower=True)
+    c = cho_solve_banded((cb, True), XtWy)
+    tr = np.trace(cho_solve_banded((cb, True), xtwx_dense))
+    return c, tr
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -3081,7 +3087,8 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         # as accepted by solveh_banded.
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
     if lam is None:
-        lam = _make_smoothing_spline_user_knots_gcv(XtWX_banded, XtWy)
+        lam = _make_smoothing_spline_user_knots_gcv(
+            XtWX_banded, X, y, w, XtWy, omega, XtWX.toarray())
     try:
         c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,16 +2973,19 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
-                                          xtwx_dense):
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
     def _gcv(lam):
-        c, tr = _solve_smoothing_spline_coefficients(
-            xtwx_banded, lam, omega, xtwy, xtwx_dense=xtwx_dense)
+        try:
+            c, tr = _solve_smoothing_spline_coefficients(
+                xtwx_banded, lam, omega, xtwy, compute_trace=True)
+        except LinAlgError:
+            # numerically singular for this lam
+            return np.inf
         rss = np.sum(w * np.square(y - x @ c)) / n
         return rss / (1 - tr / n) ** 2
 
@@ -2994,16 +2997,24 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         xtwx_dense=None):
+                                         compute_trace=False):
     _lhs = XtWX_banded + lam * omega
-    if xtwx_dense is None:
-        return solveh_banded(_lhs, XtWy, lower=True), None
-    # factor once, then reuse it for the coefficients and for
-    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]  (solve, don't invert)
-    cb = cholesky_banded(_lhs, lower=True)
-    c = cho_solve_banded((cb, True), XtWy)
-    tr = np.trace(cho_solve_banded((cb, True), xtwx_dense))
-    return c, tr
+    c = solveh_banded(_lhs, XtWy, lower=True)
+    if not compute_trace:
+        return c, None
+    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
+    # 7-banded, so only the central bands of the inverse are needed
+    # (Hutchinson & de Hoog); convert lower- to upper-banded storage.
+    m = XtWX_banded.shape[1]
+    lhs_upper = np.zeros_like(_lhs)
+    xtwx_upper = np.zeros_like(XtWX_banded)
+    for d in range(4):
+        lhs_upper[3 - d, d:] = _lhs[d, :m - d]
+        xtwx_upper[3 - d, d:] = XtWX_banded[d, :m - d]
+    b_banded = _compute_b_inv(lhs_upper)
+    tr = b_banded * xtwx_upper
+    tr[:-1] *= 2
+    return c, tr.sum()
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -3088,7 +3099,7 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
     if lam is None:
         lam = _make_smoothing_spline_user_knots_gcv(
-            XtWX_banded, X, y, w, XtWy, omega, XtWX.toarray())
+            XtWX_banded, X, y, w, XtWy, omega)
     try:
         c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -3105,7 +3105,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         lam = _make_smoothing_spline_user_knots_gcv(
             XtWX_banded, X, y, w, XtWy, omega)
     try:
-        c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
+        c, _ = _solve_smoothing_spline_coefficients(
+            XtWX_banded, lam, omega, XtWy, compute_trace=False,
+        )
     except LinAlgError as e:
         # why only the two extremes of lam can fail: companion report,
         # Sec. 15 FAQ 1 (link in make_smoothing_spline)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2954,6 +2954,25 @@ class TestSmoothingSpline:
         with assert_raises(err, match=match):
             make_smoothing_spline(_x_err, y, **kwargs)
 
+    @pytest.mark.parametrize("scale", [
+        pytest.param(4.0, id="normal"),
+        pytest.param(3e-6, id="tiny"),
+        pytest.param(1e6, id="huge"),
+    ])
+    def test_gcv_user_knots_scale_free(self, scale):
+        """Auto lam selection works at any data scale: the search window is
+        the dimensionless log10(lam / r), so it needs no absolute bounds."""
+        rng = np.random.default_rng(11)
+        x = np.sort(rng.uniform(0, scale, 50))
+        y = np.sin(2 * np.pi * 3 * x / scale) + 0.3 * rng.normal(size=50)
+        tk = np.linspace(x[0], x[-1], 15)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        f = make_smoothing_spline(x, y, t=t)
+        assert np.all(np.isfinite(f(x)))
+        # the fit should be reasonable.
+        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
+
     def test_gcv_user_knots_matches_grid_argmin(self):
         """GCV-selected fit agrees with the fit at the argmin of a log-lam grid."""
         rng = np.random.default_rng(42)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2918,8 +2918,6 @@ class TestSmoothingSpline:
         xp_assert_close(spl(x), oc_vals, atol=1e-10)
 
     @pytest.mark.parametrize("y, kwargs, err, match", [
-        pytest.param(_y_err, dict(t=_t_good), NotImplementedError,
-                     "pass `lam` explicitly", id="no-lam"),
         pytest.param(_y_err, dict(t=_t_good, lam=np.ones(5)),
                      NotImplementedError, "must be a scalar", id="array-lam"),
         pytest.param(_y_err, dict(t=_t_good, lam=-1.0),
@@ -2955,6 +2953,77 @@ class TestSmoothingSpline:
         # invalid inputs on the user-knots path raise with a clear message
         with assert_raises(err, match=match):
             make_smoothing_spline(_x_err, y, **kwargs)
+
+    def test_gcv_user_knots_matches_grid_argmin(self):
+        """GCV-selected fit agrees with the fit at the argmin of a log-lam grid."""
+        rng = np.random.default_rng(42)
+        x = np.sort(rng.uniform(0, 4, 60))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=60)
+        tk = np.linspace(x[0], x[-1], 15)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        n = len(x)
+        lams = np.logspace(-6, 3, 30)
+        eye = np.eye(n)
+        V = np.empty(len(lams))
+        for i, lam in enumerate(lams):
+            yhat = make_smoothing_spline(x, y, lam=lam, t=t)(x)
+            trA = sum(make_smoothing_spline(x, eye[:, k], lam=lam, t=t)(x)[k]
+                      for k in range(n))
+            V[i] = np.mean((y - yhat)**2) / (1 - trA / n)**2
+        lam_star = lams[np.argmin(V)]
+        f_auto = make_smoothing_spline(x, y, t=t)(x)
+        f_star = make_smoothing_spline(x, y, lam=lam_star, t=t)(x)
+        # the continuous search converges within one grid step of the grid
+        # argmin; on the flat GCV valley the fits are close, not bit identical.
+        xp_assert_close(f_auto, f_star, atol=5e-2)
+
+    def test_gcv_user_knots_master(self):
+        """At clamped t = x, GCV knot-path selection agrees with the t=None path."""
+        rng = np.random.default_rng(7)
+        x = np.sort(rng.uniform(0, 4, 50))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=50)
+        t = np.r_[[x[0]]*3, x, [x[-1]]*3]
+        f_old = make_smoothing_spline(x, y)(x)          # existing GCV path
+        f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
+        xp_assert_close(f_new, f_old, atol=5e-2)
+
+    def test_gcv_user_knots_weights(self):
+        """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""
+        rng = np.random.default_rng(3)
+        x = np.sort(rng.uniform(0, 4, 50))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=50)
+        tk = np.linspace(x[0], x[-1], 12)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        f_now = make_smoothing_spline(x, y, w=np.ones_like(x), t=t)(x)
+        f_no_w = make_smoothing_spline(x, y, t=t)(x)
+        xp_assert_close(f_now, f_no_w, atol=1e-12)
+        w = np.where(x < 2, 2.0, 0.5)
+        f_w = make_smoothing_spline(x, y, w=w, t=t)(x)
+        assert np.all(np.isfinite(f_w))
+
+    def test_gcv_user_knots_vs_R(self):
+        """GCV selection on fixed knots agrees with R's smooth.spline GCV."""
+        # Reproduction session (R 4.5.2):
+        #   x <- seq(0, 4, length.out = 25)
+        #   y <- sin(2 * x) + 0.25 * cos(11 * x)
+        #   fit <- smooth.spline(x, y, cv = FALSE,
+        #                        all.knots = c(0, c(0.8, 1.6, 2.4, 3.2)/4, 1))
+        #   predict(fit, x)$y    # fit$lambda = 2.463429220330e-04
+        x = np.linspace(0, 4, 25)
+        y = np.sin(2 * x) + 0.25 * np.cos(11 * x)
+        t = np.r_[[0.0]*4, [0.8, 1.6, 2.4, 3.2], [4.0]*4]
+        r_yhat = np.array([
+            0.186393846962, 0.398457768892, 0.615308455998, 0.802461275320,
+            0.925431593898, 0.949816825933, 0.858608383717, 0.673605986607,
+            0.421860372253, 0.130422278305, -0.173654841629, -0.463211951010,
+            -0.710952857343, -0.889572201770, -0.971764625430, -0.932419617350,
+            -0.779268094191, -0.545322368638, -0.264245078675, 0.030301137713,
+            0.307835131483, 0.561388945297, 0.794533303938, 1.010888642951,
+            1.214075397881])
+        f = make_smoothing_spline(x, y, t=t)(x)
+        xp_assert_close(f, r_yhat, atol=5e-4)
 
     def test_user_defined_knots_axis(self):
         # batched (n-D) `y` is not supported on the user-knots path yet,

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2988,30 +2988,6 @@ class TestSmoothingSpline:
         f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
         xp_assert_close(f_new, f_old, atol=5e-2)
 
-    @pytest.mark.xfail(
-        reason="pending review discussion on what to return for the "
-               "singular case")
-    def test_gcv_search_with_singular_lam_in_window(self):
-        """Auto lam selection succeeds even when part of the search window
-        is numerically singular for the given data scale."""
-        rng = np.random.default_rng(5)
-        x = np.sort(rng.uniform(0, 3e-6, 40))
-        y = np.sin(7e5 * x) + 0.1 * rng.normal(size=40)
-        tk = np.linspace(x[0], x[-1], 12)
-        tk[0], tk[-1] = x[0], x[-1]
-        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
-
-        # the upper end of the search window is numerically singular for
-        # this data scale: an explicit fit there raises
-        with assert_raises(ValueError, match="not positive definite"):
-            make_smoothing_spline(x, y, lam=1e9, t=t)
-
-        # the automatic search must route around that region
-        f = make_smoothing_spline(x, y, t=t)
-        assert np.all(np.isfinite(f(x)))
-        # and select a fit that tracks the signal, not the flattened limit
-        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
-
     def test_gcv_user_knots_weights(self):
         """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""
         rng = np.random.default_rng(3)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2476,7 +2476,7 @@ _t_mult5b = np.r_[[-2.0]*5, [0.0], [2.0]*4]               # boundary multiplicit
 _t_unclamped = np.r_[[-4., -3.5, -3., -2.], [0.], [2., 3., 3.5, 4.]]  # not clamped
 
 def _dense_omega(ab, m):
-    """Reconstruct a dense symmetric matrix from (4, m) lower-banded storage.
+    """Reconstruct a dense symmetric matrix from (4, m) upper-banded storage.
 
     Used for the penalty matrix Omega of the smoothing spline,
     ``Omega[i, j] = integral(B_i'' * B_j'')``, which
@@ -2484,9 +2484,9 @@ def _dense_omega(ab, m):
     """
     omega = np.zeros((m, m))
     for i in range(4):
-        omega += np.diag(ab[i, :m - i], -i)
+        omega += np.diag(ab[3 - i, i:], -i)
         if i > 0:
-            omega += np.diag(ab[i, :m - i], i)
+            omega += np.diag(ab[3 - i, i:], i)
     return omega
 
 @make_xp_test_case(make_smoothing_spline)
@@ -2987,6 +2987,30 @@ class TestSmoothingSpline:
         f_old = make_smoothing_spline(x, y)(x)          # existing GCV path
         f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
         xp_assert_close(f_new, f_old, atol=5e-2)
+
+    @pytest.mark.xfail(
+        reason="pending review discussion on what to return for the "
+               "singular case")
+    def test_gcv_search_with_singular_lam_in_window(self):
+        """Auto lam selection succeeds even when part of the search window
+        is numerically singular for the given data scale."""
+        rng = np.random.default_rng(5)
+        x = np.sort(rng.uniform(0, 3e-6, 40))
+        y = np.sin(7e5 * x) + 0.1 * rng.normal(size=40)
+        tk = np.linspace(x[0], x[-1], 12)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+
+        # the upper end of the search window is numerically singular for
+        # this data scale: an explicit fit there raises
+        with assert_raises(ValueError, match="not positive definite"):
+            make_smoothing_spline(x, y, lam=1e9, t=t)
+
+        # the automatic search must route around that region
+        f = make_smoothing_spline(x, y, t=t)
+        assert np.all(np.isfinite(f(x)))
+        # and select a fit that tracks the signal, not the flattened limit
+        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
 
     def test_gcv_user_knots_weights(self):
         """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""


### PR DESCRIPTION
#### Reference issue
Part 2 of gh-25862. That PR added support for user-provided knots `t` with an explicit `lam`, this one adds automatic `lam` selection via GCV, so `lam=None` works for user knots the same way it does for the default knots.

#### What does this implement/fix?
This PR adapts the Generalized Cross Validation algorithm for the case when user passes the knot vector. The previous GCV path assumed that knots are always at the data sites. This PR implements the general case of the GCV algorithm
implementing the formulas defined in [this](https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf) companion report Section 12.

#### Additional information

**Design**
- The search is scale-free. We compute the scale `r = tr(XᵀWX) / tr(Ω)` and minimize the GCV criterion over `s = log10(lam / r)` in a fixed bounded window, instead of searching `lam` directly.
- Rescaling `x` or `y` rescales the selected `lam` by exactly the right factor and returns the same spline.
- The window edges match the two failure extremes of the linear system: below it the penalty is under the roundoff of the data term, above it the system is numerically singular. This also avoids the failures of linear-scale search discussed in gh-23472.

**Implementation**
- The influence-matrix trace is computed from the banded Cholesky factor using de Hoog's formula, so each evaluation of the criterion is `O(m)`. No dense inverse is formed.
- Upper-banded (LAPACK) storage is used throughout the user-knots path.
- Solver failures inside the search propagate as `LinAlgError`.
- TODO left in the code: estimate the condition number via LAPACK `dpbcon` once it is wrapped in `scipy.linalg` (separate follow-up PR later).

**Tests**
- Main test: knots at all data sites must reproduce the default GCV path.
- Grid-argmin check of the GCV criterion.
- Auto-selection compared against R's `smooth.spline` with forced knots.
- Weighted data.
- Scale-invariance at scales from `3e-6` to `1e6`.

#### AI Generation Disclosure
AI was used in finding bugs, writing some doc/comments, executing shell commands and brainstorming. However, code and logic is all mine and not AI generated!
