### PR TITLE
BLD: add portable configuration output for reproducible wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.buildplat[4] }}
         run: |
           if [[ "${BLAS_VARIANT}" == "accelerate" ]]; then
-            echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
+            echo "CIBW_CONFIG_SETTINGS=setup-args=-Dblas=accelerate setup-args=-Dconfig-output=portable" >> "$GITHUB_ENV"
 
             # Builds with Accelerate only target macOS>=14.0
             CIBW_ENV="CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=14.0 INSTALL_OPENBLAS=false"

--- a/doc/source/building/compilers_and_options.rst
+++ b/doc/source/building/compilers_and_options.rst
@@ -85,7 +85,7 @@ Controlling installed configuration details
 and build machine/configuration. This is quite useful for diagnostics, but
 not reproducible across machines - at least for relocatable packages - because
 it embeds build machine paths and compiler options (which can also contain
-paths. There is a build option to achieve reproducible builds:
+paths). There is a build option to achieve reproducible builds:
 ``-Dconfig-output``.
 
 The default, ``-Dconfig-output=auto``, selects portable output when

--- a/doc/source/building/compilers_and_options.rst
+++ b/doc/source/building/compilers_and_options.rst
@@ -78,6 +78,31 @@ or::
     spin build -j6
 
 
+Controlling installed configuration details
+--------------------------------------------
+
+``scipy.show_config()`` provides a lot of detail about build-time dependencies
+and build machine/configuration. This is quite useful for diagnostics, but
+not reproducible across machines - at least for relocatable packages - because
+it embeds build machine paths and compiler options (which can also contain
+paths. There is a build option to achieve reproducible builds:
+``-Dconfig-output``.
+
+The default, ``-Dconfig-output=auto``, selects portable output when
+``SOURCE_DATE_EPOCH`` is set at Meson configuration time, and full output
+otherwise. Redistributors can always omit build-host paths and other
+host-dependent details from binary artifacts with::
+
+    python -m build -Csetup-args=-Dconfig-output=portable
+
+Use ``-Dconfig-output=full`` to retain detailed diagnostics even when
+``SOURCE_DATE_EPOCH`` is set.  Portable mode reports paths,
+compiler commands, all compiler and linker flags (including optimization
+flags), and OpenBLAS configuration as ``unknown``.  It keeps compiler IDs,
+versions, linker IDs, dependency versions, ABI information, and machine details.
+Explicit ``full`` and ``portable`` settings override the automatic choice.
+
+
 Use GCC and Clang builds in parallel
 ------------------------------------
 

--- a/meson.options
+++ b/meson.options
@@ -24,6 +24,11 @@ option('use-pythran', type: 'boolean', value: true,
         description: 'If set to false, disables using Pythran (it falls back ' +
                      'to either pure Python code or Cython code, depending on ' +
                      'the implementation).')
+option('config-output', type: 'combo', choices: ['auto', 'full', 'portable'],
+       value: 'auto',
+       description: 'Detail level for the installed scipy.__config__; use ' +
+                    'portable for redistributable binary artifacts. ' +
+                    'auto selects portable when SOURCE_DATE_EPOCH is set')
 option('use-system-libraries', type: 'array',
         choices : ['none', 'all', 'auto', 'boost.math', 'qhull'], value : ['none'],
         description: 'Choose which system libraries for subprojects ' +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,9 @@ before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
+[tool.cibuildwheel.config-settings]
+setup-args = ["-Dconfig-output=portable"]
+
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
@@ -278,7 +281,7 @@ repair-wheel-command = "pyodide auditwheel repair --libdir {project}/.blis/lib -
 test-requires = ["pytest", "pytest-split", "hypothesis", "threadpoolctl", "pooch"]
 test-command = "bash {project}/tools/wheels/cibw_test_command_pyodide.sh"
 [tool.cibuildwheel.pyodide.config-settings]
-setup-args = ["-Dblas=blis", "-Dlapack=semicolon-lapack"]
+setup-args = ["-Dblas=blis", "-Dlapack=semicolon-lapack", "-Dconfig-output=portable"]
 build-dir = "build/pyodide"
 
 [tool.cibuildwheel.pyodide.environment]

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -541,26 +541,40 @@ machines = {
 }
 
 conf_data = configuration_data()
+portable_config_output = get_option('config-output') == 'portable'
+if get_option('config-output') == 'auto'
+  portable_config_output = run_command(
+    py3, '-c', 'import os; print("SOURCE_DATE_EPOCH" in os.environ)',
+    check: true
+  ).stdout().strip() == 'True'
+endif
 
 # Set compiler information
 foreach name, compiler : compilers
   conf_data.set(name + '_COMP', compiler.get_id())
   conf_data.set(name + '_COMP_LINKER_ID', compiler.get_linker_id())
   conf_data.set(name + '_COMP_VERSION', compiler.version())
-  conf_data.set(name + '_COMP_CMD_ARRAY', ', '.join(compiler.cmd_array()))
-  conf_data.set(name + '_COMP_ARGS', ', '.join(
-      get_option(name.to_lower() + '_args')
+  if portable_config_output
+    # Commands and flags can embed build paths in compiler-specific syntax.
+    conf_data.set(name + '_COMP_CMD_ARRAY', 'unknown')
+    conf_data.set(name + '_COMP_ARGS', 'unknown')
+    conf_data.set(name + '_COMP_LINK_ARGS', 'unknown')
+  else
+    conf_data.set(name + '_COMP_CMD_ARRAY', ', '.join(compiler.cmd_array()))
+    conf_data.set(name + '_COMP_ARGS', ', '.join(
+        get_option(name.to_lower() + '_args')
+      )
     )
-  )
-  conf_data.set(name + '_COMP_LINK_ARGS', ', '.join(
-      get_option(name.to_lower() + '_link_args')
+    conf_data.set(name + '_COMP_LINK_ARGS', ', '.join(
+        get_option(name.to_lower() + '_link_args')
+      )
     )
-  )
+  endif
 endforeach
 # Add `pythran` information if present
 if use_pythran
   conf_data.set('PYTHRAN_VERSION', pythran.version())
-  conf_data.set('PYTHRAN_INCDIR', incdir_pythran)
+  conf_data.set('PYTHRAN_INCDIR', portable_config_output ? 'unknown' : incdir_pythran)
 endif
 
 # Machines CPU and system information
@@ -574,7 +588,7 @@ endforeach
 conf_data.set('CROSS_COMPILED', meson.is_cross_build().to_string())
 
 # Python information
-conf_data.set('PYTHON_PATH', py3.full_path().replace('\\', '/'))
+conf_data.set('PYTHON_PATH', portable_config_output ? 'unknown' : py3.full_path().replace('\\', '/'))
 conf_data.set('PYTHON_VERSION', py3.language_version())
 
 # Information on dependencies, to store in `scipy/__config__.py`
@@ -590,10 +604,17 @@ foreach name, dep : dependency_map
   if dep.found()
     conf_data.set(name + '_VERSION', dep.version())
     conf_data.set(name + '_TYPE_NAME', dep.type_name())
-    conf_data.set(name + '_INCLUDEDIR', dep.get_variable('includedir', default_value: 'unknown'))
-    conf_data.set(name + '_LIBDIR', dep.get_variable('libdir', default_value: 'unknown'))
-    conf_data.set(name + '_OPENBLAS_CONFIG', dep.get_variable('openblas_config', default_value: 'unknown'))
-    conf_data.set(name + '_PCFILEDIR', dep.get_variable('pcfiledir', default_value: 'unknown').replace('\\', '/'))
+    if portable_config_output
+      conf_data.set(name + '_INCLUDEDIR', 'unknown')
+      conf_data.set(name + '_LIBDIR', 'unknown')
+      conf_data.set(name + '_OPENBLAS_CONFIG', 'unknown')
+      conf_data.set(name + '_PCFILEDIR', 'unknown')
+    else
+      conf_data.set(name + '_INCLUDEDIR', dep.get_variable('includedir', default_value: 'unknown'))
+      conf_data.set(name + '_LIBDIR', dep.get_variable('libdir', default_value: 'unknown'))
+      conf_data.set(name + '_OPENBLAS_CONFIG', dep.get_variable('openblas_config', default_value: 'unknown'))
+      conf_data.set(name + '_PCFILEDIR', dep.get_variable('pcfiledir', default_value: 'unknown').replace('\\', '/'))
+    endif
     conf_data.set(name + '_HAS_ILP64', use_ilp64.to_string())
   endif
 endforeach


### PR DESCRIPTION
Build paths and the host-selected OpenBLAS CPU core can make `scipy/__config__.py` differ between otherwise identical wheel builds. Portable output omits paths, commands, flags, and OpenBLAS configuration while retaining versions and ABI metadata.

Default to auto: select portable when `SOURCE_DATE_EPOCH` (see https://reproducible-builds.org/docs/source-date-epoch/) is set, full otherwise. Allow explicit overrides and use `portable` for `cibuildwheel`.


#### AI Generation Disclosure

Implemented with Codex Astra 6, polished by hand. 
