### PR TITLE
ENH: stats: add Array API support for `trim1` and `trimboth`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3482,7 +3482,7 @@ def sigmaclip(a, low=4., high=4., *, nan_policy='propagate'):
     return SigmaclipResult(c, critlower, critupper)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def trimboth(a, proportiontocut, axis=0):
     """Slice off a proportion of items from both ends of an array.
 
@@ -3547,13 +3547,14 @@ def trimboth(a, proportiontocut, axis=0):
     (6,)
 
     """
-    a = np.asarray(a)
+    xp = array_namespace(a)
+    a = xp.asarray(a)
 
-    if a.size == 0:
+    if xp_size(a) == 0:
         return a
 
     if axis is None:
-        a = a.ravel()
+        a = xp_ravel(a)
         axis = 0
 
     nobs = a.shape[axis]
@@ -3562,14 +3563,15 @@ def trimboth(a, proportiontocut, axis=0):
     if (lowercut >= uppercut):
         raise ValueError("Proportion too big.")
 
-    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
+    atmp = (np.partition(a, (lowercut, uppercut - 1), axis) if is_numpy(xp)
+            else xp.sort(a, axis=axis))
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
     return atmp[tuple(sl)]
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def trim1(a, proportiontocut, tail='right', axis=0):
     """Slice off a proportion from ONE end of the passed array distribution.
 
@@ -3631,16 +3633,17 @@ def trim1(a, proportiontocut, tail='right', axis=0):
     (6,)
 
     """
-    a = np.asarray(a)
+    xp = array_namespace(a)
+    a = xp.asarray(a)
     if axis is None:
-        a = a.ravel()
+        a = xp_ravel(a)
         axis = 0
 
     nobs = a.shape[axis]
 
     # avoid possible corner case
     if proportiontocut >= 1:
-        return []
+        return xp.asarray([])
 
     if tail.lower() == 'right':
         lowercut = 0
@@ -3650,7 +3653,8 @@ def trim1(a, proportiontocut, tail='right', axis=0):
         lowercut = int(proportiontocut * nobs)
         uppercut = nobs
 
-    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
+    atmp = (np.partition(a, (lowercut, uppercut - 1), axis) if is_numpy(xp)
+            else xp.sort(a, axis=axis))
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7401,53 +7401,56 @@ class TestGSTD:
         xp_assert_close(gstd_actual, gstd_desired)
 
 
+@make_xp_test_case(stats.trimboth, stats.trim1)
 class TestTrim:
     # test trim functions
-    def test_trim1(self):
-        a = np.arange(11)
-        assert_equal(np.sort(stats.trim1(a, 0.1)), np.arange(10))
-        assert_equal(np.sort(stats.trim1(a, 0.2)), np.arange(9))
-        assert_equal(np.sort(stats.trim1(a, 0.2, tail='left')),
-                     np.arange(2, 11))
-        assert_equal(np.sort(stats.trim1(a, 3/11., tail='left')),
-                     np.arange(3, 11))
-        assert_equal(stats.trim1(a, 1.0), [])
-        assert_equal(stats.trim1(a, 1.0, tail='left'), [])
+    def test_trim1(self, xp):
+        a = xp.arange(11)
+        empty = xp.asarray([])
+        xp_assert_equal(xp.sort(stats.trim1(a, 0.1)), xp.arange(10))
+        xp_assert_equal(xp.sort(stats.trim1(a, 0.2)), xp.arange(9))
+        xp_assert_equal(xp.sort(stats.trim1(a, 0.2, tail='left')),
+                     xp.arange(2, 11))
+        xp_assert_equal(xp.sort(stats.trim1(a, 3/11., tail='left')),
+                     xp.arange(3, 11))
+        xp_assert_equal(stats.trim1(a, 1.0), empty)
+        xp_assert_equal(stats.trim1(a, 1.0, tail='left'), empty)
 
         # empty input
-        assert_equal(stats.trim1([], 0.1), [])
-        assert_equal(stats.trim1([], 3/11., tail='left'), [])
-        assert_equal(stats.trim1([], 4/6.), [])
+        xp_assert_equal(stats.trim1(empty, 0.1), empty)
+        xp_assert_equal(stats.trim1(empty, 3/11., tail='left'), empty)
+        xp_assert_equal(stats.trim1(empty, 4/6.), empty)
 
         # test axis
-        a = np.arange(24).reshape(6, 4)
-        ref = np.arange(4, 24).reshape(5, 4)  # first row trimmed
+        a = xp.reshape(xp.arange(24), (6, 4))
+        ref = xp.reshape(xp.arange(4, 24), (5, 4))  # first row trimmed
 
         axis = 0
         trimmed = stats.trim1(a, 0.2, tail='left', axis=axis)
-        assert_equal(np.sort(trimmed, axis=axis), ref)
+        xp_assert_equal(xp.sort(trimmed, axis=axis), ref)
 
         axis = 1
         trimmed = stats.trim1(a.T, 0.2, tail='left', axis=axis)
-        assert_equal(np.sort(trimmed, axis=axis), ref.T)
+        xp_assert_equal(xp.sort(trimmed, axis=axis), ref.T)
 
-    def test_trimboth(self):
-        a = np.arange(11)
-        assert_equal(np.sort(stats.trimboth(a, 3/11.)), np.arange(3, 8))
-        assert_equal(np.sort(stats.trimboth(a, 0.2)),
-                     np.array([2, 3, 4, 5, 6, 7, 8]))
-        assert_equal(np.sort(stats.trimboth(np.arange(24).reshape(6, 4), 0.2)),
-                     np.arange(4, 20).reshape(4, 4))
-        assert_equal(np.sort(stats.trimboth(np.arange(24).reshape(4, 6).T,
-                                            2/6.)),
-                     np.array([[2, 8, 14, 20], [3, 9, 15, 21]]))
+    def test_trimboth(self, xp):
+        a = xp.arange(11)
+        xp_assert_equal(xp.sort(stats.trimboth(a, 3/11.)), xp.arange(3, 8))
+        xp_assert_equal(xp.sort(stats.trimboth(a, 0.2)),
+                        xp.asarray([2, 3, 4, 5, 6, 7, 8]))
+        xp_assert_equal(xp.sort(stats.trimboth(xp.reshape(xp.arange(24), (6, 4)), 0.2)),
+                        xp.reshape(xp.arange(4, 20), (4, 4)))
+        xp_assert_equal(xp.sort(stats.trimboth(xp.reshape(xp.arange(24), (4, 6)).T,
+                                               2/6.)),
+                        xp.asarray([[2, 8, 14, 20], [3, 9, 15, 21]]))
         assert_raises(ValueError, stats.trimboth,
-                      np.arange(24).reshape(4, 6).T, 4/6.)
+                      xp.reshape(xp.arange(24), (4, 6)).T, 4/6.)
 
         # empty input
-        assert_equal(stats.trimboth([], 0.1), [])
-        assert_equal(stats.trimboth([], 3/11.), [])
-        assert_equal(stats.trimboth([], 4/6.), [])
+        empty = xp.asarray([])
+        xp_assert_equal(stats.trimboth(empty, 0.1), empty)
+        xp_assert_equal(stats.trimboth(empty, 3/11.), empty)
+        xp_assert_equal(stats.trimboth(empty, 4/6.), empty)
 
 
 @make_xp_test_case(stats.trim_mean)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
It appeared that those were missing Array API support. This PR fixes that.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to review.