### PR TITLE
BUG: sparse.csgraph: fix exponential time in `maximum_bipartite_matching`

### DIFF
--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -165,7 +165,7 @@ cdef tuple _hopcroft_karp(const ITYPE_t[:] indices, const ITYPE_t[:] indptr,
     # every unmatched column will be matched with this vertex.
     cdef ITYPE_t[:] dist = np.empty(i + 1, dtype=ITYPE)
 
-    cdef ITYPE_t k, v, w, up, u, yu, u_old
+    cdef ITYPE_t k, v, w, up, u, yu, u_old, dist_v
 
     # At the end of the day, unmatched vertices will have a value of -1. As
     # mentioned above, unmatched vertices in the right partition will be
@@ -249,12 +249,23 @@ cdef tuple _hopcroft_karp(const ITYPE_t[:] indices, const ITYPE_t[:] indptr,
                     # Pop v from stack.
                     stack_head -= 1
                     v = stack[stack_head]
-                    could_augment = False
+                    # Mark v as visited, so that it is explored at most once
+                    # in this phase. If the search from v fails, v is a dead
+                    # end for the rest of the phase; if it succeeds, v lies on
+                    # the augmenting path and must not feature in another one.
+                    # Without this, v would be explored once for every path
+                    # that leads to it, and the number of such paths can grow
+                    # exponentially with the depth of the search (gh-26147).
+                    # A popped vertex can be marked already only when the
+                    # input contains duplicate entries.
+                    if dist[v] == INF:
+                        continue
+                    dist_v = dist[v]
+                    dist[v] = INF
                     for up in range(indptr[v], indptr[v + 1]):
                         u = indices[up]
                         yu = y[u]
-                        if dist[yu] == dist[v] + 1:
-                            could_augment = True
+                        if dist[yu] == dist_v + 1:
                             # If yu is unmatched, we have found an augmenting
                             # path. We update the matching and move on to the
                             # next unmatched vertex.
@@ -262,10 +273,6 @@ cdef tuple _hopcroft_karp(const ITYPE_t[:] indices, const ITYPE_t[:] indptr,
                                 done = True
                                 # Unwind and follow the path back to the root.
                                 while True:
-                                    # Mark v as visited to ensure that it
-                                    # features in only one augmenting path in
-                                    # this sequence of DFS runs.
-                                    dist[v] = INF
                                     u_old = x[v]
                                     y[u] = v
                                     x[v] = u

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -149,6 +149,46 @@ def test_matching_large_random_graph_with_one_edge_incident_to_each_vertex():
     assert_equal(any(C2.diagonal() == 0), False)
 
 
+@pytest.mark.timeout(2)  # only slow when broken
+def test_maximum_bipartite_matching_dead_end_explored_once():
+    # Regression test for gh-26147: the depth-first search must explore every
+    # vertex at most once per phase. The graph consists of a chain of `depth`
+    # rows that leads to a free column, and a ladder of `depth` layers of two
+    # rows each, in which both rows of a layer are adjacent to the columns
+    # matched to both rows of the next layer. The ladder contains no free
+    # column, so the search from the row that enters it fails. Without
+    # marking the rows it has explored, the search then walks all 2**depth
+    # paths through the ladder, whatever the order in which it visits them,
+    # and with depth = 30 this takes seconds.
+    depth = 30
+    rows, cols = [], []
+    # Chain: row k is adjacent to columns k and k + 1.
+    for k in range(depth):
+        rows += [k, k]
+        cols += [k, k + 1]
+    # Ladder: layer k consists of rows r0 + 2k and r0 + 2k + 1, which are
+    # both adjacent to columns c0 + 2k, ..., c0 + 2k + 3.
+    r0, c0 = depth, depth + 1
+    for k in range(depth):
+        for r in (r0 + 2 * k, r0 + 2 * k + 1):
+            for c in range(c0 + 2 * k, min(c0 + 2 * k + 4, c0 + 2 * depth)):
+                rows.append(r)
+                cols.append(c)
+    # One more row enters the chain, and one more row enters the ladder.
+    s = r0 + 2 * depth
+    t = s + 1
+    rows += [s, t, t]
+    cols += [0, c0, c0 + 1]
+    graph = csr_array((np.ones(len(rows)), (rows, cols)),
+                      shape=(t + 1, c0 + 2 * depth))
+    x = maximum_bipartite_matching(graph, perm_type='column')
+    y = maximum_bipartite_matching(graph, perm_type='row')
+    # The graph has one more row than it has columns, and every column can be
+    # matched.
+    assert (x != -1).sum() == graph.shape[1]
+    assert (y != -1).sum() == graph.shape[1]
+
+
 @pytest.mark.parametrize('num_rows,num_cols', [(0, 0), (2, 0), (0, 3)])
 def test_min_weight_full_matching_trivial_graph(num_rows, num_cols):
     biadjacency = csr_array((num_cols, num_rows))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-26147.

#### What does this implement/fix?
<!-- Write this part yourself. Facts to cover, then delete these notes:
- Cause: in the depth-first phase of `_hopcroft_karp`, a vertex whose search fails is never marked. A vertex reachable along k level-respecting paths is explored k times, so the time grows exponentially with the depth of the layered graph.
- Fix: mark `v` with `dist[v] = INF` when it is popped. Each vertex is explored at most once per phase, which gives O(E) per phase and the documented O(E sqrt(V)) total.
- A popped vertex that is already marked is skipped. This happens only when the input has duplicate entries. Duplicate entries can also overflow the fixed-size stack; that bug is older than this PR and will be reported separately (add the issue number once filed).
- Removed: the unused `could_augment`, and the `dist[v] = INF` in the unwind loop, since every vertex on the path is already marked when popped.
- Not chosen: marking at push also marks siblings that were pushed but never explored, so a phase can miss vertex-disjoint shortest augmenting paths and the O(E sqrt(V)) bound no longer holds.
- New test `test_maximum_bipartite_matching_dead_end_explored_once`: a free row whose search must fail walks the whole ladder in any visiting order. It uses `@pytest.mark.timeout(2)`, as `sparse/tests/test_csr.py` does. On `main` it fails with `Timeout (>2.0s)`, and the run takes 9.6 s. With the fix, all of `test_matching.py` runs in 0.78 s.
-->

#### Additional information
Time of `maximum_bipartite_matching(A, perm_type='column')`. Each value is the minimum of 10 runs; a case whose first run takes more than 1 s runs once.

| Graph | n | nnz | SciPy 1.16.3 | This PR |
|---|---:|---:|---:|---:|
| Ladder from gh-26147, L = 28 | 88 | 288 | 2.1 s | 0.004 ms |
| Pipeline-network Jacobian from gh-26147 | 15 231 | 116 659 | no result within 60 s | 0.35 ms |
| PEGASE 9241 power-flow Jacobian | 18 482 | 138 608 | 98 ms | 4.2 ms |
| Method-of-lines gas-network Jacobian | 10 242 | 35 832 | 1.3 ms | 0.21 ms |
| GB network dynamic-simulation Jacobian | 18 708 | 67 765 | 4.5 ms | 1.9 ms |
| Random graph as in `benchmarks/sparse_csgraph_matching.py`, density 1e-4 | 100 000 | 999 947 | 44 ms | 27 ms |

- The four Jacobians in rows 2 to 5 are attached as `scipy-gh26147-matrices.zip`, as sparsity patterns in canonical CSR format with SHA-256 checksums. `python rerun.py` in the unzipped folder also builds the graphs of rows 1 and 6, and it reproduces every row.
[scipy-gh26147-matrices.zip](https://github.com/user-attachments/files/32087129/scipy-gh26147-matrices.zip)

- All timings on an Apple M4 under macOS 26.6.2, build 25G83. SciPy 1.16.3: the PyPI wheel `cp311-cp311-macosx_14_0_arm64`, built with clang 15.0.0, on Python 3.11.13 and NumPy 2.3.5. This PR: `main` at 4361d71 with this change, built locally with Apple clang 17.0.0, on Python 3.12.11 and NumPy 2.5.3. Both builds link Accelerate, which `_hopcroft_karp` does not call.
- The nine graphs of `benchmarks/sparse_csgraph_matching.py`, n ≤ 10 000: eight are faster or within 4 %; the ninth goes from 0.72 ms to 0.83 ms.
- `spin test -t scipy/sparse/csgraph`: 1346 passed, 58 skipped because pydata/sparse is not installed.
- `scipy/optimize/tests/test_linear_assignment.py`: 22 passed.
- `ruff` and `cython-lint`: no findings.
- 406 random and banded graphs: the matching size equals that of `scipy.optimize.linear_sum_assignment`, and every matching is valid.

#### AI Generation Disclosure
These commits have been reviewed by Claude Opus 5.