### PR TITLE
TST: stats.UnivariateDistribution: eliminate hypothesis from tests, refactor for control, and prepare for Array API

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -386,3 +386,30 @@ def _run_concurrent_barrier(n_workers, fn, *args, **kwargs):
                 barrier.abort()
 
     return [f.result() for f in futures]
+
+
+def mutually_broadcastable_shapes(nshapes, *, base_shape=None, min_dims=2,
+                                  max_dims=None, min_side=0, max_side=10, rng=None):
+    rng = np.random.default_rng(rng)
+    ndim = rng.integers(min_dims, max_dims or min_dims, endpoint=True)
+    min_side = np.broadcast_to(min_side, ndim)  # so min_side and max_side
+    max_side = np.broadcast_to(max_side, ndim)  # can be scalars or array-like
+    base_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in
+                       zip(min_side, max_side)) if base_shape is None else base_shape
+    shapes = np.repeat([base_shape], nshapes, axis=0)
+
+    # make some elements of some shapes 1 (while preserving overall batch shape)
+    for column in shapes.T:
+        column[rng.integers(1, nshapes):] = 1
+    # permute elements between shapes (while preserving overall batch shape)
+    shapes = list(rng.permuted(shapes, axis=0))
+    # potentially trim preceding 1s from a shape
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        j = np.where(shape != 1)[0][0] if np.any(shape != 1) else ndim
+        if rng.random() < 0.25:
+            shapes[i] = shape[rng.integers(j+1):]
+            break
+
+    assert np.broadcast_shapes(*shapes) == base_shape
+    return [tuple(int(el) for el in shape) for shape in shapes]

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -388,28 +388,42 @@ def _run_concurrent_barrier(n_workers, fn, *args, **kwargs):
     return [f.result() for f in futures]
 
 
-def mutually_broadcastable_shapes(nshapes, *, base_shape=None, min_dims=2,
-                                  max_dims=None, min_side=0, max_side=10, rng=None):
+def mutually_broadcastable_shapes(num_shapes, *, base_shape=(), min_dims=0,
+                                  max_dims=3, min_side=0, max_side=5, rng=None):
+    # We ignore incompatibilities between base_shape and min_side/max_side
+
     rng = np.random.default_rng(rng)
     ndim = rng.integers(min_dims, max_dims or min_dims, endpoint=True)
     min_side = np.broadcast_to(min_side, ndim)  # so min_side and max_side
     max_side = np.broadcast_to(max_side, ndim)  # can be scalars or array-like
-    base_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in
-                       zip(min_side, max_side)) if base_shape is None else base_shape
-    shapes = np.repeat([base_shape], nshapes, axis=0)
 
+    new_base_shape = rng.integers(min_side, max_side)
+    if base_shape == () and num_shapes == 1:
+        return [tuple(new_base_shape)]
+
+    shapes = np.repeat([new_base_shape], num_shapes, axis=0)
     # make some elements of some shapes 1 (while preserving overall batch shape)
     for column in shapes.T:
-        column[rng.integers(1, nshapes):] = 1
+        column[rng.integers(1 if base_shape == () else 0, num_shapes+1):] = 1
     # permute elements between shapes (while preserving overall batch shape)
     shapes = list(rng.permuted(shapes, axis=0))
+    if base_shape != ():
+        # resolve any non-broadcastabilities
+        for i, shape in enumerate(shapes):
+            j = min(ndim, len(base_shape))
+            cond1 = shape[ndim - j:] == base_shape[len(base_shape) - j:]
+            cond2 = shape[ndim - j:] == 1
+            mask = ~(cond1 | cond2)
+            replacements = np.asarray(base_shape[len(base_shape) - j:])
+            replacements[rng.random(len(replacements)) > 0.5] = 1
+            shapes[i][ndim - j:][mask] = replacements[mask]
     # potentially trim preceding 1s from a shape
-    for i in range(len(shapes)):
-        shape = shapes[i]
+    for i, shape in enumerate(shapes):
         j = np.where(shape != 1)[0][0] if np.any(shape != 1) else ndim
         if rng.random() < 0.25:
             shapes[i] = shape[rng.integers(j+1):]
             break
 
-    assert np.broadcast_shapes(*shapes) == base_shape
+    if base_shape == ():
+        assert np.broadcast_shapes(*shapes) == tuple(new_base_shape)
     return [tuple(int(el) for el in shape) for shape in shapes]

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -36,12 +36,15 @@ pytestmark = make_xp_pytest_marks(
     aslinearoperator
 )
 
-def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
+def mutually_broadcastable_shapes(nshapes, *, base_shape=None, min_dims=2,
+                                  max_dims=None, min_side=0, max_side=10, rng=None):
     rng = np.random.default_rng(rng)
-    min = np.broadcast_to(min, ndim)  # so min and max can be scalars or array-like
-    max = np.broadcast_to(max, ndim)
-    batch_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in zip(min, max))
-    shapes = np.repeat([batch_shape], nshapes, axis=0)
+    ndim = rng.integers(min_dims, max_dims or min_dims, endpoint=True)
+    min_side = np.broadcast_to(min_side, ndim)  # so min_side and max_side
+    max_side = np.broadcast_to(max_side, ndim)  # can be scalars or array-like
+    base_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in
+                       zip(min_side, max_side)) if base_shape is None else base_shape
+    shapes = np.repeat([base_shape], nshapes, axis=0)
 
     # make some elements of some shapes 1 (while preserving overall batch shape)
     for column in shapes.T:
@@ -56,7 +59,7 @@ def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
             shapes[i] = shape[rng.integers(j+1):]
             break
 
-    assert np.broadcast_shapes(*shapes) == batch_shape
+    assert np.broadcast_shapes(*shapes) == base_shape
     return [tuple(int(el) for el in shape) for shape in shapes]
 
 @pytest.mark.xfail_xp_backends('dask.array', reason=(
@@ -408,8 +411,8 @@ class TestDotTests:
         dtype = np.dtype(data_dtype)
         *batch_shape, M, N = op.shape
 
-        u_broadcast, v_broadcast = generate_broadcastable_shapes(
-            2, ndim=3, min=0, max=5, rng=63
+        u_broadcast, v_broadcast = mutually_broadcastable_shapes(
+            2, min_dims=3, max_dims=3, min_side=0, max_side=5, rng=63
         )
 
         for u_shape, v_shape in (

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -24,6 +24,7 @@ import scipy.sparse.linalg._interface as interface
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse._sputils import matrix
 from scipy._lib._gcutils import assert_deallocated
+from scipy._lib._testutils import mutually_broadcastable_shapes
 
 pytestmark = make_xp_pytest_marks(
     (LinearOperator, "__init__"),
@@ -35,32 +36,6 @@ pytestmark = make_xp_pytest_marks(
     (LinearOperator, "rmatmat"),
     aslinearoperator
 )
-
-def mutually_broadcastable_shapes(nshapes, *, base_shape=None, min_dims=2,
-                                  max_dims=None, min_side=0, max_side=10, rng=None):
-    rng = np.random.default_rng(rng)
-    ndim = rng.integers(min_dims, max_dims or min_dims, endpoint=True)
-    min_side = np.broadcast_to(min_side, ndim)  # so min_side and max_side
-    max_side = np.broadcast_to(max_side, ndim)  # can be scalars or array-like
-    base_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in
-                       zip(min_side, max_side)) if base_shape is None else base_shape
-    shapes = np.repeat([base_shape], nshapes, axis=0)
-
-    # make some elements of some shapes 1 (while preserving overall batch shape)
-    for column in shapes.T:
-        column[rng.integers(1, nshapes):] = 1
-    # permute elements between shapes (while preserving overall batch shape)
-    shapes = list(rng.permuted(shapes, axis=0))
-    # potentially trim preceding 1s from a shape
-    for i in range(len(shapes)):
-        shape = shapes[i]
-        j = np.where(shape != 1)[0][0] if np.any(shape != 1) else ndim
-        if rng.random() < 0.25:
-            shapes[i] = shape[rng.integers(j+1):]
-            break
-
-    assert np.broadcast_shapes(*shapes) == base_shape
-    return [tuple(int(el) for el in shape) for shape in shapes]
 
 @pytest.mark.xfail_xp_backends('dask.array', reason=(
     "dask does not support broadcast_shapes(). "

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2205,7 +2205,9 @@ class UnivariateDistribution(_ProbabilityDistribution):
         raise NotImplementedError(self._not_implemented)
 
     def _entropy_logexp(self, **params):
-        return np.real(np.exp(self._logentropy_dispatch(**params)))
+        with np.errstate(invalid='ignore'):
+            # np.exp(np.nan) raises on some platforms?
+            return np.real(np.exp(self._logentropy_dispatch(**params)))
 
     def _entropy_quadrature(self, **params):
         def integrand(x, **params):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2459,7 +2459,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
     def _logcdf2_logexp(self, x, y, **params):
         expres = self._cdf2_dispatch(x, y, **params)
         expres = expres + 0j if np.any(x > y) else expres
-        return np.log(expres)
+        with np.errstate(divide='ignore'):
+            return np.log(expres)
 
     def _logcdf2_logexp_safe(self, x, y, **params):
         out = self._logcdf2_logexp(x, y, **params)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2574,7 +2574,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
 
         cdf_max = np.maximum(cdf_x, cdf_y)
         ccdf_max = np.maximum(ccdf_x, ccdf_y)
-        spacing = np.spacing(np.where(i, ccdf_max, cdf_max))
+        with np.errstate(invalid='ignore'):
+            spacing = np.spacing(np.where(i, ccdf_max, cdf_max))
         mask = np.abs(tol * out) < spacing
 
         if np.any(mask):
@@ -2617,7 +2618,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
         out = 1 - ccdf
         eps = np.finfo(self._dtype).eps
         tol = self.tol if not _isnull(self.tol) else np.sqrt(eps)
-        mask = tol * out < np.spacing(ccdf)
+        with np.errstate(invalid='ignore'):
+            mask = tol * out < np.spacing(ccdf)
         if np.any(mask):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
@@ -2755,7 +2757,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
         out = 1 - cdf
         eps = np.finfo(self._dtype).eps
         tol = self.tol if not _isnull(self.tol) else np.sqrt(eps)
-        mask = tol * out < np.spacing(cdf)
+        with np.errstate(invalid='ignore'):
+            mask = tol * out < np.spacing(cdf)
         if np.any(mask):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
@@ -2817,7 +2820,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
         out = self._icdf_complement(x, **params)
         eps = np.finfo(self._dtype).eps
         tol = self.tol if not _isnull(self.tol) else np.sqrt(eps)
-        mask = tol * x < np.spacing(1 - x)
+        with np.errstate(invalid='ignore'):
+            mask = tol * x < np.spacing(1 - x)
         if np.any(mask):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
@@ -2875,7 +2879,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
         out = self._iccdf_complement(x, **params)
         eps = np.finfo(self._dtype).eps
         tol = self.tol if not _isnull(self.tol) else np.sqrt(eps)
-        mask = tol * x < np.spacing(1 - x)
+        with np.errstate(invalid='ignore'):
+            mask = tol * x < np.spacing(1 - x)
         if np.any(mask):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2166,8 +2166,10 @@ class UnivariateDistribution(_ProbabilityDistribution):
         raise NotImplementedError(self._not_implemented)
 
     def _logentropy_logexp(self, **params):
-        res = np.log(self._entropy_dispatch(**params)+0j)
-        return _log_real_standardize(res)
+        with np.errstate(invalid='ignore'):
+            # np.log warns with complex NaN argument
+            res = np.log(self._entropy_dispatch(**params)+0j)
+            return _log_real_standardize(res)
 
     def _logentropy_logexp_safe(self, **params):
         out = self._logentropy_logexp(**params)
@@ -2445,7 +2447,9 @@ class UnivariateDistribution(_ProbabilityDistribution):
         case_central = ~(case_left | case_right)
         log_mass = _logexpxmexpy(logcdf_y, logcdf_x)
         log_mass[case_right] = _logexpxmexpy(logccdf_x, logccdf_y)[case_right]
-        log_tail = np.logaddexp(logcdf_x, logccdf_y)[case_central]
+        with np.errstate(invalid='ignore'):
+            # np.logaddexp warns with NaN argument
+            log_tail = np.logaddexp(logcdf_x, logccdf_y)[case_central]
         log_mass[case_central] = _log1mexp(log_tail)
         log_mass[flip_sign] += np.pi * 1j
         return log_mass[()] if np.any(flip_sign) else log_mass.real[()]

--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -82,13 +82,16 @@ class Normal(ContinuousDistribution):
         return StandardNormal._ilogccdf_formula(self, x) * sigma + mu
 
     def _entropy_formula(self, *, mu, sigma, **kwargs):
-        return StandardNormal._entropy_formula(self) + np.log(abs(sigma))
+        with np.errstate(invalid='ignore'):
+            log_abs_sigma = np.log(abs(sigma))
+        return StandardNormal._entropy_formula(self) + log_abs_sigma
 
     def _logentropy_formula(self, *, mu, sigma, **kwargs):
         lH0 = StandardNormal._logentropy_formula(self)
-        with np.errstate(divide='ignore'):
-            # sigma = 1 -> log(sigma) = 0 -> log(log(sigma)) = -inf
-            # Silence the unnecessary runtime warning
+        with np.errstate(divide='ignore', invalid='ignore'):
+            # sigma = 1 -> log(sigma) = 0 -> log(log(sigma)) = -inf -> divide
+            # sigma = NaN -> invalid
+            # Silence the unnecessary runtime warnings
             lls = np.log(np.log(abs(sigma))+0j)
         return special.logsumexp(np.broadcast_arrays(lH0, lls), axis=0)
 

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -16,6 +16,7 @@ py3.install_sources([
     'test_discrete_basic.py',
     'test_discrete_distns.py',
     'test_distributions.py',
+    'test_distribution_test.py',
     'test_entropy.py',
     'test_fast_gen_inversion.py',
     'test_fit.py',

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -379,8 +379,9 @@ class TestUniform(DistributionsTest):
     def test_quasi_random_sample(self, case):
         return super().test_quasi_random_sample(case)
 
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_moment(self, case):
-        return super().test_moment(case, tol_override={'atol': 1e-10})
+        return super().test_moment(case, tol_override={'atol': 1e-9})
 
 
 class Test_LogUniform(DistributionsTest):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -217,12 +217,12 @@ class DistributionsTest:
         check_support(case.dist)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_moment(self, case):
-        check_moment_funcs(case.dist, case.result_shape)  # this needs to get split up
+    def test_moment(self, case, tol_override=None):
+        check_moment_funcs(case.dist, case.result_shape, tol_override=tol_override)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_lmoment(self, case):
-        check_lmoment_funcs(case.dist, case.result_shape)
+    def test_lmoment(self, case, tol_override=None):
+        check_lmoment_funcs(case.dist, case.result_shape, tol_override=tol_override)
 
     def test_random_sample(self, case):
         sample_shape, = mutually_broadcastable_shapes(1, max_side=20, rng=case.rng)
@@ -235,92 +235,107 @@ class DistributionsTest:
         check_sample_shape_NaNs(case.dist, 'sample', sample_shape,
                                 case.result_shape, qrng)
 
-    def test_entropy(self, case):
+    def test_entropy(self, case, tol_override=None):
         check_dist_func(case.dist, 'entropy', None, case.result_shape,
-                        {'log/exp', 'quadrature'})
+                        {'log/exp', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_logentropy(self, case):
+    def test_logentropy(self, case, tol_override=None):
         check_dist_func(case.dist, 'logentropy', None, case.result_shape,
-                        {'log/exp', 'quadrature'})
+                        {'log/exp', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_median(self, case):
-        check_dist_func(case.dist, 'median', None, case.result_shape, {'icdf'})
+    def test_median(self, case, tol_override=None):
+        check_dist_func(case.dist, 'median', None, case.result_shape, {'icdf'},
+                        tol_override=tol_override)
 
-    def test_mode(self, case):
+    def test_mode(self, case, tol_override=None):
+        tol_override = {'atol': 1e-6} if tol_override is None else tol_override
         check_dist_func(case.dist, 'mode', None, case.result_shape,
-                        {'optimization'}, tol_override={'atol': 1e-6})
+                        {'optimization'}, tol_override=tol_override)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_mean(self, case):
-        check_dist_func(case.dist, 'mean', None, case.result_shape, {'cache'})
+    def test_mean(self, case, tol_override=None):
+        check_dist_func(case.dist, 'mean', None, case.result_shape, {'cache'},
+                        tol_override=tol_override)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_variance(self, case):
-        check_dist_func(case.dist, 'variance', None, case.result_shape, {'cache'})
+    def test_variance(self, case, tol_override=None):
+        check_dist_func(case.dist, 'variance', None, case.result_shape, {'cache'},
+                        tol_override=tol_override)
 
-    def test_standard_deviation(self, case):
-        assert_allclose(case.dist.standard_deviation()**2, case.dist.variance())
+    def test_standard_deviation(self, case, tol_override=None):
+        tol_override = {} if tol_override is None else tol_override
+        assert_allclose(case.dist.standard_deviation()**2, case.dist.variance(),
+                        **tol_override)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_skewness(self, case):
-        check_dist_func(case.dist, 'skewness', None, case.result_shape, {'cache'})
+    def test_skewness(self, case, tol_override=None):
+        check_dist_func(case.dist, 'skewness', None, case.result_shape,
+                        {'cache'}, tol_override=tol_override)
 
     @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
-    def test_kurtosis(self, case):
-        check_dist_func(case.dist, 'kurtosis', None, case.result_shape, {'cache'})
+    def test_kurtosis(self, case, tol_override=None):
+        check_dist_func(case.dist, 'kurtosis', None, case.result_shape,
+                        {'cache'}, tol_override=tol_override)
 
-    def test_pdf(self, case):
-        check_dist_func(case.dist, 'pdf', case.x, case.x_result_shape, {'log/exp'})
+    def test_pdf(self, case, tol_override=None):
+        check_dist_func(case.dist, 'pdf', case.x, case.x_result_shape,
+                        {'log/exp'}, tol_override=tol_override)
 
-    def test_logpdf(self, case):
+    def test_logpdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'logpdf', case.x, case.x_result_shape,
-                        {'log/exp'})
+                        {'log/exp'}, tol_override=tol_override)
 
-    def test_logcdf(self, case):
+    def test_logcdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'logcdf', case.x, case.x_result_shape,
-                        {'log/exp', 'complement', 'quadrature'})
+                        {'log/exp', 'complement', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_cdf(self, case):
+    def test_cdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'cdf', case.x, case.x_result_shape,
-                        {'log/exp', 'complement', 'quadrature'})
+                        {'log/exp', 'complement', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_cdf2(self, case):
+    def test_cdf2(self, case, tol_override=None):
         check_cdf2(case.dist, False, case.x, case.y,
-                    case.xy_result_shape, {'quadrature'})
+                    case.xy_result_shape, {'quadrature'}, tol_override=tol_override)
         check_cdf2(case.dist, True, case.x, case.y,
-                    case.xy_result_shape, {'quadrature'})
+                    case.xy_result_shape, {'quadrature'}, tol_override=tol_override)
 
-    def test_logccdf(self, case):
+    def test_logccdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'logccdf', case.x, case.x_result_shape,
-                        {'log/exp', 'complement', 'quadrature'})
+                        {'log/exp', 'complement', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_ccdf(self, case):
+    def test_ccdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'ccdf', case.x, case.x_result_shape,
-                        {'log/exp', 'complement', 'quadrature'})
+                        {'log/exp', 'complement', 'quadrature'},
+                        tol_override=tol_override)
 
-    def test_ccdf2(self, case):
+    def test_ccdf2(self, case, tol_override=None):
         check_ccdf2(case.dist, False, case.x, case.y,
-                    case.xy_result_shape, {'addition'})
+                    case.xy_result_shape, {'addition'}, tol_override=tol_override)
         check_ccdf2(case.dist, True, case.x, case.y,
-                    case.xy_result_shape, {'addition'})
+                    case.xy_result_shape, {'addition'}, tol_override=tol_override)
 
-    def test_ilogcdf(self, case):
+    def test_ilogcdf(self, case, tol_override=None):
         with np.errstate(divide='ignore', over='ignore'):
             check_dist_func(case.dist, 'ilogcdf', case.logp, case.x_result_shape,
-                            {'complement', 'inversion'})
+                            {'complement', 'inversion'}, tol_override=tol_override)
 
-    def test_icdf(self, case):
+    def test_icdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'icdf', case.p, case.x_result_shape,
-                        {'complement', 'inversion'})
+                        {'complement', 'inversion'}, tol_override=tol_override)
 
-    def test_ilogccdf(self, case):
+    def test_ilogccdf(self, case, tol_override=None):
         with np.errstate(divide='ignore', over='ignore'):
             check_dist_func(case.dist, 'ilogccdf', case.logp, case.x_result_shape,
-                            {'complement', 'inversion'})
+                            {'complement', 'inversion'}, tol_override=tol_override)
 
-    def test_iccdf(self, case):
+    def test_iccdf(self, case, tol_override=None):
         check_dist_func(case.dist, 'iccdf', case.p, case.x_result_shape,
-                        {'complement', 'inversion'})
+                        {'complement', 'inversion'}, tol_override=tol_override)
 
 
 class TestStandardNormal(DistributionsTest):
@@ -339,6 +354,9 @@ class TestNormal(DistributionsTest):
     @pytest.mark.filterwarnings("ignore:divide:RuntimeWarning")
     def test_logpdf(self, case):
         return super().test_logpdf(case)
+
+    def test_lmoment(self, case):
+        return super().test_lmoment(case, tol_override={'atol': 1e-8})
 
 
 class TestLogistic(DistributionsTest):
@@ -360,6 +378,9 @@ class TestUniform(DistributionsTest):
     @pytest.mark.fail_slow(10)
     def test_quasi_random_sample(self, case):
         return super().test_quasi_random_sample(case)
+
+    def test_moment(self, case):
+        return super().test_moment(case, tol_override={'atol': 1e-10})
 
 
 class Test_LogUniform(DistributionsTest):
@@ -537,12 +558,11 @@ def check_support(dist):
 
 
 def check_dist_func(dist, fname, arg, result_shape, methods, tol_override=None):
-    tol_override = {'atol': 0} if tol_override is None else tol_override
-
     # Check that all computation methods of all distribution functions agree
     # with one another, effectively testing the correctness of the generic
     # computation methods and confirming the consistency of specific
     # distributions with their pdf/logpdf.
+    tol_override = {'atol': 0} if tol_override is None else tol_override
 
     args = tuple() if arg is None else (arg,)
     methods = methods.copy()
@@ -581,12 +601,13 @@ def check_dist_func(dist, fname, arg, result_shape, methods, tol_override=None):
             assert np.isscalar(res)
 
 
-def check_cdf2(dist, log, x, y, result_shape, methods):
+def check_cdf2(dist, log, x, y, result_shape, methods, tol_override=None):
     # Specialized test for 2-arg cdf since the interface is a bit different
     # from the other methods. Here, we'll use 1-arg cdf as a reference, and
     # since we have already checked 1-arg cdf in `check_nans_and_edges`, this
     # checks the equivalent of both `check_dist_func` and
     # `check_nans_and_edges`.
+    tol_override = {'atol' : 0} if tol_override is None else tol_override
     methods = methods.copy()
 
     if log:
@@ -624,7 +645,7 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
             # np.exp(np.nan) raises on some platforms?
             res = (np.exp(dist.logcdf(x, y, method=method)) if log
                 else dist.cdf(x, y, method=method))
-        np.testing.assert_allclose(res, ref, atol=1e-14)
+        np.testing.assert_allclose(res, ref, **tol_override)
         if log:
             np.testing.assert_equal(res.dtype, (ref + 0j).dtype)
         else:
@@ -634,10 +655,11 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
             assert np.isscalar(res)
 
 
-def check_ccdf2(dist, log, x, y, result_shape, methods):
+def check_ccdf2(dist, log, x, y, result_shape, methods, tol_override=None):
     # Specialized test for 2-arg ccdf since the interface is a bit different
     # from the other methods. Could be combined with check_cdf2 above, but
     # writing it separately is simpler.
+    tol_override = {'atol' : 0} if tol_override is None else tol_override
     methods = methods.copy()
 
     if dist._overrides(f'_{"log" if log else ""}ccdf2_formula'):
@@ -659,7 +681,7 @@ def check_ccdf2(dist, log, x, y, result_shape, methods):
             continue
         res = (np.exp(dist.logccdf(x, y, method=method)) if log
                else dist.ccdf(x, y, method=method))
-        np.testing.assert_allclose(res, ref, atol=1e-14)
+        np.testing.assert_allclose(res, ref, **tol_override)
         np.testing.assert_equal(res.dtype, ref.dtype)
         np.testing.assert_equal(res.shape, result_shape)
         if result_shape == tuple():
@@ -753,18 +775,21 @@ def check_nans_and_edges(dist, fname, arg, res):
         assert np.isfinite(res[all_valid & (endpoint_arg == 0)]).all()
 
 
-def check_moment_funcs(dist, result_shape):
+def check_moment_funcs(dist, result_shape, tol_override=None):
     # Check that all computation methods of all distribution functions agree
     # with one another, effectively testing the correctness of the generic
     # computation methods and confirming the consistency of specific
     # distributions with their pdf/logpdf.
-
-    atol = 1e-9  # make this tighter (e.g. 1e-13) after fixing `draw`
+    _tol_override = {'rtol': 1e-7, 'atol': 1e-13}
+    if tol_override is not None:
+        _tol_override.update(tol_override)
+    tol_override = _tol_override
 
     def check(order, kind, method=None, ref=None, success=True):
         if success:
             res = dist.moment(order, kind, method=method)
-            assert_allclose(res, ref, atol=atol*10**order)
+            assert_allclose(res, ref, rtol=tol_override['rtol'],
+                            atol=tol_override['atol']*10**order)
             assert res.shape == ref.shape
         else:
             with pytest.raises(NotImplementedError):
@@ -862,8 +887,9 @@ def check_moment_funcs(dist, result_shape):
     dist.reset_cache()
 
 
-def check_lmoment_funcs(dist, result_shape):
+def check_lmoment_funcs(dist, result_shape, tol_override=None):
     # Perform consistency check for L-moments similar to check_moment_funcs above
+    tol_override = {'atol' : 5e-13} if tol_override is None else tol_override
 
     if not isinstance(dist, ContinuousDistribution):
         message = "L-moments are currently available only for continuous..."
@@ -871,12 +897,10 @@ def check_lmoment_funcs(dist, result_shape):
             dist.lmoment(1)
         return
 
-    atol = 1e-8
-
     def check(order, standardize=False, method=None, ref=None, success=True):
         if success:
             res = dist.lmoment(order, standardize=standardize, method=method)
-            assert_allclose(res, ref, atol=atol)
+            assert_allclose(res, ref, **tol_override)
             assert res.shape == ref.shape
         else:
             with pytest.raises(NotImplementedError):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -23,6 +23,7 @@ from scipy.stats._distribution_infrastructure import (
 from scipy.stats._new_distributions import StandardNormal, _LogUniform, _Gamma
 from scipy.stats._new_distributions import DiscreteDistribution
 from scipy.stats import Normal, Logistic, Uniform, Binomial
+from scipy._lib._testutils import mutually_broadcastable_shapes
 
 
 class Test_RealInterval:
@@ -150,12 +151,13 @@ def draw_distribution_from_family(family, data, rng, proportions, min_side=0):
     # If the distribution has parameters, choose a parameterization and
     # draw broadcastable shapes for the parameter arrays.
     n_parameterizations = family._num_parameterizations()
+    rng.random()
     if n_parameterizations > 0:
-        i = data.draw(strategies.integers(0, max_value=n_parameterizations-1))
+        i = rng.integers(0, n_parameterizations)
         n_parameters = family._num_parameters(i)
-        shapes, result_shape = data.draw(
-            npst.mutually_broadcastable_shapes(num_shapes=n_parameters,
-                                               min_side=min_side))
+        shapes = mutually_broadcastable_shapes(num_shapes=n_parameters,
+                                               min_side=min_side, rng=rng)
+        result_shape = np.broadcast_shapes(*shapes)
         dist = family._draw(shapes, rng=rng, proportions=proportions,
                             i_parameterization=i)
     else:
@@ -164,13 +166,13 @@ def draw_distribution_from_family(family, data, rng, proportions, min_side=0):
 
     # Draw a broadcastable shape for the arguments, and draw values for the
     # arguments.
-    x_shape = data.draw(npst.broadcastable_shapes(result_shape,
-                                                  min_side=min_side))
+    x_shape, = mutually_broadcastable_shapes(1, base_shape=result_shape,
+                                             min_side=min_side)
     x = dist._variable.draw(x_shape, parameter_values=dist._parameters,
                             proportions=proportions, rng=rng, region='typical')
     x_result_shape = np.broadcast_shapes(x_shape, result_shape)
-    y_shape = data.draw(npst.broadcastable_shapes(x_result_shape,
-                                                  min_side=min_side))
+    y_shape, = mutually_broadcastable_shapes(1, base_shape=x_result_shape,
+                                             min_side=min_side)
     y = dist._variable.draw(y_shape, parameter_values=dist._parameters,
                             proportions=proportions, rng=rng, region='typical')
     xy_result_shape = np.broadcast_shapes(y_shape, x_result_shape)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -216,9 +216,11 @@ class DistributionsTest:
     def test_support(self, case):
         check_support(case.dist)
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_moment(self, case):
         check_moment_funcs(case.dist, case.result_shape)  # this needs to get split up
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_lmoment(self, case):
         check_lmoment_funcs(case.dist, case.result_shape)
 
@@ -234,36 +236,36 @@ class DistributionsTest:
                                 case.result_shape, qrng)
 
     def test_entropy(self, case):
-        with np.errstate(invalid='ignore'):
-            check_dist_func(case.dist, 'entropy', None, case.result_shape,
-                            {'log/exp', 'quadrature'})
+        check_dist_func(case.dist, 'entropy', None, case.result_shape,
+                        {'log/exp', 'quadrature'})
 
     def test_logentropy(self, case):
-        with np.errstate(invalid='ignore'):
-            check_dist_func(case.dist, 'logentropy', None, case.result_shape,
-                            {'log/exp', 'quadrature'})
+        check_dist_func(case.dist, 'logentropy', None, case.result_shape,
+                        {'log/exp', 'quadrature'})
 
     def test_median(self, case):
         check_dist_func(case.dist, 'median', None, case.result_shape, {'icdf'})
 
     def test_mode(self, case):
-        if case.family == Uniform:
-            pytest.skip("Mode is not unique; `method`s disagree.")
         check_dist_func(case.dist, 'mode', None, case.result_shape,
                         {'optimization'}, tol_override={'atol': 1e-6})
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_mean(self, case):
         check_dist_func(case.dist, 'mean', None, case.result_shape, {'cache'})
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_variance(self, case):
         check_dist_func(case.dist, 'variance', None, case.result_shape, {'cache'})
 
     def test_standard_deviation(self, case):
         assert_allclose(case.dist.standard_deviation()**2, case.dist.variance())
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_skewness(self, case):
         check_dist_func(case.dist, 'skewness', None, case.result_shape, {'cache'})
 
+    @pytest.mark.thread_unsafe(reason="unknown")
     def test_kurtosis(self, case):
         check_dist_func(case.dist, 'kurtosis', None, case.result_shape, {'cache'})
 
@@ -271,9 +273,8 @@ class DistributionsTest:
         check_dist_func(case.dist, 'pdf', case.x, case.x_result_shape, {'log/exp'})
 
     def test_logpdf(self, case):
-        with np.errstate(divide='ignore'):
-            check_dist_func(case.dist, 'logpdf', case.x, case.x_result_shape,
-                            {'log/exp'})
+        check_dist_func(case.dist, 'logpdf', case.x, case.x_result_shape,
+                        {'log/exp'})
 
     def test_logcdf(self, case):
         check_dist_func(case.dist, 'logcdf', case.x, case.x_result_shape,
@@ -284,11 +285,10 @@ class DistributionsTest:
                         {'log/exp', 'complement', 'quadrature'})
 
     def test_cdf2(self, case):
-        with np.errstate(invalid='ignore', divide='ignore'):
-            check_cdf2(case.dist, False, case.x, case.y,
-                       case.xy_result_shape, {'quadrature'})
-            check_cdf2(case.dist, True, case.x, case.y,
-                       case.xy_result_shape, {'quadrature'})
+        check_cdf2(case.dist, False, case.x, case.y,
+                    case.xy_result_shape, {'quadrature'})
+        check_cdf2(case.dist, True, case.x, case.y,
+                    case.xy_result_shape, {'quadrature'})
 
     def test_logccdf(self, case):
         check_dist_func(case.dist, 'logccdf', case.x, case.x_result_shape,
@@ -299,11 +299,10 @@ class DistributionsTest:
                         {'log/exp', 'complement', 'quadrature'})
 
     def test_ccdf2(self, case):
-        with np.errstate(invalid='ignore', divide='ignore'):
-            check_ccdf2(case.dist, False, case.x, case.y,
-                        case.xy_result_shape, {'addition'})
-            check_ccdf2(case.dist, True, case.x, case.y,
-                        case.xy_result_shape, {'addition'})
+        check_ccdf2(case.dist, False, case.x, case.y,
+                    case.xy_result_shape, {'addition'})
+        check_ccdf2(case.dist, True, case.x, case.y,
+                    case.xy_result_shape, {'addition'})
 
     def test_ilogcdf(self, case):
         with np.errstate(divide='ignore', over='ignore'):
@@ -328,20 +327,35 @@ class TestStandardNormal(DistributionsTest):
     seed = 726527242
     family = StandardNormal
 
+    def test_cdf2(self, case):
+        with np.errstate(divide='ignore'):
+            return super().test_cdf2(case)
+
 
 class TestNormal(DistributionsTest):
     seed = 353965734
     family = Normal
+
+    def test_logpdf(self, case):
+        with np.errstate(divide='ignore'):
+            return super().test_logpdf(case)
 
 
 class TestLogistic(DistributionsTest):
     seed = 389513556
     family = Logistic
 
+    def test_cdf2(self, case):
+        with np.errstate(divide='ignore'):
+            return super().test_cdf2(case)
+
 
 class TestUniform(DistributionsTest):
     seed = 893709074
     family = Uniform
+
+    def test_mode(self, case):
+        pytest.skip("mode of Uniform distribution is not unique")
 
 
 class Test_LogUniform(DistributionsTest):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -147,11 +147,10 @@ class Test_RealInterval:
         assert domain1.symbols is not domain2.symbols
 
 
-def draw_distribution_from_family(family, data, rng, proportions, min_side=0):
+def draw_distribution_from_family(family, rng, proportions, min_side=0):
     # If the distribution has parameters, choose a parameterization and
     # draw broadcastable shapes for the parameter arrays.
     n_parameterizations = family._num_parameterizations()
-    rng.random()
     if n_parameterizations > 0:
         i = rng.integers(0, n_parameterizations)
         n_parameters = family._num_parameters(i)
@@ -204,16 +203,16 @@ class TestDistributions:
     @pytest.mark.fail_slow(60)  # need to break up check_moment_funcs
     @settings(max_examples=20)
     @pytest.mark.parametrize('family', families)
-    @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    def test_support_moments_sample(self, family, data, seed):
+    @given(seed=strategies.integers(min_value=0))
+    def test_support_moments_sample(self, family, seed):
         rng = np.random.default_rng(seed)
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
         proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, data, rng, proportions)
+        tmp = draw_distribution_from_family(family, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
-        sample_shape = data.draw(npst.array_shapes(min_dims=0, min_side=0,
-                                                   max_side=20))
+        sample_shape, = mutually_broadcastable_shapes(1, min_dims=0, min_side=0,
+                                                      max_side=20)
 
         with np.errstate(invalid='ignore', divide='ignore'):
             check_support(dist)
@@ -244,8 +243,8 @@ class TestDistributions:
                               ('iccdf', {'complement', 'inversion'}, 'p'),
                               ])
     @settings(max_examples=20)
-    @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    def test_funcs(self, family, data, seed, func, methods, arg):
+    @given(seed=strategies.integers(min_value=0))
+    def test_funcs(self, family, seed, func, methods, arg):
         if family == Uniform and func == 'mode':
             pytest.skip("Mode is not unique; `method`s disagree.")
 
@@ -253,7 +252,7 @@ class TestDistributions:
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
         proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, data, rng, proportions)
+        tmp = draw_distribution_from_family(family, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 
         args = {'x': x, 'p': p, 'logp': p}
@@ -1569,13 +1568,13 @@ class TestMakeDistribution:
 
     @pytest.mark.slow  # just in case
     @settings(max_examples=20)  # no need for more
-    @given(data=strategies.data())
-    def test_draw_distribution(self, data):
-        # `draw_distribution_from_family` is a private function right now, but we will
+    @given(seed=strategies.integers(min_value=0))
+    def test_draw_distribution(self, seed):
+        # `draw_distribution_from_family` is a private function right now, but we may
         # want that functionality to be public someday. It was broken for custom
         # distributions because the `typical` parameter of the support was ignored.
         # Check that this is resolved.
-        rng = np.random.default_rng(8465652168548465121)
+        rng = np.random.default_rng(seed)
         u_typical = tuple(np.sort(rng.standard_normal(2)))
         s_typical = tuple(np.sort(rng.random(2)*2))
         x_typical = tuple(np.sort(rng.standard_normal(2)))
@@ -1591,7 +1590,7 @@ class TestMakeDistribution:
 
         family = stats.make_distribution(MyNormal())
         proportions = (1.0, 0., 0., 0.)
-        tmp = draw_distribution_from_family(family, data, rng, proportions, min_side=1)
+        tmp = draw_distribution_from_family(family, rng, proportions, min_side=1)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
         assert u_typical[0] < np.min(dist.u) and np.max(dist.u) < u_typical[1]
         assert s_typical[0] < np.min(dist.s) and np.max(dist.s) < s_typical[1]
@@ -1661,8 +1660,8 @@ class TestTransforms:
         assert np.all((sample > lb) & (sample < ub))
 
     @pytest.mark.fail_slow(10)
-    @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    def test_loc_scale(self, data, seed):
+    @given(seed=strategies.integers(min_value=0))
+    def test_loc_scale(self, seed):
         # Need tests with negative scale
         rng = np.random.default_rng(seed)
 
@@ -1671,7 +1670,7 @@ class TestTransforms:
                 super().__init__(StandardNormal(), *args, **kwargs)
 
         tmp = draw_distribution_from_family(
-            TransformedNormal, data, rng, proportions=(1, 0, 0, 0), min_side=1)
+            TransformedNormal, rng, proportions=(1, 0, 0, 0), min_side=1)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 
         loc = dist.loc

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -188,52 +188,31 @@ def draw_distribution_from_family(family, rng, shape_options,
                        x_result_shape=x_result_shape, xy_result_shape=xy_result_shape)
 
 
-continuous_families = [
-    StandardNormal,
-    Normal,
-    Logistic,
-    Uniform,
-    _LogUniform
-]
+class DistributionsTest:
+    _options = [
+        (dict(min_dims=0, max_dims=0), [1, 0, 0, 0]), # all valid scalar
+        (dict(min_dims=0, max_dims=0), [1, 0, 0, 1]), # all nan scalar
+        (dict(min_dims=1, max_dims=1,
+            min_side=5, max_side=6), [1, 0, 0, 0]), # all valid array
+        (dict(min_dims=1, max_dims=1,
+            min_side=5, max_side=6), [0, 0, 0, 1]), # all nan array
+        (dict(min_dims=1, max_dims=1,  # mixed valid, invalid, and edge cases
+            min_side=20, max_side=25), [0.25, 0.25, 0.25, 0.25]),
+    ] + [({}, None)]*15  # other, randomly-generated shape options
 
-discrete_families = [
-    Binomial,
-]
+    @pytest.fixture(params=list(enumerate(_options)), ids=range(len(_options)))
+    def options(self, request):
+        return request.param
 
-families = continuous_families + discrete_families
-_options = [
-    (dict(min_dims=0, max_dims=0), [1, 0, 0, 0]), # all valid scalar
-    (dict(min_dims=0, max_dims=0), [1, 0, 0, 1]), # all nan scalar
-    (dict(min_dims=1, max_dims=1,
-          min_side=5, max_side=6), [1, 0, 0, 0]), # all valid array
-    (dict(min_dims=1, max_dims=1,
-          min_side=5, max_side=6), [0, 0, 0, 1]), # all nan array
-    (dict(min_dims=1, max_dims=1,  # mixed valid, invalid, and edge cases
-          min_side=20, max_side=25), [0.25, 0.25, 0.25, 0.25]),
-] + [({}, None)]*15  # other, randomly-generated shape options
+    @pytest.fixture
+    def case(self, options):
+        i, _options = options
+        shape_options, proportions = _options
+        rng = np.random.default_rng(abs(hash((i, self.seed))))
+        tmp = draw_distribution_from_family(self.family, rng,
+                                            shape_options, proportions)
+        return _RichResult(family=self.family, rng=rng, **tmp)
 
-
-@pytest.fixture(params=list(enumerate(_options)), ids=range(len(_options)))
-def options(request):
-    return request.param
-
-
-@pytest.fixture(params=list(enumerate(families)), ids=families)
-def family(request):
-    return request.param
-
-
-@pytest.fixture
-def case(family, options):
-    i, _options = options
-    shape_options, proportions = _options
-    j, family = family
-    rng = np.random.default_rng(abs(hash((i, j))))
-    tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
-    return _RichResult(family=family, rng=rng, **tmp)
-
-
-class TestDistributions:
     def test_support(self, case):
         check_support(case.dist)
 
@@ -252,7 +231,7 @@ class TestDistributions:
         sample_shape, = mutually_broadcastable_shapes(1, max_side=20, rng=case.rng)
         qrng = qmc.Halton(d=1, seed=case.rng)
         check_sample_shape_NaNs(case.dist, 'sample', sample_shape,
-                                case.result_shape, case.rng)
+                                case.result_shape, qrng)
 
     def test_entropy(self, case):
         with np.errstate(invalid='ignore'):
@@ -343,6 +322,36 @@ class TestDistributions:
     def test_iccdf(self, case):
         check_dist_func(case.dist, 'iccdf', case.p, case.x_result_shape,
                         {'complement', 'inversion'})
+
+
+class TestStandardNormal(DistributionsTest):
+    seed = 726527242
+    family = StandardNormal
+
+
+class TestNormal(DistributionsTest):
+    seed = 353965734
+    family = Normal
+
+
+class TestLogistic(DistributionsTest):
+    seed = 389513556
+    family = Logistic
+
+
+class TestUniform(DistributionsTest):
+    seed = 893709074
+    family = Uniform
+
+
+class Test_LogUniform(DistributionsTest):
+    seed = 260607439
+    family = _LogUniform
+
+
+class TestBinomial(DistributionsTest):
+    seed = 706381675
+    family = Binomial
 
 
 class TestOtherMethods:
@@ -838,7 +847,7 @@ def check_lmoment_funcs(dist, result_shape):
             dist.lmoment(1)
         return
 
-    atol = 3e-9
+    atol = 1e-8
 
     def check(order, standardize=False, method=None, ref=None, success=True):
         if success:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -216,11 +216,11 @@ class DistributionsTest:
     def test_support(self, case):
         check_support(case.dist)
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_moment(self, case):
         check_moment_funcs(case.dist, case.result_shape)  # this needs to get split up
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_lmoment(self, case):
         check_lmoment_funcs(case.dist, case.result_shape)
 
@@ -250,22 +250,22 @@ class DistributionsTest:
         check_dist_func(case.dist, 'mode', None, case.result_shape,
                         {'optimization'}, tol_override={'atol': 1e-6})
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_mean(self, case):
         check_dist_func(case.dist, 'mean', None, case.result_shape, {'cache'})
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_variance(self, case):
         check_dist_func(case.dist, 'variance', None, case.result_shape, {'cache'})
 
     def test_standard_deviation(self, case):
         assert_allclose(case.dist.standard_deviation()**2, case.dist.variance())
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_skewness(self, case):
         check_dist_func(case.dist, 'skewness', None, case.result_shape, {'cache'})
 
-    @pytest.mark.thread_unsafe(reason="unknown")
+    @pytest.mark.thread_unsafe(reason="tests cache of shared `case.dist`")
     def test_kurtosis(self, case):
         check_dist_func(case.dist, 'kurtosis', None, case.result_shape, {'cache'})
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -24,6 +24,7 @@ from scipy.stats._new_distributions import StandardNormal, _LogUniform, _Gamma
 from scipy.stats._new_distributions import DiscreteDistribution
 from scipy.stats import Normal, Logistic, Uniform, Binomial
 from scipy._lib._testutils import mutually_broadcastable_shapes
+from scipy._lib._util import _RichResult
 
 
 class Test_RealInterval:
@@ -147,9 +148,11 @@ class Test_RealInterval:
         assert domain1.symbols is not domain2.symbols
 
 
-def draw_distribution_from_family(family, rng, shape_options, proportions):
+def draw_distribution_from_family(family, rng, shape_options,
+                                  proportions=None):
     # If the distribution has parameters, choose a parameterization and
     # draw broadcastable shapes for the parameter arrays.
+    proportions = (0.7, 0.1, 0.1, 0.1) if proportions is None else proportions
     n_parameterizations = family._num_parameterizations()
     if n_parameterizations > 0:
         i = rng.integers(0, n_parameterizations)
@@ -181,7 +184,8 @@ def draw_distribution_from_family(family, rng, shape_options, proportions):
     with np.errstate(divide='ignore', invalid='ignore'):
         logp = np.log(p)
 
-    return dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape
+    return _RichResult(dist=dist, x=x, y=y, p=p, logp=logp, result_shape=result_shape,
+                       x_result_shape=x_result_shape, xy_result_shape=xy_result_shape)
 
 
 continuous_families = [
@@ -197,84 +201,151 @@ discrete_families = [
 ]
 
 families = continuous_families + discrete_families
-shape_options = [{}]*20
+_options = [
+    (dict(min_dims=0, max_dims=0), [1, 0, 0, 0]), # all valid scalar
+    (dict(min_dims=0, max_dims=0), [1, 0, 0, 1]), # all nan scalar
+    (dict(min_dims=1, max_dims=1,
+          min_side=5, max_side=6), [1, 0, 0, 0]), # all valid array
+    (dict(min_dims=1, max_dims=1,
+          min_side=5, max_side=6), [0, 0, 0, 1]), # all nan array
+    (dict(min_dims=1, max_dims=1,  # mixed valid, invalid, and edge cases
+          min_side=20, max_side=25), [0.25, 0.25, 0.25, 0.25]),
+] + [({}, None)]*15  # other, randomly-generated shape options
+
+
+@pytest.fixture(params=list(enumerate(_options)), ids=range(len(_options)))
+def options(request):
+    return request.param
+
+
+@pytest.fixture(params=list(enumerate(families)), ids=families)
+def family(request):
+    return request.param
+
+
+@pytest.fixture
+def case(family, options):
+    i, _options = options
+    shape_options, proportions = _options
+    j, family = family
+    rng = np.random.default_rng(abs(hash((i, j))))
+    tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
+    return _RichResult(family=family, rng=rng, **tmp)
 
 
 class TestDistributions:
-    @pytest.mark.parametrize('i, shape_options', list(enumerate(shape_options)))
-    @pytest.mark.parametrize('j, family',  list(enumerate(families)))
-    def test_support_moments_sample(self, i, shape_options, j, family):
-        rng = np.random.default_rng(abs(hash((i, j))))
+    def test_support(self, case):
+        check_support(case.dist)
 
-        # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
-        dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
-        sample_shape, = mutually_broadcastable_shapes(1, min_dims=0, min_side=0,
-                                                      max_side=20)
+    def test_moment(self, case):
+        check_moment_funcs(case.dist, case.result_shape)  # this needs to get split up
 
-        with np.errstate(invalid='ignore', divide='ignore'):
-            check_support(dist)
-            check_moment_funcs(dist, result_shape)  # this needs to get split up
-            check_lmoment_funcs(dist, result_shape)
-            check_sample_shape_NaNs(dist, 'sample', sample_shape, result_shape, rng)
-            qrng = qmc.Halton(d=1, seed=rng)
-            check_sample_shape_NaNs(dist, 'sample', sample_shape, result_shape, qrng)
+    def test_lmoment(self, case):
+        check_lmoment_funcs(case.dist, case.result_shape)
 
-    @pytest.mark.fail_slow(10)
-    @pytest.mark.parametrize('i, family',  list(enumerate(families)))
-    @pytest.mark.parametrize('j, func, methods, arg', [
-        (1, 'entropy', {'log/exp', 'quadrature'}, None),
-        (2, 'logentropy', {'log/exp', 'quadrature'}, None),
-        (3, 'median', {'icdf'}, None),
-        (4, 'mode', {'optimization'}, None),
-        (5, 'mean', {'cache'}, None),
-        (6, 'variance', {'cache'}, None),
-        (7, 'skewness', {'cache'}, None),
-        (8, 'kurtosis', {'cache'}, None),
-        (9, 'pdf', {'log/exp'}, 'x'),
-        (10, 'logpdf', {'log/exp'}, 'x'),
-        (11, 'logcdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-        (12, 'cdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-        (13, 'logccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-        (14, 'ccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-        (15, 'ilogccdf', {'complement', 'inversion'}, 'logp'),
-        (16, 'iccdf', {'complement', 'inversion'}, 'p'),
-    ])
-    @pytest.mark.parametrize('k, shape_options',  list(enumerate(shape_options)))
-    def test_funcs(self, i, family, j, func, methods, arg, k, shape_options):
-        if family == Uniform and func == 'mode':
+    def test_random_sample(self, case):
+        sample_shape, = mutually_broadcastable_shapes(1, max_side=20, rng=case.rng)
+        check_sample_shape_NaNs(case.dist, 'sample', sample_shape,
+                                case.result_shape, case.rng)
+
+    def test_quasi_random_sample(self, case):
+        sample_shape, = mutually_broadcastable_shapes(1, max_side=20, rng=case.rng)
+        qrng = qmc.Halton(d=1, seed=case.rng)
+        check_sample_shape_NaNs(case.dist, 'sample', sample_shape,
+                                case.result_shape, case.rng)
+
+    def test_entropy(self, case):
+        with np.errstate(invalid='ignore'):
+            check_dist_func(case.dist, 'entropy', None, case.result_shape,
+                            {'log/exp', 'quadrature'})
+
+    def test_logentropy(self, case):
+        with np.errstate(invalid='ignore'):
+            check_dist_func(case.dist, 'logentropy', None, case.result_shape,
+                            {'log/exp', 'quadrature'})
+
+    def test_median(self, case):
+        check_dist_func(case.dist, 'median', None, case.result_shape, {'icdf'})
+
+    def test_mode(self, case):
+        if case.family == Uniform:
             pytest.skip("Mode is not unique; `method`s disagree.")
+        check_dist_func(case.dist, 'mode', None, case.result_shape,
+                        {'optimization'}, tol_override={'atol': 1e-6})
 
-        rng = np.random.default_rng(abs(hash((i, j, k))))
+    def test_mean(self, case):
+        check_dist_func(case.dist, 'mean', None, case.result_shape, {'cache'})
 
-        # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
-        dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
+    def test_variance(self, case):
+        check_dist_func(case.dist, 'variance', None, case.result_shape, {'cache'})
 
-        args = {'x': x, 'p': p, 'logp': p}
-        with np.errstate(invalid='ignore', divide='ignore', over='ignore'):
-            if arg is None:
-                check_dist_func(dist, func, None, result_shape, methods)
-            elif arg in args:
-                check_dist_func(dist, func, args[arg], x_result_shape, methods)
+    def test_standard_deviation(self, case):
+        assert_allclose(case.dist.standard_deviation()**2, case.dist.variance())
 
-        if func == 'variance':
-            assert_allclose(dist.standard_deviation()**2, dist.variance())
+    def test_skewness(self, case):
+        check_dist_func(case.dist, 'skewness', None, case.result_shape, {'cache'})
 
-        # invalid and divide are to be expected; maybe look into over
-        with np.errstate(invalid='ignore', divide='ignore', over='ignore'):
-            if not isinstance(dist, ShiftedScaledDistribution):
-                if func == 'cdf':
-                    methods = {'quadrature'}
-                    check_cdf2(dist, False, x, y, xy_result_shape, methods)
-                    check_cdf2(dist, True, x, y, xy_result_shape, methods)
-                elif func == 'ccdf':
-                    methods = {'addition'}
-                    check_ccdf2(dist, False, x, y, xy_result_shape, methods)
-                    check_ccdf2(dist, True, x, y, xy_result_shape, methods)
+    def test_kurtosis(self, case):
+        check_dist_func(case.dist, 'kurtosis', None, case.result_shape, {'cache'})
 
+    def test_pdf(self, case):
+        check_dist_func(case.dist, 'pdf', case.x, case.x_result_shape, {'log/exp'})
+
+    def test_logpdf(self, case):
+        with np.errstate(divide='ignore'):
+            check_dist_func(case.dist, 'logpdf', case.x, case.x_result_shape,
+                            {'log/exp'})
+
+    def test_logcdf(self, case):
+        check_dist_func(case.dist, 'logcdf', case.x, case.x_result_shape,
+                        {'log/exp', 'complement', 'quadrature'})
+
+    def test_cdf(self, case):
+        check_dist_func(case.dist, 'cdf', case.x, case.x_result_shape,
+                        {'log/exp', 'complement', 'quadrature'})
+
+    def test_cdf2(self, case):
+        with np.errstate(invalid='ignore', divide='ignore'):
+            check_cdf2(case.dist, False, case.x, case.y,
+                       case.xy_result_shape, {'quadrature'})
+            check_cdf2(case.dist, True, case.x, case.y,
+                       case.xy_result_shape, {'quadrature'})
+
+    def test_logccdf(self, case):
+        check_dist_func(case.dist, 'logccdf', case.x, case.x_result_shape,
+                        {'log/exp', 'complement', 'quadrature'})
+
+    def test_ccdf(self, case):
+        check_dist_func(case.dist, 'ccdf', case.x, case.x_result_shape,
+                        {'log/exp', 'complement', 'quadrature'})
+
+    def test_ccdf2(self, case):
+        with np.errstate(invalid='ignore', divide='ignore'):
+            check_ccdf2(case.dist, False, case.x, case.y,
+                        case.xy_result_shape, {'addition'})
+            check_ccdf2(case.dist, True, case.x, case.y,
+                        case.xy_result_shape, {'addition'})
+
+    def test_ilogcdf(self, case):
+        with np.errstate(divide='ignore', over='ignore'):
+            check_dist_func(case.dist, 'ilogcdf', case.logp, case.x_result_shape,
+                            {'complement', 'inversion'})
+
+    def test_icdf(self, case):
+        check_dist_func(case.dist, 'icdf', case.p, case.x_result_shape,
+                        {'complement', 'inversion'})
+
+    def test_ilogccdf(self, case):
+        with np.errstate(divide='ignore', over='ignore'):
+            check_dist_func(case.dist, 'ilogccdf', case.logp, case.x_result_shape,
+                            {'complement', 'inversion'})
+
+    def test_iccdf(self, case):
+        check_dist_func(case.dist, 'iccdf', case.p, case.x_result_shape,
+                        {'complement', 'inversion'})
+
+
+class TestOtherMethods:
     def test_plot(self):
         try:
             import matplotlib.pyplot as plt
@@ -434,7 +505,9 @@ def check_support(dist):
     assert b.dtype == dist._dtype
 
 
-def check_dist_func(dist, fname, arg, result_shape, methods):
+def check_dist_func(dist, fname, arg, result_shape, methods, tol_override=None):
+    tol_override = {'atol': 0} if tol_override is None else tol_override
+
     # Check that all computation methods of all distribution functions agree
     # with one another, effectively testing the correctness of the generic
     # computation methods and confirming the consistency of specific
@@ -451,18 +524,6 @@ def check_dist_func(dist, fname, arg, result_shape, methods):
 
     ref = getattr(dist, fname)(*args)
     check_nans_and_edges(dist, fname, arg, ref)
-
-    # Remove this after fixing `draw`
-    tol_override = {'atol': 1e-15}
-    # Mean can be 0, which makes logmean -inf.
-    if fname in {'logmean', 'mean', 'logskewness', 'skewness'}:
-        tol_override = {'atol': 1e-15}
-    elif fname in {'mode'}:
-        # can only expect about half of machine precision for optimization
-        # because math
-        tol_override = {'atol': 1e-6}
-    elif fname in {'logcdf'}:  # gh-22276
-        tol_override = {'rtol': 2e-7}
 
     if dist._overrides(f'_{fname}_formula'):
         methods.add('formula')
@@ -777,7 +838,7 @@ def check_lmoment_funcs(dist, result_shape):
             dist.lmoment(1)
         return
 
-    atol = 2e-9
+    atol = 3e-9
 
     def check(order, standardize=False, method=None, ref=None, success=True):
         if success:
@@ -1568,7 +1629,7 @@ class TestMakeDistribution:
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
     @pytest.mark.slow  # just in case
-    @pytest.mark.parametrize('seed', 777603258 + np.arange(20))
+    @pytest.mark.parametrize('seed', 77760325 + np.arange(20))
     def test_draw_distribution(self, seed):
         # `draw_distribution_from_family` is a private function right now, but we may
         # want that functionality to be public someday. It was broken for custom
@@ -1591,7 +1652,7 @@ class TestMakeDistribution:
         family = stats.make_distribution(MyNormal())
         proportions = (1.0, 0., 0., 0.)
         tmp = draw_distribution_from_family(family, rng, {'min_side': 1}, proportions)
-        dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
+        dist, x = tmp.dist, tmp.x
         assert u_typical[0] < np.min(dist.u) and np.max(dist.u) < u_typical[1]
         assert s_typical[0] < np.min(dist.s) and np.max(dist.s) < s_typical[1]
         assert x_typical[0] < np.min(x) and np.max(x) < x_typical[1]
@@ -1660,7 +1721,7 @@ class TestTransforms:
         assert np.all((sample > lb) & (sample < ub))
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.parametrize('seed', 9116796398 + np.arange(20))
+    @pytest.mark.parametrize('seed', 911679639 + np.arange(20))
     def test_loc_scale(self, seed):
         # Need tests with negative scale
         rng = np.random.default_rng(seed)
@@ -1671,7 +1732,7 @@ class TestTransforms:
 
         tmp = draw_distribution_from_family(
             TransformedNormal, rng, {'min_side': 1}, proportions=(1, 0, 0, 0))
-        dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
+        dist, x, y, p, logp = tmp.dist, tmp.x, tmp.y, tmp.p, tmp.logp
 
         loc = dist.loc
         # negative scale tested in test_abs_finite_support, test_reciprocal, etc.

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -327,27 +327,27 @@ class TestStandardNormal(DistributionsTest):
     seed = 726527242
     family = StandardNormal
 
+    @pytest.mark.filterwarnings("ignore:divide:RuntimeWarning")
     def test_cdf2(self, case):
-        with np.errstate(divide='ignore'):
-            return super().test_cdf2(case)
+        return super().test_cdf2(case)
 
 
 class TestNormal(DistributionsTest):
     seed = 353965734
     family = Normal
 
+    @pytest.mark.filterwarnings("ignore:divide:RuntimeWarning")
     def test_logpdf(self, case):
-        with np.errstate(divide='ignore'):
-            return super().test_logpdf(case)
+        return super().test_logpdf(case)
 
 
 class TestLogistic(DistributionsTest):
     seed = 389513556
     family = Logistic
 
+    @pytest.mark.filterwarnings("ignore:divide:RuntimeWarning")
     def test_cdf2(self, case):
-        with np.errstate(divide='ignore'):
-            return super().test_cdf2(case)
+        return super().test_cdf2(case)
 
 
 class TestUniform(DistributionsTest):
@@ -355,7 +355,7 @@ class TestUniform(DistributionsTest):
     family = Uniform
 
     def test_mode(self, case):
-        pytest.skip("mode of Uniform distribution is not unique")
+        assert_allclose(case.dist.mode(), case.dist.a + case.dist.ab/2)
 
 
 class Test_LogUniform(DistributionsTest):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -357,10 +357,18 @@ class TestUniform(DistributionsTest):
     def test_mode(self, case):
         assert_allclose(case.dist.mode(), case.dist.a + case.dist.ab/2)
 
+    @pytest.mark.fail_slow(10)
+    def test_quasi_random_sample(self, case):
+        return super().test_quasi_random_sample(case)
+
 
 class Test_LogUniform(DistributionsTest):
     seed = 260607439
     family = _LogUniform
+
+    @pytest.mark.fail_slow(10)
+    def test_lmoment(self, case):
+        return super().test_lmoment(case)
 
 
 class TestBinomial(DistributionsTest):
@@ -612,8 +620,10 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
                 res = (np.exp(dist.logcdf(x, y, method=method)) if log
                        else dist.cdf(x, y, method=method))
             continue
-        res = (np.exp(dist.logcdf(x, y, method=method)) if log
-               else dist.cdf(x, y, method=method))
+        with np.errstate(invalid='ignore'):
+            # np.exp(np.nan) raises on some platforms?
+            res = (np.exp(dist.logcdf(x, y, method=method)) if log
+                else dist.cdf(x, y, method=method))
         np.testing.assert_allclose(res, ref, atol=1e-14)
         if log:
             np.testing.assert_equal(res.dtype, (ref + 0j).dtype)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy import inf
 import pytest
 from numpy.testing import assert_allclose, assert_equal
-from hypothesis import strategies, given, reproduce_failure, settings  # noqa: F401
+from hypothesis import strategies, given
 import hypothesis.extra.numpy as npst
 
 from scipy import special
@@ -147,7 +147,7 @@ class Test_RealInterval:
         assert domain1.symbols is not domain2.symbols
 
 
-def draw_distribution_from_family(family, rng, proportions, min_side=0):
+def draw_distribution_from_family(family, rng, shape_options, proportions):
     # If the distribution has parameters, choose a parameterization and
     # draw broadcastable shapes for the parameter arrays.
     n_parameterizations = family._num_parameterizations()
@@ -155,7 +155,7 @@ def draw_distribution_from_family(family, rng, proportions, min_side=0):
         i = rng.integers(0, n_parameterizations)
         n_parameters = family._num_parameters(i)
         shapes = mutually_broadcastable_shapes(num_shapes=n_parameters,
-                                               min_side=min_side, rng=rng)
+                                               rng=rng, **shape_options)
         result_shape = np.broadcast_shapes(*shapes)
         dist = family._draw(shapes, rng=rng, proportions=proportions,
                             i_parameterization=i)
@@ -166,12 +166,12 @@ def draw_distribution_from_family(family, rng, proportions, min_side=0):
     # Draw a broadcastable shape for the arguments, and draw values for the
     # arguments.
     x_shape, = mutually_broadcastable_shapes(1, base_shape=result_shape,
-                                             min_side=min_side)
+                                             rng=rng, **shape_options)
     x = dist._variable.draw(x_shape, parameter_values=dist._parameters,
                             proportions=proportions, rng=rng, region='typical')
     x_result_shape = np.broadcast_shapes(x_shape, result_shape)
     y_shape, = mutually_broadcastable_shapes(1, base_shape=x_result_shape,
-                                             min_side=min_side)
+                                             rng=rng, **shape_options)
     y = dist._variable.draw(y_shape, parameter_values=dist._parameters,
                             proportions=proportions, rng=rng, region='typical')
     xy_result_shape = np.broadcast_shapes(y_shape, x_result_shape)
@@ -197,19 +197,18 @@ discrete_families = [
 ]
 
 families = continuous_families + discrete_families
+shape_options = [{}]*20
 
 
 class TestDistributions:
-    @pytest.mark.fail_slow(60)  # need to break up check_moment_funcs
-    @settings(max_examples=20)
-    @pytest.mark.parametrize('family', families)
-    @given(seed=strategies.integers(min_value=0))
-    def test_support_moments_sample(self, family, seed):
-        rng = np.random.default_rng(seed)
+    @pytest.mark.parametrize('i, shape_options', list(enumerate(shape_options)))
+    @pytest.mark.parametrize('j, family',  list(enumerate(families)))
+    def test_support_moments_sample(self, i, shape_options, j, family):
+        rng = np.random.default_rng(abs(hash((i, j))))
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
         proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, rng, proportions)
+        tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
         sample_shape, = mutually_broadcastable_shapes(1, min_dims=0, min_side=0,
                                                       max_side=20)
@@ -223,36 +222,35 @@ class TestDistributions:
             check_sample_shape_NaNs(dist, 'sample', sample_shape, result_shape, qrng)
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.parametrize('family', families)
-    @pytest.mark.parametrize('func, methods, arg',
-                             [('entropy', {'log/exp', 'quadrature'}, None),
-                              ('logentropy', {'log/exp', 'quadrature'}, None),
-                              ('median', {'icdf'}, None),
-                              ('mode', {'optimization'}, None),
-                              ('mean', {'cache'}, None),
-                              ('variance', {'cache'}, None),
-                              ('skewness', {'cache'}, None),
-                              ('kurtosis', {'cache'}, None),
-                              ('pdf', {'log/exp'}, 'x'),
-                              ('logpdf', {'log/exp'}, 'x'),
-                              ('logcdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-                              ('cdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-                              ('logccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-                              ('ccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
-                              ('ilogccdf', {'complement', 'inversion'}, 'logp'),
-                              ('iccdf', {'complement', 'inversion'}, 'p'),
-                              ])
-    @settings(max_examples=20)
-    @given(seed=strategies.integers(min_value=0))
-    def test_funcs(self, family, seed, func, methods, arg):
+    @pytest.mark.parametrize('i, family',  list(enumerate(families)))
+    @pytest.mark.parametrize('j, func, methods, arg', [
+        (1, 'entropy', {'log/exp', 'quadrature'}, None),
+        (2, 'logentropy', {'log/exp', 'quadrature'}, None),
+        (3, 'median', {'icdf'}, None),
+        (4, 'mode', {'optimization'}, None),
+        (5, 'mean', {'cache'}, None),
+        (6, 'variance', {'cache'}, None),
+        (7, 'skewness', {'cache'}, None),
+        (8, 'kurtosis', {'cache'}, None),
+        (9, 'pdf', {'log/exp'}, 'x'),
+        (10, 'logpdf', {'log/exp'}, 'x'),
+        (11, 'logcdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
+        (12, 'cdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
+        (13, 'logccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
+        (14, 'ccdf', {'log/exp', 'complement', 'quadrature'}, 'x'),
+        (15, 'ilogccdf', {'complement', 'inversion'}, 'logp'),
+        (16, 'iccdf', {'complement', 'inversion'}, 'p'),
+    ])
+    @pytest.mark.parametrize('k, shape_options',  list(enumerate(shape_options)))
+    def test_funcs(self, i, family, j, func, methods, arg, k, shape_options):
         if family == Uniform and func == 'mode':
             pytest.skip("Mode is not unique; `method`s disagree.")
 
-        rng = np.random.default_rng(seed)
+        rng = np.random.default_rng(abs(hash((i, j, k))))
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
         proportions = (0.7, 0.1, 0.1, 0.1)
-        tmp = draw_distribution_from_family(family, rng, proportions)
+        tmp = draw_distribution_from_family(family, rng, shape_options, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 
         args = {'x': x, 'p': p, 'logp': p}
@@ -390,6 +388,7 @@ class TestDistributions:
         assert res1[1] == res2[1]
         assert res1[1] != ref[1]
 
+
 def check_sample_shape_NaNs(dist, fname, sample_shape, result_shape, rng):
     full_shape = sample_shape + result_shape
     if fname == 'sample':
@@ -488,6 +487,7 @@ def check_dist_func(dist, fname, arg, result_shape, methods):
         np.testing.assert_equal(res.shape, result_shape)
         if result_shape == tuple():
             assert np.isscalar(res)
+
 
 def check_cdf2(dist, log, x, y, result_shape, methods):
     # Specialized test for 2-arg cdf since the interface is a bit different
@@ -889,6 +889,7 @@ def get_valid_parameters(dist):
     assert_equal(~all_valid, dist._invalid)
 
     return all_valid
+
 
 def classify_arg(dist, arg, arg_domain):
     if arg is None:
@@ -1567,8 +1568,7 @@ class TestMakeDistribution:
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
     @pytest.mark.slow  # just in case
-    @settings(max_examples=20)  # no need for more
-    @given(seed=strategies.integers(min_value=0))
+    @pytest.mark.parametrize('seed', 777603258 + np.arange(20))
     def test_draw_distribution(self, seed):
         # `draw_distribution_from_family` is a private function right now, but we may
         # want that functionality to be public someday. It was broken for custom
@@ -1590,7 +1590,7 @@ class TestMakeDistribution:
 
         family = stats.make_distribution(MyNormal())
         proportions = (1.0, 0., 0., 0.)
-        tmp = draw_distribution_from_family(family, rng, proportions, min_side=1)
+        tmp = draw_distribution_from_family(family, rng, {'min_side': 1}, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
         assert u_typical[0] < np.min(dist.u) and np.max(dist.u) < u_typical[1]
         assert s_typical[0] < np.min(dist.s) and np.max(dist.s) < s_typical[1]
@@ -1660,7 +1660,7 @@ class TestTransforms:
         assert np.all((sample > lb) & (sample < ub))
 
     @pytest.mark.fail_slow(10)
-    @given(seed=strategies.integers(min_value=0))
+    @pytest.mark.parametrize('seed', 9116796398 + np.arange(20))
     def test_loc_scale(self, seed):
         # Need tests with negative scale
         rng = np.random.default_rng(seed)
@@ -1670,7 +1670,7 @@ class TestTransforms:
                 super().__init__(StandardNormal(), *args, **kwargs)
 
         tmp = draw_distribution_from_family(
-            TransformedNormal, rng, proportions=(1, 0, 0, 0), min_side=1)
+            TransformedNormal, rng, {'min_side': 1}, proportions=(1, 0, 0, 0))
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 
         loc = dist.loc
@@ -2019,6 +2019,7 @@ class TestTransforms:
         assert_allclose(Y.ilogccdf(np.log(p)), Y0.isf(p))
         sample = Y.sample(10)
         assert np.all(sample > 0)
+
 
 class TestOrderStatistic:
     @pytest.mark.fail_slow(20)  # Moments require integration

--- a/scipy/stats/tests/test_distribution_test.py
+++ b/scipy/stats/tests/test_distribution_test.py
@@ -1,0 +1,38 @@
+# This is added as a separate file to demonstrate how users can run standard
+# distribution tests on custom distributions; it relies only on `DistributionsTest`,
+# no other definitions in `test_continuous.py`.
+import pytest
+import numpy as np
+from scipy import stats, special
+from .test_continuous import DistributionsTest
+
+
+class MyNormal:
+    __make_distribution_version__ = "1.16.0"
+    parameters = {'u': {'endpoints': (-np.inf, np.inf), 'typical': (-1, 1)},
+                    's': {'endpoints': (0, np.inf), 'typical': (0.5, 2)}}
+    support = {'endpoints': (-np.inf, np.inf), 'typical': (-3, 3)}
+
+    def pdf(self, x, u, s):
+        return 1 / np.sqrt(2*np.pi) / s * np.exp(-((x-u)/s)**2/2)
+
+    def cdf(self, x, u, s):
+        return special.ndtr((x-u)/s)
+
+    def logcdf(self, x, u, s):
+        return special.log_ndtr((x-u)/s)
+
+    def icdf(self, p, u, s):
+        return special.ndtri(p)*s + u
+
+    def entropy(self, u, s):
+        return np.full_like(u, fill_value=np.log(2*np.pi*np.e*s**2)/2)
+
+
+class TestMyNormal(DistributionsTest):
+    family = stats.make_distribution(MyNormal())
+    seed =7694871135
+
+    @pytest.mark.xslow
+    def test_lmoment(self, case):
+        return super().test_lmoment()


### PR DESCRIPTION
#### Reference issue
gh-20544 ("Also, to facilitate array API test translations and speed up test execution, it would be good to eliminate use of hypothesis from tests.")
Toward gh-25837 

#### What does this implement/fix?
This PR will refactor the tests of `scipy.stats.UnivariateDistribution` to:
- [x] eliminate use of `hypothesis`
- [x] break up tests
  - [x] break up `test_support_moments_sample` by function
  - [x] break up `test_funcs` by function
- [x] refactor for greater control. Rather than `@parametrize`ing over distributions, I'm thinking about subclassing `TestDistributions`. This will make it easier for different distributions to control tolerances independently, modify existing tests, and add distribution-specific tests.
- [x] ~~rename `test_continuous.py`, and consider splitting~~ separate PR
- [x] ~~other Array API preparations~~ I don't think we need anything here.


#### AI Generation Disclosure
No AI yet except that I had GPT-5.6 Sol analyze a log of all the `shapes`, `x_shape`, and `y_shape` generated by `draw_distribution_from_family` (main vs PR) to check that we're still getting good coverage. Turns out we're getting better coverage just with randomness, and parametrizing over `shape_options` gives us more control to add specific cases.

<details>

# Shape and broadcasting coverage: `main.npz` versus `PR2.npz`

## Executive summary

`PR2.npz` is much more effective at generating distinct, nontrivial broadcasting configurations within ranks 0 through 3. Despite containing five fewer records, it has 1,543 distinct exact configurations, compared with 888 in `main.npz`. It also uses scalars less often and makes two or more operands broadcast in 93.2% of records, compared with 74.4% in `main.npz`.

`main.npz` has one important advantage: it covers higher dimensionality. Its results reach rank 6, whereas every result in `PR2.npz` has rank at most 3. Consequently, `main.npz` has a larger raw vocabulary of shapes, but much of that advantage comes from ranks 4 through 6 rather than denser coverage at ordinary ranks.

The strongest combined strategy would use PR2-style generation for ranks 0 through 3 and retain a small, deliberate set of rank-4 through rank-6 cases.

## Data and methodology

Each record was normalized to

```text
(tuple(parameter_shapes), x_shape, y_shape)
```

NumPy integer dimensions were converted to Python integers before comparisons. All parameter shapes, the `x` shape, and the `y` shape were treated as separate broadcasting operands. The broadcast-result shape was computed with `numpy.broadcast_shapes`.

The archives contain only shape information. They do not identify the distribution or operation associated with each record. Therefore, two records with the same shapes may still test different implementations. Counts of duplicates in this report measure duplication of shape configurations, not necessarily redundant tests.

## Definitions

The short labels used below have the following precise meanings.

**Exact configuration**

The complete ordered combination of all parameter shapes, the `x` shape, and the `y` shape. Parameter order is significant. Two records are exact duplicates only when all these shapes agree.

**Structural broadcast pattern**

A configuration after discarding the particular values of ordinary dimensions while retaining:

- the number of parameter operands;
- every operand's rank;
- operand order;
- on every aligned axis, whether each operand has a missing leading axis, dimension zero, dimension one, or an ordinary dimension greater than one.

Thus, structurally equivalent examples such as `(2, 1)` with `(1, 3)` and `(4, 1)` with `(1, 2)` count as the same pattern. Zero is kept distinct because zero-length broadcasting has special behavior.

**Implicit leading-axis expansion** or **rank padding**

At least one operand has fewer axes than the broadcast result. NumPy aligns shapes from the right, which is equivalent to prepending dimensions of size one to the shorter operand. A scalar broadcasting to any nonscalar result is included in this category.

**Mixed operand ranks**

Not all operands have the same rank. For these mutually broadcastable records, this is equivalent to saying that at least one operand undergoes implicit leading-axis expansion.

**Singleton expansion**

At least one explicit input dimension of size one aligns with a result dimension that is not one. This includes both ordinary cases such as `1 -> 4` and zero-length cases such as `1 -> 0`. Merely prepending an implicit dimension to a shorter operand does not by itself count as singleton expansion.

**No broadcasting required**

Every operand shape is already exactly equal to the result shape. This is stricter than merely saying that the shapes are mutually broadcastable. For example, `()` with `(3,)` does require broadcasting under this definition.

**Operand changed to the result shape**

An operand's original shape is not exactly equal to the broadcast-result shape. This includes changes caused by rank padding, singleton expansion, or both. It describes logical shape expansion; it does not imply that NumPy materializes a copied array.

**Zero-length dimension present**

At least one operand has an explicit dimension of size zero. Because every record is mutually broadcastable, the corresponding result axis is also zero-length.

**Zero against singleton**

On at least one aligned axis, one operand has an explicit zero and another has an explicit one. Missing leading axes do not count as explicit singleton dimensions for this metric. For example, `(0, 3)` with `(1, 3)` qualifies and broadcasts to `(0, 3)`.

**Same-rank, multidirectional singleton expansion**

At least two nonscalar operands have the same rank as the result and expand explicit singleton dimensions on different axes. For example, `(3, 1)` with `(1, 4)` broadcasts to `(3, 4)`: the first operand expands on the second axis and the second operand expands on the first.

**Three operands owning different result axes**

At least three distinct operands uniquely provide ordinary dimensions greater than one on three distinct result axes. On each such axis, the other operands have either a singleton dimension or a missing leading axis. A canonical example is `(2, 1, 1)`, `(1, 3, 1)`, and `(1, 1, 4)`, which broadcast to `(2, 3, 4)`.

**All operands scalar**

Every parameter shape, the `x` shape, and the `y` shape is `()`.

## Overall diversity

| Metric | `main.npz` | `PR2.npz` |
|---|---:|---:|
| Records | 2,025 | 2,020 |
| Distinct exact configurations | 888 (43.9%) | 1,543 (76.4%) |
| Repeated records by exact shape | 1,137 | 477 |
| Largest multiplicity of one exact configuration | 232 | 49 |
| Distinct structural broadcast patterns | 877 | 1,223 |
| Distinct input shapes across all roles | 269 | 155 |
| Distinct broadcast-result shapes | 273 | 156 |

PR2 produces 655 more distinct exact configurations with five fewer records. Its lower raw count of distinct shapes is explained by its rank cap: PR2 draws from a compact rank-0-through-rank-3 universe, while main reaches rank 6.

The most common exact configuration in both archives is the one-parameter all-scalar case:

```text
parameter shapes = [()], x = (), y = () -> result = ()
```

It occurs 232 times in main and 49 times in PR2.

## Rank coverage

### Broadcast-result ranks

| Result rank | `main.npz` | `PR2.npz` |
|---:|---:|---:|
| 0 | 448 (22.1%) | 69 (3.4%) |
| 1 | 315 (15.6%) | 301 (14.9%) |
| 2 | 659 (32.5%) | 619 (30.6%) |
| 3 | 223 (11.0%) | 1,031 (51.0%) |
| 4 | 298 (14.7%) | 0 |
| 5 | 42 (2.1%) | 0 |
| 6 | 40 (2.0%) | 0 |

Main assigns 18.8% of its records to result ranks 4 through 6. PR2 instead concentrates just over half of its records at rank 3.

### Distinct input shapes by rank

| Input-shape rank | `main.npz` | `PR2.npz` | Possible in PR2's `{0,1,2,3,4}` dimension universe |
|---:|---:|---:|---:|
| 0 | 1 | 1 | 1 |
| 1 | 5 | 5 | 5 |
| 2 | 21 | 25 | 25 |
| 3 | 60 | 124 | 125 |
| 4 | 110 | 0 | Not in scope |
| 5 | 34 | 0 | Not in scope |
| 6 | 38 | 0 | Not in scope |

PR2 covers every possible rank-0, rank-1, and rank-2 input shape using dimensions `{0,1,2,3,4}`. At rank 3 it covers 124 of 125 possibilities; the only absent input shape is `(2, 2, 0)`. That shape does occur as a broadcast result, so PR2 still covers all 156 possible result shapes in its bounded universe.

## Coverage by operand role

| Role | Metric | `main.npz` | `PR2.npz` |
|---|---|---:|---:|
| Parameters | Operand occurrences | 3,370 | 3,360 |
| Parameters | Distinct shapes | 13 | 148 |
| Parameters | Scalar occurrences | 1,921 (57.0%) | 1,426 (42.4%) |
| `x` | Operand occurrences | 2,025 | 2,020 |
| `x` | Distinct shapes | 143 | 139 |
| `x` | Scalar occurrences | 929 (45.9%) | 539 (26.7%) |
| `y` | Operand occurrences | 2,025 | 2,020 |
| `y` | Distinct shapes | 219 | 115 |
| `y` | Scalar occurrences | 1,042 (51.5%) | 558 (27.6%) |

The most substantial PR2 improvement is parameter-shape diversity: 148 distinct shapes rather than 13. Main's larger `y` vocabulary is primarily a consequence of permitting ranks 4 through 6.

Across all roles, 52.5% of main's operands are scalar, compared with 34.1% of PR2's operands.

## Broadcasting mechanisms

| Per-record condition | `main.npz` | `PR2.npz` |
|---|---:|---:|
| No broadcasting required | 453 (22.4%) | 76 (3.8%) |
| Implicit leading-axis expansion, without singleton expansion | 872 (43.1%) | 750 (37.1%) |
| Singleton expansion, without implicit leading-axis expansion | 2 (0.1%) | 46 (2.3%) |
| Both mechanisms | 698 (34.5%) | 1,148 (56.8%) |
| Any implicit leading-axis expansion | 1,570 (77.5%) | 1,898 (94.0%) |
| Any singleton expansion | 700 (34.6%) | 1,194 (59.1%) |
| Zero-length dimension present | 728 (36.0%) | 705 (34.9%) |

The four mechanism rows at the top of the table are mutually exclusive and exhaust all records. PR2's main improvement is not merely that it broadcasts more often: it combines rank padding and explicit singleton expansion in 56.8% of records, compared with 34.5% in main.

### Number of operands changed to the result shape

| Changed operands | `main.npz` | `PR2.npz` |
|---:|---:|---:|
| 0 | 453 (22.4%) | 76 (3.8%) |
| 1 | 65 (3.2%) | 61 (3.0%) |
| 2 | 451 (22.3%) | 711 (35.2%) |
| 3 | 749 (37.0%) | 798 (39.5%) |
| 4 | 307 (15.2%) | 374 (18.5%) |

Records have either three operands (one parameter, `x`, and `y`) or four operands (two parameters, `x`, and `y`). PR2 changes at least two operands in 1,883 records, or 93.2% of the archive. Main does so in 1,507 records, or 74.4%.

## Selected situations

| Situation | `main.npz` | `PR2.npz` |
|---|---:|---:|
| Same-rank, multidirectional singleton expansion | 12 | 38 |
| Three operands owning different result axes | 3 | 2 |
| Zero against singleton | 359 | 399 |
| All operands scalar | 448 | 69 |

Both archives contain every selected situation. PR2 gives substantially more coverage to same-rank multidirectional expansion and slightly more to explicit zero-versus-singleton broadcasting. Cases in which three operands independently determine three result axes remain rare in both archives.

The all-scalar count is large in main because it includes records associated with different parameter counts and, potentially, different distributions. It should not automatically be interpreted as 448 redundant tests. As shape coverage alone, however, it is heavy repetition of the same baseline condition.

## Dimension values

Counting every explicit axis in every operand:

| Dimension value | `main.npz` | `PR2.npz` |
|---:|---:|---:|
| 0 | 1,273 | 1,168 |
| 1 | 4,221 | 4,730 |
| 2 | 1,122 | 1,213 |
| 3 | 304 | 1,270 |
| 4 | 89 | 1,254 |
| 5 | 8 | 0 |

On non-singleton ordinary dimensions, PR2 is much more balanced across sizes 2, 3, and 4. Main is strongly concentrated on size 2 and uses size 5 only eight times. The high frequency of ones in both archives is expected for generators designed to produce mutually broadcastable shapes.

## Assessment

Within ranks 0 through 3, PR2 is the stronger suite by a wide margin. It provides:

- many more exact and structural configurations;
- nearly exhaustive coverage of its intended input-shape universe;
- dramatically broader parameter-shape coverage;
- fewer all-scalar and otherwise non-broadcasting records;
- more cases combining rank padding with explicit singleton expansion; and
- more cases in which several operands change shape simultaneously.

Main remains valuable for a separate reason: high-rank coverage. It has 380 records whose broadcast result has rank 4, 5, or 6, including 82 at ranks 5 and 6. PR2 tests none of these ranks.

If PR2 is intended to replace main entirely, loss of high-rank coverage is the principal regression. If high-rank behavior is not inherently important, PR2 is a clear improvement. If it is important, a compact deterministic supplement of representative rank-4-through-rank-6 configurations would preserve main's distinctive benefit without restoring its heavy scalar duplication.

</details>
