### PR TITLE
BUG: preserve sparse sum out identity with dtype

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1482,6 +1482,8 @@ class _spbase(SparseABC):
             if hasattr(self, 'sum_duplicates'):
                 self.sum_duplicates()
             temp = self.astype(dtype, copy=False).sum(axis=axis, dtype=None, out=out)
+            if out is not None:
+                return out
             return temp.astype(dtype, copy=False)
 
         # Note: all valid 1D axis values are canonically `None`.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1106,8 +1106,8 @@ class _TestCommon:
                 if input_is_complex and not output_is_complex:
                     continue
 
-                # Check axis=None
                 with np.errstate(over='ignore'):
+                    # Check axis=None
                     dat_sum = dat.sum(dtype=output_dtype)
                     datsp_sum = datsp.sum(dtype=output_dtype)
                     assert_allclose(datsp_sum, dat_sum)
@@ -1124,6 +1124,18 @@ class _TestCommon:
                     datsp_sum = datsp.sum(axis=1, dtype=output_dtype)
                     assert_allclose(datsp_sum, dat_sum)
                     assert_equal(datsp_sum.dtype, dat_sum.dtype)
+
+    def test_sum_dtype_out_preserves_identity(self):
+        if not self.is_array_test:
+            pytest.skip("sparse matrices are not affected")
+
+        datsp = self.spcreator([[0, 1], [2, 0]], dtype=np.float32)
+        out = np.empty(2, dtype=np.float64)
+
+        result = datsp.sum(axis=0, dtype=np.float32, out=out)
+
+        assert result is out
+        assert_array_equal(result, [2, 1])
 
     def test_sum_dtype_fractional_to_int(self):
         # Test sum with dtype=int on data of float input dtype


### PR DESCRIPTION
Fixes #26149.

## Summary

- Preserve the identity of a caller-provided `out` array when sparse `sum` receives an explicit `dtype`.
- Add a regression test covering a `float32` computation into a `float64` output array.

## Testing

- `python3 -m compileall -q scipy/sparse/_base.py scipy/sparse/tests/test_base.py`
- `git diff --check`
- The focused SciPy test cannot run in this checkout because the generated SciPy build configuration is absent and the required build tools are not installed.

## AI disclosure

AI was used to inspect the issue, reason about the existing implementation, draft the minimal code/test change, and prepare this pull request text. The code and text in this PR were reviewed and understood by the contributor before submission.
