### PR TITLE
Updated test_streams for assertion error on python 3.14

### DIFF
--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -198,7 +198,7 @@ class TestZlibInputStream:
         assert_(stream.all_data_read())
 
     @pytest.mark.skipif(
-            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            (sys.version_info >= (3, 14)),
             reason='gh-23185')
     def test_all_data_read_overlap(self):
         COMPRESSION_LEVEL = 6
@@ -217,7 +217,7 @@ class TestZlibInputStream:
         assert_(stream.all_data_read())
 
     @pytest.mark.skipif(
-            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            (sys.version_info >= (3, 14)),
             reason='gh-23185')
     def test_all_data_read_bad_checksum(self):
         COMPRESSION_LEVEL = 6


### PR DESCRIPTION
Updated skip condition for tests to remove platform check for `test_all_data_read_overlap` and `test_all_data_read_bad_checksum`

#### Reference issue
https://github.com/scipy/scipy/issues/23185

#### What does this implement/fix?
Remove the platform check, as this fails on Linux for 3.14.

#### Additional information

