### PR TITLE
DEP: stats.anderson: follow up on `method=None` deprecation

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -32,7 +32,6 @@ from scipy._lib._array_api import (
 
 from ._ansari_swilk_statistics import gscale
 from . import _stats_py, _wilcoxon
-from ._fit import FitResult
 from ._stats_py import (_get_pvalue, SignificanceResult,
                         _SimpleNormal, _SimpleChi2, _SimpleF, _demean)
 from .contingency import chi2_contingency  # noqa:F401
@@ -2347,24 +2346,8 @@ def _weibull_fit_check(params, x):
     return m, u, s
 
 
-AndersonResult = _make_tuple_bunch('AndersonResult',
-                                   ['statistic', 'critical_values',
-                                    'significance_level'], ['fit_result'])
-
-
-_anderson_warning_message = (
-"""As of SciPy 1.17, users must choose a p-value calculation method by providing the
-`method` parameter. `method='interpolate'` interpolates the p-value from pre-calculated
-tables; `method` may also be an instance of `MonteCarloMethod` to approximate the
-p-value via Monte Carlo simulation. When `method` is specified, the result object will
-include a `pvalue` attribute and not attributes `critical_value`, `significance_level`,
-or `fit_result`. Beginning in 2.0.0, these other attributes will no longer be
-available, and a p-value will always be computed according to one of the available
-`method` options.""".replace('\n', ' '))
-
-
 @xp_capabilities(np_only=True)
-def anderson(x, dist='norm', *, method=None):
+def anderson(x, dist='norm', *, method="interpolate"):
     """Anderson-Darling test for data coming from a particular distribution.
 
     The Anderson-Darling test tests the null hypothesis that a sample is
@@ -2390,15 +2373,6 @@ def anderson(x, dist='norm', *, method=None):
         `scipy.stats.monte_carlo_test` with the provided configuration options and other
         appropriate settings.
 
-        .. versionadded:: 1.17.0
-            If `method` is not specified, `anderson` will emit a ``FutureWarning``
-            specifying that the user must opt into a p-value calculation method.
-            When `method` is specified, the object returned will include a ``pvalue``
-            attribute, but no ``critical_value``, ``significance_level``, or
-            ``fit_result`` attributes. Beginning in 2.0.0, these other attributes will
-            no longer be available, and a p-value will always be computed according to
-            one of the available `method` options.
-
     Returns
     -------
     result : AndersonResult
@@ -2409,28 +2383,6 @@ def anderson(x, dist='norm', *, method=None):
         pvalue: float
             The p-value corresponding with the test statistic, calculated according to
             the specified `method`.
-
-        If `method` is unspecified, this is an object with the following attributes:
-
-        statistic : float
-            The Anderson-Darling test statistic.
-        critical_values : list
-            The critical values for this distribution.
-        significance_level : list
-            The significance levels for the corresponding critical values
-            in percents.  The function returns critical values for a
-            differing set of significance levels depending on the
-            distribution that is being tested against.
-        fit_result : `~scipy.stats._result_classes.FitResult`
-            An object containing the results of fitting the distribution to
-            the data.
-
-        .. deprecated:: 1.17.0
-            The tuple-unpacking behavior of the return object and attributes
-            ``critical_values``, ``significance_level``, and ``fit_result`` are
-            deprecated. Beginning in SciPy 2.0.0, these features will no longer be
-            available, and the object returned will have attributes ``statistic`` and
-            ``pvalue``.
 
     See Also
     --------
@@ -2591,17 +2543,6 @@ def anderson(x, dist='norm', *, method=None):
 
     i = arange(1, N + 1)
     A2 = -N - np.sum((2*i - 1.0) / N * (logcdf + logsf[::-1]), axis=0)
-
-    # FitResult initializer expects an optimize result, so let's work with it
-    message = '`anderson` successfully fit the distribution to the data.'
-    res = optimize.OptimizeResult(success=True, message=message)
-    res.x = np.array(fit_params)
-    fit_result = FitResult(getattr(distributions, dist), y,
-                           discrete=False, res=res)
-
-    if method is None:
-        warnings.warn(_anderson_warning_message, FutureWarning, stacklevel=2)
-        return AndersonResult(A2, critical, sig, fit_result=fit_result)
 
     if method == 'interpolate':
         sig = 1 - sig if dist == 'weibull_min' else sig / 100

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -9,7 +9,7 @@ from functools import partial
 import numpy as np
 from numpy.random import RandomState
 from numpy.testing import (assert_array_equal, assert_almost_equal,
-                           assert_array_less, assert_array_almost_equal,
+                           assert_array_almost_equal,
                            assert_, assert_allclose, assert_equal)
 import pytest
 from pytest import raises as assert_raises
@@ -248,47 +248,13 @@ class TestShapiro:
         xp_assert_close(res.pvalue, ref_pvalue, rtol=5e-7)
 
 
-@pytest.mark.filterwarnings("ignore: As of SciPy 1.17: FutureWarning")
 class TestAnderson:
-    def test_normal(self):
-        rs = RandomState(1234567890)
-        x1 = rs.standard_exponential(size=50)
-        x2 = rs.standard_normal(size=50)
-        A, crit, sig = stats.anderson(x1)
-        assert_array_less(crit[:-1], A)
-        A, crit, sig = stats.anderson(x2)
-        assert_array_less(A, crit[-2:])
-
-        v = np.ones(10)
-        v[0] = 0
-        A, crit, sig = stats.anderson(v)
-        # The expected statistic 3.208057 was computed independently of scipy.
-        # For example, in R:
-        #   > library(nortest)
-        #   > v <- rep(1, 10)
-        #   > v[1] <- 0
-        #   > result <- ad.test(v)
-        #   > result$statistic
-        #          A
-        #   3.208057
-        assert_allclose(A, 3.208057)
-
-    def test_expon(self):
-        rs = RandomState(1234567890)
-        x1 = rs.standard_exponential(size=50)
-        x2 = rs.standard_normal(size=50)
-        A, crit, sig = stats.anderson(x1, 'expon')
-        assert_array_less(A, crit[-2:])
-        with np.errstate(all='ignore'):
-            A, crit, sig = stats.anderson(x2, 'expon')
-        assert_(A > crit[-1])
-
     def test_gumbel(self):
         # Regression test for gh-6306.  Before that issue was fixed,
         # this case would return a2=inf.
         v = np.ones(100)
         v[0] = 0.0
-        a2, crit, sig = stats.anderson(v, 'gumbel')
+        a2, _ = stats.anderson(v, 'gumbel')
         # A brief reimplementation of the calculation of the statistic.
         n = len(v)
         xbar, s = stats.gumbel_l.fit(v)
@@ -306,7 +272,7 @@ class TestAnderson:
         rs = RandomState(1234567890)
         x = rs.standard_exponential(size=50)
         res = stats.anderson(x)
-        attributes = ('statistic', 'critical_values', 'significance_level')
+        attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes)
 
     def test_gumbel_l(self):
@@ -314,44 +280,10 @@ class TestAnderson:
         # Adds support to 'gumbel_r' and 'gumbel_l' as valid inputs for dist.
         rs = RandomState(1234567890)
         x = rs.gumbel(size=100)
-        A1, crit1, sig1 = stats.anderson(x, 'gumbel')
-        A2, crit2, sig2 = stats.anderson(x, 'gumbel_l')
+        A1, _ = stats.anderson(x, 'gumbel')
+        A2, _ = stats.anderson(x, 'gumbel_l')
 
         assert_allclose(A2, A1)
-
-    def test_gumbel_r(self):
-        # gh-2592, gh-6337
-        # Adds support to 'gumbel_r' and 'gumbel_l' as valid inputs for dist.
-        rs = RandomState(1234567890)
-        x1 = rs.gumbel(size=100)
-        x2 = np.ones(100)
-        # A constant array is a degenerate case and breaks gumbel_r.fit, so
-        # change one value in x2.
-        x2[0] = 0.996
-        A1, crit1, sig1 = stats.anderson(x1, 'gumbel_r')
-        A2, crit2, sig2 = stats.anderson(x2, 'gumbel_r')
-
-        assert_array_less(A1, crit1[-2:])
-        assert_(A2 > crit2[-1])
-
-    def test_weibull_min_case_A(self):
-        # data and reference values from `anderson` reference [7]
-        x = np.array([225, 171, 198, 189, 189, 135, 162, 135, 117, 162])
-        res = stats.anderson(x, 'weibull_min')
-        m, loc, scale = res.fit_result.params
-        assert_allclose((m, loc, scale), (2.38, 99.02, 78.23), rtol=2e-3)
-        assert_allclose(res.statistic, 0.260, rtol=1e-3)
-        assert res.statistic < res.critical_values[0]
-
-        c = 1 / m  # ~0.42
-        assert_allclose(c, 1/2.38, rtol=2e-3)
-        # interpolate between rows for c=0.4 and c=0.45, indices -3 and -2
-        As40 = _Avals_weibull[-3]
-        As45 = _Avals_weibull[-2]
-        As_ref = As40 + (c - 0.4)/(0.45 - 0.4) * (As45 - As40)
-        # atol=1e-3 because results are rounded up to the next third decimal
-        assert np.all(res.critical_values > As_ref)
-        assert_allclose(res.critical_values, As_ref, atol=1e-3)
 
     def test_weibull_min_case_B(self):
         # From `anderson` reference [7]
@@ -372,20 +304,6 @@ class TestAnderson:
         with wcontext, econtext:
             stats.anderson(x, 'weibull_min')
 
-    @pytest.mark.parametrize('distname',
-                             ['norm', 'expon', 'gumbel_l', 'extreme1',
-                              'gumbel', 'gumbel_r', 'logistic', 'weibull_min'])
-    def test_anderson_fit_params(self, distname):
-        # check that anderson now returns a FitResult
-        rng = np.random.default_rng(330691555377792039)
-        real_distname = ('gumbel_l' if distname in {'extreme1', 'gumbel'}
-                         else distname)
-        dist = getattr(stats, real_distname)
-        params = distcont[real_distname]
-        x = dist.rvs(*params, size=1000, random_state=rng)
-        res = stats.anderson(x, distname)
-        assert res.fit_result.success
-
     def test_anderson_weibull_As(self):
         m = 1  # "when mi < 2, so that c > 0.5, the last line...should be used"
         assert_equal(_get_As_weibull(1/m), _Avals_weibull[-1])
@@ -394,11 +312,6 @@ class TestAnderson:
 
 
 class TestAndersonMethod:
-    def test_warning(self):
-        message = "As of SciPy 1.17, users..."
-        with pytest.warns(FutureWarning, match=message):
-            stats.anderson([1, 2, 3], 'norm')
-
     def test_method_input_validation(self):
         message = "`method` must be either..."
         with pytest.raises(ValueError, match=message):
@@ -446,33 +359,6 @@ class TestAndersonMethod:
         res = stats.anderson(x, dist_name, method=stats.MonteCarloMethod(rng=rng))
         np.testing.assert_allclose(res.statistic, ref.statistic)
         np.testing.assert_allclose(res.pvalue, ref.pvalue, atol=0.005)
-
-    @pytest.mark.parametrize('dist_name',
-        ['norm', 'expon', 'logistic', 'gumbel_l', 'gumbel_r', 'weibull_min'])
-    def test_interpolate_saturation(self, dist_name):
-        dist = getattr(stats, dist_name)
-        rng = np.random.default_rng(4202165767276)
-        args = (3.5,) if dist_name == 'weibull_min' else tuple()
-        x = dist.rvs(*args, size=50, random_state=rng)
-
-        with pytest.warns(FutureWarning):
-            res = stats.anderson(x, dist_name)
-        pvalues = (1 - np.asarray(res.significance_level) if dist_name == 'weibull_min'
-                   else np.asarray(res.significance_level) / 100)
-        pvalue_min = np.min(pvalues)
-        pvalue_max = np.max(pvalues)
-        statistic_min = np.min(res.critical_values)
-        statistic_max = np.max(res.critical_values)
-
-        # data drawn from distribution -> low statistic / high p-value
-        res = stats.anderson(x, dist_name, method='interpolate')
-        assert res.statistic < statistic_min
-        assert res.pvalue == pvalue_max
-
-        # data not from distribution -> high statistic / low p-value
-        res = stats.anderson(rng.random(size=50), dist_name, method='interpolate')
-        assert res.statistic > statistic_max
-        assert res.pvalue == pvalue_min
 
 
 @pytest.mark.filterwarnings("ignore:Parameter `variant`...:UserWarning")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow-up to gh-24030
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes the deprecated `method=None` behavior. 
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai