### PR TITLE
DEP: interpolate: remove interp2d stub

### DIFF
--- a/doc/source/tutorial/interpolate/interp_transition_guide.md
+++ b/doc/source/tutorial/interpolate/interp_transition_guide.md
@@ -3,8 +3,8 @@
 
 This page contains three sets of demonstrations:
 
-- lower-level FITPACK replacements for {class}`scipy.interpolate.interp2d` for legacy bug-for-bug compatible {class}`scipy.interpolate.interp2d` replacements;
-- recommended replacements for {class}`scipy.interpolate.interp2d` for use in new code;
+- lower-level FITPACK replacements for `scipy.interpolate.interp2d` for legacy bug-for-bug compatible `scipy.interpolate.interp2d` replacements;
+- recommended replacements for `scipy.interpolate.interp2d` for use in new code;
 - a demonstration of failure modes of 2D FITPACK-based linear interpolation and recommended replacements.
 
 ## 1. How to transition away from using  `interp2d`

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -181,7 +181,6 @@ Additional tools
    pchip_interpolate
    Rbf
    interp1d
-   interp2d
 
 .. seealso::
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,4 +1,4 @@
-__all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
+__all__ = ['interp1d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 import functools
 import os
 from math import prod
@@ -123,47 +123,6 @@ def lagrange(x, w):
 # !! found, get rid of it!
 
 
-err_mesg = """\
-`interp2d` has been removed in SciPy 1.14.0.
-
-For legacy code, nearly bug-for-bug compatible replacements are
-`RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
-scattered 2D data.
-
-In new code, for regular grids use `RegularGridInterpolator` instead.
-For scattered data, prefer `LinearNDInterpolator` or
-`CloughTocher2DInterpolator`.
-
-For more details see
-https://scipy.github.io/devdocs/tutorial/interpolate/interp_transition_guide.html
-"""
-
-class interp2d:
-    """
-    interp2d(x, y, z, kind='linear', copy=True, bounds_error=False,
-             fill_value=None)
-
-    Class for 2D interpolation (deprecated and removed).
-
-    .. versionremoved:: 1.14.0
-
-        `interp2d` has been removed in SciPy 1.14.0.
-
-        For legacy code, nearly bug-for-bug compatible replacements are
-        `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
-        scattered 2D data.
-
-        In new code, for regular grids use `RegularGridInterpolator` instead.
-        For scattered data, prefer `LinearNDInterpolator` or
-        `CloughTocher2DInterpolator`.
-
-        For more details see :ref:`interp-transition-guide`.
-    """
-    def __init__(self, x, y, z, kind='linear', copy=True, bounds_error=False,
-                 fill_value=None):
-        raise NotImplementedError(err_mesg)
-
-
 def _check_broadcast_up_to(arr_from, shape_to, name):
     """Helper to check that arr_from broadcasts up to shape_to"""
     shape_from = arr_from.shape
@@ -266,7 +225,6 @@ class interp1d(_Interpolator1D):
     splrep, splev
         Spline interpolation/smoothing based on FITPACK.
     UnivariateSpline : An object-oriented wrapper of the FITPACK routines.
-    interp2d : 2-D interpolation
 
     Notes
     -----

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -8,10 +8,10 @@ from scipy._external import array_api_extra as xpx
 from pytest import raises as assert_raises
 import pytest
 
-from numpy import mgrid, pi, sin, poly1d
+from numpy import poly1d
 import numpy as np
 
-from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
+from scipy.interpolate import (interp1d, lagrange, PPoly, BPoly,
         splrep, splev, splantider, splint, sproot, Akima1DInterpolator,
         NdPPoly, BSpline, PchipInterpolator, make_interp_spline, CubicSpline,
         FloaterHormannInterpolator, BarycentricInterpolator, KroghInterpolator,
@@ -31,14 +31,6 @@ from scipy.special import binom
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
-
-
-class TestInterp2D:
-    def test_interp2d(self):
-        y, x = mgrid[0:2:20j, 0:pi:21j]
-        z = sin(x+0.5*y)
-        with assert_raises(NotImplementedError):
-            interp2d(x, y, z)
 
 
 class TestInterp1D:

--- a/tools/linting/numpydoc_lint.py
+++ b/tools/linting/numpydoc_lint.py
@@ -549,7 +549,6 @@ legacy_functions = [
     "scipy.interpolate.UnivariateSpline",
     "scipy.interpolate.splder",
     "scipy.interpolate.Rbf",
-    "scipy.interpolate.interp2d",
     "scipy.sparse.lil_matrix",
     "scipy.sparse.dok_matrix",
     "scipy.sparse.dia_matrix",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #18583
#### What does this implement/fix?
<!--Please explain your changes.-->
I think SciPy 2.0 is a suitable point to remove this stub, it has been 4 years (9 releases) since the deprecation and 2 years (5 releases) since it was replaced by a stub.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No ai