### PR TITLE
DEP: stats.anderson_ksamp: follow up on midrank deprecation

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -11,7 +11,6 @@ from numpy import (isscalar, log, around, arange, sort, amin, amax, sqrt, array,
 from scipy import optimize, special, interpolate, stats
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
-from scipy._lib.deprecation import _NoValue
 import scipy._external.array_api_extra as xpx
 
 from scipy._lib._array_api import (
@@ -2753,7 +2752,7 @@ Anderson_ksampResult = _make_tuple_bunch(
 
 
 @xp_capabilities(np_only=True)
-def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
+def anderson_ksamp(samples, *, variant="midrank", method=None):
     """The Anderson-Darling test for k-samples.
 
     The k-sample Anderson-Darling test is a modification of the
@@ -2766,14 +2765,6 @@ def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
     ----------
     samples : sequence of 1-D array_like
         Array of sample data in arrays.
-    midrank : bool, optional
-        Variant of Anderson-Darling test which is computed. Default
-        (True) is the midrank test applicable to continuous and
-        discrete populations. If False, the right side empirical
-        distribution is used.
-
-        .. deprecated:: 1.17.0
-            Use parameter `variant` instead.
     variant : {'midrank', 'right', 'continuous'}
         Variant of Anderson-Darling test to be computed. ``'midrank'`` is applicable
         to both continuous and discrete populations. ``'discrete'`` and ``'continuous'``
@@ -2795,13 +2786,6 @@ def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
 
         statistic : float
             Normalized k-sample Anderson-Darling test statistic.
-        critical_values : array
-            The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%,
-            0.5%, 0.1%.
-
-            .. deprecated:: 1.17.0
-                 Present only when `variant` is unspecified.
-
         pvalue : float
             The approximate p-value of the test. If `method` is not
             provided, the value is floored / capped at 0.1% / 25%.
@@ -2895,18 +2879,6 @@ def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
         raise ValueError("anderson_ksamp encountered sample without "
                          "observations")
 
-    if variant == _NoValue or midrank != _NoValue:
-        message = ("Parameter `variant` has been introduced to replace `midrank`; "
-                   "`midrank` will be removed in SciPy 2.0.0. Specify `variant` to "
-                   "silence this warning. Note that the returned object will no longer "
-                   "be unpackable as a tuple, and `critical_values` will be omitted.")
-        warnings.warn(message, category=UserWarning, stacklevel=2)
-
-    return_critical_values = False
-    if variant == _NoValue:
-        return_critical_values = True
-        variant = 'midrank' if midrank else 'right'
-
     if variant == 'midrank':
         A2kN_fun = _anderson_ksamp_midrank
     elif variant == 'right':
@@ -2967,14 +2939,7 @@ def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
     else:
         p = res.pvalue if method is not None else p
 
-    if return_critical_values:
-        # create result object with alias for backward compatibility
-        res = Anderson_ksampResult(A2, critical, p)
-        res.significance_level = p
-    else:
-        res = SignificanceResult(statistic=A2, pvalue=p)
-
-    return res
+    return SignificanceResult(statistic=A2, pvalue=p)
 
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -475,7 +475,6 @@ class TestAndersonMethod:
         assert res.pvalue == pvalue_min
 
 
-@pytest.mark.filterwarnings("ignore:Parameter `variant`...:UserWarning")
 class TestAndersonKSamp:
     def test_example1a(self):
         # Example data from Scholz & Stephens (1987), originally
@@ -487,11 +486,9 @@ class TestAndersonKSamp:
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
 
-        Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4), midrank=False)
+        Tk, p = stats.anderson_ksamp((t1, t2, t3, t4), variant="right")
 
         assert_almost_equal(Tk, 4.449, 3)
-        assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
-                                  tm[0:5], 4)
         assert_allclose(p, 0.0021, atol=0.00025)
 
     def test_example1b(self):
@@ -503,11 +500,9 @@ class TestAndersonKSamp:
         t2 = np.array([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
-        Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4), midrank=True)
+        Tk, p = stats.anderson_ksamp((t1, t2, t3, t4))
 
         assert_almost_equal(Tk, 4.480, 3)
-        assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
-                                  tm[0:5], 4)
         assert_allclose(p, 0.0020, atol=0.00025)
 
     @pytest.mark.xslow
@@ -536,17 +531,14 @@ class TestAndersonKSamp:
                61, 34]
 
         samples = (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
-        Tk, tm, p = stats.anderson_ksamp(samples, midrank=False)
+        Tk, p = stats.anderson_ksamp(samples, variant="right")
         assert_almost_equal(Tk, 3.288, 3)
-        assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
-                                  tm[0:5], 4)
         assert_allclose(p, 0.0041, atol=0.00025)
 
         rng = np.random.default_rng(6989860141921615054)
         method = stats.PermutationMethod(n_resamples=9999, rng=rng)
-        res = stats.anderson_ksamp(samples, midrank=False, method=method)
+        res = stats.anderson_ksamp(samples, variant="right", method=method)
         assert_array_equal(res.statistic, Tk)
-        assert_array_equal(res.critical_values, tm)
         assert_allclose(res.pvalue, p, atol=6e-4)
 
     def test_example2b(self):
@@ -572,13 +564,10 @@ class TestAndersonKSamp:
         t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
                61, 34]
 
-        Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4, t5, t6, t7, t8,
-                                          t9, t10, t11, t12, t13, t14),
-                                         midrank=True)
+        Tk, p = stats.anderson_ksamp((t1, t2, t3, t4, t5, t6, t7, t8,
+                                          t9, t10, t11, t12, t13, t14))
 
         assert_almost_equal(Tk, 3.294, 3)
-        assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
-                                  tm[0:5], 4)
         assert_allclose(p, 0.0041, atol=0.00025)
 
     def test_R_kSamples(self):
@@ -619,45 +608,45 @@ class TestAndersonKSamp:
         # test case for issue #5493 / #8536
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", 'p-value floored', UserWarning)
-            s, _, p = stats.anderson_ksamp([x1, x1 + 40.5], midrank=False)
+            s, p = stats.anderson_ksamp([x1, x1 + 40.5], variant="right")
         assert_almost_equal(s, 41.105, 3)
         assert_equal(p, 0.001)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", 'p-value floored', UserWarning)
-            s, _, p = stats.anderson_ksamp([x1, x1 + 40.5])
+            s, p = stats.anderson_ksamp([x1, x1 + 40.5])
         assert_almost_equal(s, 41.235, 3)
         assert_equal(p, 0.001)
 
         # test case: similar distributions --> p-value capped at 0.25
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", 'p-value capped', UserWarning)
-            s, _, p = stats.anderson_ksamp([x1, x1 + .5], midrank=False)
+            s, p = stats.anderson_ksamp([x1, x1 + .5], variant="right")
         assert_almost_equal(s, -1.2824, 4)
         assert_equal(p, 0.25)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", 'p-value capped', UserWarning)
-            s, _, p = stats.anderson_ksamp([x1, x1 + .5])
+            s, p = stats.anderson_ksamp([x1, x1 + .5])
         assert_almost_equal(s, -1.2944, 4)
         assert_equal(p, 0.25)
 
         # test case: check interpolated p-value in [0.01, 0.25] (no ties)
-        s, _, p = stats.anderson_ksamp([x1, x1 + 7.5], midrank=False)
+        s, p = stats.anderson_ksamp([x1, x1 + 7.5], variant="right")
         assert_almost_equal(s, 1.4923, 4)
         assert_allclose(p, 0.0775, atol=0.005, rtol=0)
 
         # test case: check interpolated p-value in [0.01, 0.25] (w/ ties)
-        s, _, p = stats.anderson_ksamp([x1, x1 + 6])
+        s, p = stats.anderson_ksamp([x1, x1 + 6])
         assert_almost_equal(s, 0.6389, 4)
         assert_allclose(p, 0.1798, atol=0.005, rtol=0)
 
         # test extended critical values for p=0.001 and p=0.005
-        s, _, p = stats.anderson_ksamp([x1, x1 + 11.5], midrank=False)
+        s, p = stats.anderson_ksamp([x1, x1 + 11.5], variant="right")
         assert_almost_equal(s, 4.5042, 4)
         assert_allclose(p, 0.00545, atol=0.0005, rtol=0)
 
-        s, _, p = stats.anderson_ksamp([x1, x1 + 13.5], midrank=False)
+        s, p = stats.anderson_ksamp([x1, x1 + 13.5], variant="right")
         assert_almost_equal(s, 6.2982, 4)
         assert_allclose(p, 0.00118, atol=0.0001, rtol=0)
 
@@ -675,54 +664,10 @@ class TestAndersonKSamp:
         # Pass a mixture of lists and arrays
         t1 = [38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0]
         t2 = np.array([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
-        res = stats.anderson_ksamp((t1, t2), midrank=False)
+        res = stats.anderson_ksamp((t1, t2), variant="right")
 
-        attributes = ('statistic', 'critical_values', 'significance_level')
+        attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes)
-
-        assert_equal(res.significance_level, res.pvalue)
-
-
-class TestAndersonKSampVariant:
-    def test_variant_values(self):
-        x = [1, 2, 2, 3, 4, 5]
-        y = [1, 2, 3, 4, 4, 5, 6, 6, 6, 7]
-        message = "Parameter `variant` has been introduced..."
-        with pytest.warns(UserWarning, match=message):
-            ref = stats.anderson_ksamp((x, y))
-        assert len(ref) == 3 and hasattr(ref, 'critical_values')
-
-        with pytest.warns(UserWarning, match=message):
-            res = stats.anderson_ksamp((x, y), midrank=True)
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert len(res) == 3 and hasattr(res, 'critical_values')
-
-        with pytest.warns(UserWarning, match=message):
-            res = stats.anderson_ksamp((x, y), midrank=False, variant='midrank')
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert not hasattr(res, 'critical_values')
-
-        res = stats.anderson_ksamp((x, y), variant='midrank')
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert not hasattr(res, 'critical_values')
-
-        with pytest.warns(UserWarning, match=message):
-            ref = stats.anderson_ksamp((x, y), midrank=False)
-        assert len(ref) == 3 and hasattr(ref, 'critical_values')
-
-        with pytest.warns(UserWarning, match=message):
-            res = stats.anderson_ksamp((x, y), midrank=True, variant='right')
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert not hasattr(res, 'critical_values')
-
-        res = stats.anderson_ksamp((x, y), variant='right')
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert not hasattr(res, 'critical_values')
 
     def test_variant_input_validation(self):
         x = np.arange(10)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow-up to #24031
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes deprecated `midrank` argument
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai