### PR TITLE
BUG: sparse.linalg.LinearOperator: fix pickling `__slots__`

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -259,13 +259,25 @@ class LinearOperator:
         self._xp = xp
 
     def __getstate__(self):
-        state = self.__dict__.copy()
-        state["_xp"] = state["_xp"].empty(0)
-        return state
+        result = super().__getstate__()
+        if isinstance(result, tuple):
+            dict_state, slots_state = result
+        else:
+            dict_state, slots_state = result, None
+        dict_state = dict(dict_state) if dict_state else {}
+        dict_state["_xp"] = dict_state["_xp"].empty(0)
+        return dict_state, slots_state
 
     def __setstate__(self, state):
-        self._xp = array_namespace(state.pop("_xp"))
-        self.__dict__.update(state)
+        # scipy 1.18.{0,1} pickled state as a flat dict with no `__slots__` support;
+        # keep loading those without crashing.
+        dict_state, slots_state = state if isinstance(state, tuple) else (state, None)
+        dict_state = dict(dict_state) if dict_state else {}
+        self._xp = array_namespace(dict_state.pop("_xp"))
+        self.__dict__.update(dict_state)
+        if slots_state:
+            for slot, value in slots_state.items():
+                setattr(self, slot, value)
 
     def _init_dtype(self):
         """Determine the dtype by executing `matvec` on an `int8` test vector.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -923,15 +923,6 @@ def test_attributes(xp):
         assert hasattr(op, "shape")
         assert hasattr(op, "_matvec")
 
-@pytest.mark.xfail_xp_backends('dask.array', reason=(
-    "dask does not support broadcast_shapes(). "
-    "See: https://github.com/data-apis/array-api-compat/issues/439"
-))
-def matvec_for_pickle(x):
-    """ Needed for test_pickle as local functions are not pickleable """
-    return x
-
-
 @pytest.mark.skip_xp_backends(
     "array_api_strict",
     reason="pickle-ability is not guaranteed by the standard"
@@ -940,17 +931,62 @@ def matvec_for_pickle(x):
     "dask does not support broadcast_shapes(). "
     "See: https://github.com/data-apis/array-api-compat/issues/439"
 ))
-def test_pickle(xp):
-    import pickle
+class TestPickle:
+    class _SlottedOperator(interface.LinearOperator):
+        """LinearOperator subclass storing state in __slots__, for gh-25871."""
 
-    protocol_min = 0 if is_numpy(xp) else 2
-    for protocol in range(protocol_min, pickle.HIGHEST_PROTOCOL + 1):
-        A = interface.LinearOperator((3, 3), matvec_for_pickle, xp=xp)
-        s = pickle.dumps(A, protocol=protocol)
-        B = pickle.loads(s)
+        __slots__ = ["_diagonal"]
 
-        for k in A.__dict__:
-            assert getattr(A, k) == getattr(B, k)
+        def __init__(self, diagonal, xp):
+            self._diagonal = diagonal
+            super().__init__(
+                dtype=diagonal.dtype, shape=(diagonal.shape[0],) * 2, xp=xp
+            )
+
+        def _matvec(self, x):
+            return self._diagonal * x
+
+    @staticmethod
+    def _matvec_for_pickle(x):
+        """ Needed for test_pickle as local functions are not pickleable """
+        return x
+
+    def test_pickle(self, xp):
+        import pickle
+
+        protocol_min = 0 if is_numpy(xp) else 2
+        for protocol in range(protocol_min, pickle.HIGHEST_PROTOCOL + 1):
+            A = interface.LinearOperator((3, 3), self._matvec_for_pickle, xp=xp)
+            s = pickle.dumps(A, protocol=protocol)
+            B = pickle.loads(s)
+
+            for k in A.__dict__:
+                assert getattr(A, k) == getattr(B, k)
+
+    def test_pickle_slots(self, xp):
+        # gh-25871: __slots__-stored state must survive a pickle round-trip.
+        import pickle
+
+        diagonal = xp.asarray([1.0, 2.0, 3.0])
+        A = self._SlottedOperator(diagonal, xp)
+        B = pickle.loads(pickle.dumps(A))
+
+        xp_assert_equal(B._diagonal, diagonal)
+        xp_assert_equal(B.matvec(xp.ones(3)), diagonal)
+
+    def test_setstate_legacy_pickle(self):
+        # gh-25871: scipy 1.18.{0,1} pickled state as a flat dict with no __slots__
+        # support; __setstate__ must still load those without crashing
+        # (even though any lost slot data is unrecoverable).
+        op = self._SlottedOperator.__new__(self._SlottedOperator)
+        legacy_state = {
+            "dtype": np.dtype(np.float64), "shape": (3, 3), "ndim": 2,
+            "_xp": np.empty(0),
+        }
+        op.__setstate__(legacy_state)
+        assert op.dtype == np.dtype(np.float64)
+        assert not hasattr(op, "_diagonal")
+
 
 @pytest.mark.xfail_xp_backends('dask.array', reason=(
     "dask does not support broadcast_shapes(). "


### PR DESCRIPTION
[skip circle]

closes gh-25871

Hey @antoinecollet5, please could you test whether this patch fixes the problem for you?

Might be worth checking if a similar consideration applies for other classes in the repo.

#### AI Generation Disclosure
All code written by claude, guided by me.