### PR TITLE
BUG: sparse: Fix A.sum to return out object when dtype specified and axis=0

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1481,8 +1481,10 @@ class _spbase(SparseABC):
             # Before casting to the requested dtype, canonicalize duplicates and zeros.
             if hasattr(self, 'sum_duplicates'):
                 self.sum_duplicates()
-            temp = self.astype(dtype, copy=False).sum(axis=axis, dtype=None, out=out)
-            return temp.astype(dtype, copy=False)
+            temp = self.astype(dtype, copy=False)
+            if out is not None:
+                return temp.sum(axis=axis, dtype=None, out=out)
+            return temp.sum(axis=axis).astype(dtype, copy=False)
 
         # Note: all valid 1D axis values are canonically `None`.
         if axis is None:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1159,6 +1159,19 @@ class _TestCommon:
         datsp.sum(axis=1, out=datsp_out)
         assert_array_almost_equal(dat_out, datsp_out)
 
+        # check when out and dtype do not agree. See gh-26149
+        # convert to dtype before summing, then put into out
+        for ax in (1, 0):
+            out_shape = (3,) if self.is_array_test else (3, 1) if ax else (1, 3)
+            dat_out = np.zeros(out_shape)
+            datsp_out = np.zeros(out_shape) if not keep else matrix(np.zeros(out_shape))
+            for dtype in (np.int32, np.float32):
+                ret = (dat * 0.1).sum(axis=ax, dtype=dtype, out=dat_out, keepdims=keep)
+                retsp = (datsp * 0.1).sum(axis=ax, dtype=dtype, out=datsp_out)
+                assert ret is dat_out
+                assert retsp is datsp_out
+                assert_array_almost_equal(dat_out, datsp_out)
+
         # check that wrong shape out parameter raises
         with assert_raises(ValueError, match="output parameter"):
             datsp.sum(out=array([0]))


### PR DESCRIPTION
Fixes #26149

Sparse `sum()` method with `dtype` and `out` specified and `axis=0` does not return the `out` object when the requested `dtype` does not agree with `out.dtype`.  It should match numpy behavior: cast to the requested dtype before the sum occurs, put the result into `out` and return the `out` object. This broken corner case was due to PR #24496 and so was released in 1.18. So it should be backported in a future minor release if one occurs.

In this PR I added two commits: a test to reveal the bug and then the fix to enable the test to pass. The test also checks that `axis=1` works correct (it works fine on main) and checks both int and float dtypes to ensure the casting occurs before the sum which is followed by storing into `out`.
