### PR TITLE
DOC: interpolate.make_smoothing_spline: add tutorial for `t` param

### DIFF
--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -53,9 +53,9 @@ Here the first term penalizes the deviation of the spline function from the data
 and the second term penalizes large values of the second derivative---which is
 taken as the criterion for the smoothness of a curve.
 
-There is a classic theorem which says that the minimizer of this objective
-over all possible smooth curves is a natural cubic spline *with knots at the
-data points*, :math:`x_j`. The target function, :math:`g(x)`, is therefore
+There is a classic theorem (see, for example, Chapter 2 of [GS]_) which says
+that the minimizer of this objective over all possible smooth curves is a
+natural cubic spline *with knots at the data points*, :math:`x_j`. The target function, :math:`g(x)`, is therefore
 taken to be exactly that, and the minimization is carried over the spline
 coefficients at a given value of :math:`\lambda`. (It is also possible to
 choose the knots differently, see
@@ -146,7 +146,7 @@ the boundary knots to a vector of interior knots:
     >>> import matplotlib.pyplot as plt
     >>>
     >>> def clamped_knots(interior, xmin, xmax):
-    ...     return np.r_[[xmin] * 4, interior, [xmax] * 4]
+    ...     return np.concatenate([[xmin] * 4, interior, [xmax] * 4])
 
 Here is a minimal example:
 
@@ -281,7 +281,7 @@ captures the feature, without spending extra knots everywhere else.
     >>>
     >>> t_single = clamped_knots(np.linspace(1, 9, 5), x[0], x[-1])
     >>> # same knots, plus a second knot at the breakpoint x = 5
-    >>> t_double = np.sort(np.r_[t_single, 5.0])
+    >>> t_double = np.sort(np.concatenate([t_single, [5.0]]))
     >>>
     >>> xnew = np.linspace(x[0], x[-1], 400)
     >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
@@ -370,6 +370,10 @@ generalized cross-validation (GCV) criterion:
 The search is scale free. Internally the criterion is minimized over a
 dimensionless ratio, so rescaling ``x`` or ``y`` by a constant does not
 change the quality of the selected fit.
+
+.. [GS] P. J. Green and B. W. Silverman, *Nonparametric Regression and
+   Generalized Linear Models: A Roughness Penalty Approach*,
+   Chapman and Hall, 1993.
 
 
 .. _tutorial-interpolate_GCV_batching:

--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -204,6 +204,35 @@ curve traces the local structure on the dense left side better. Note the
 ``method='nearest'`` argument, with it, `numpy.quantile` returns actual
 elements of ``x``, so the knots are members of the data sites.
 
+Quantiles follow the density of the data. Another option is to follow the
+signal itself, more knots where the signal has features, fewer where it is
+quiet. Here the signal is flat except for a sharp bump, and we fit it twice
+with 8 interior knots, uniform versus placed around the bump:
+
+.. plot::
+    :context: close-figs
+
+    >>> rng = np.random.default_rng(42)
+    >>> x = np.sort(rng.uniform(0, 1, 400))
+    >>> y = (0.3 + 0.25 * x + 0.45 * np.exp(-((x - 0.7) / 0.045)**2)
+    ...      + rng.normal(0, 0.05, x.size))
+    >>>
+    >>> t_uniform = clamped_knots(np.linspace(x[0], x[-1], 10)[1:-1], x[0], x[-1])
+    >>> t_placed = clamped_knots([0.25, 0.5, 0.62, 0.66, 0.70, 0.74, 0.78, 0.9],
+    ...                          x[0], x[-1])
+    >>>
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> for t, label in [(t_uniform, 'uniform knots'), (t_placed, 'placed knots')]:
+    ...     spl = make_smoothing_spline(x, y, lam=1e-9, t=t)
+    ...     plt.plot(xnew, spl(xnew), label=label)
+    >>> plt.plot(x, y, 'o', alpha=0.3, markersize=3)
+    >>> plt.legend()
+    >>> plt.show()
+
+The uniform knots oversmooth the bump and wiggle in the quiet region. The
+placed knots are clustered around the bump, so the bump comes out clean and
+the rest stays calm.
+
 The knots do not need to be a subset of the data sites, or coincide with
 them at all. Any non-decreasing knot vector works, as long as the boundary
 knots have multiplicity four and all data sites lie within the base

--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -53,9 +53,14 @@ Here the first term penalizes the deviation of the spline function from the data
 and the second term penalizes large values of the second derivative---which is
 taken as the criterion for the smoothness of a curve.
 
-The target function, :math:`g(x)`, is taken to be a natural cubic spline *with
-knots at the data points*, :math:`x_j`, and the minimization is carried over
-the spline coefficients at a given value of :math:`\lambda`.
+There is a classic theorem which says that the minimizer of this objective
+over all possible smooth curves is a natural cubic spline *with knots at the
+data points*, :math:`x_j`. The target function, :math:`g(x)`, is therefore
+taken to be exactly that, and the minimization is carried over the spline
+coefficients at a given value of :math:`\lambda`. (It is also possible to
+choose the knots differently, see
+:ref:`the section on user provided knots <tutorial-interpolate_user_knots>`
+below.)
 
 Clearly, :math:`\lambda = 0` corresponds to the interpolation problem---the result
 is a *natural interpolating spline*; in the opposite limit, :math:`\lambda \gg 1`,
@@ -110,6 +115,231 @@ of ``lam`` flatten out the resulting curve towards a straight line; and the GCV
 result, ``lam=None``, is close to the underlying sine curve.
 
 
+.. _tutorial-interpolate_user_knots:
+
+User provided knot vectors
+``````````````````````````
+
+So far we never passed a knot vector to `make_smoothing_spline`, and
+rightly so. As discussed above, the minimizer of the smoothing objective
+has its knots at the data sites, so internally the knot vector was built
+to include all of ``x``.
+
+The fundamental issue with this is that the size of the system of
+equations is now in the hands of the size of the data. Every data site
+adds one basis function and one unknown to solve for. For large datasets
+it makes sense to sacrifice a little accuracy of the fitted curve for a
+smaller problem. For this reason `make_smoothing_spline` also accepts
+a user defined knot vector ``t``. If the knots are chosen smartly, in
+most cases the harm is minimal.
+
+A valid knot vector has its boundary knots repeated four times (more on
+this below), so throughout this section we use a small helper which adds
+the boundary knots to a vector of interior knots:
+
+.. plot::
+    :context:
+    :nofigs:
+
+    >>> import numpy as np
+    >>> from scipy.interpolate import make_smoothing_spline
+    >>> import matplotlib.pyplot as plt
+    >>>
+    >>> def clamped_knots(interior, xmin, xmax):
+    ...     return np.r_[[xmin] * 4, interior, [xmax] * 4]
+
+Here is a minimal example:
+
+.. plot::
+    :context: close-figs
+
+    >>> rng = np.random.default_rng(12345)
+    >>> x = np.linspace(0, 10, 50)
+    >>> y = np.sin(x) + 0.4 * rng.normal(size=len(x))
+    >>> # every other, third and fourth interior data site as knots
+    >>> t1 = clamped_knots(x[1:-1:2], x[0], x[-1])
+    >>> t2 = clamped_knots(x[1:-1:3], x[0], x[-1])
+    >>> t3 = clamped_knots(x[1:-1:4], x[0], x[-1])
+    >>>
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> for i, t in enumerate([t1, t2, t3]):
+    ...     spl = make_smoothing_spline(x, y, lam=1e-3, t=t)
+    ...     plt.plot(xnew, spl(xnew), label=f'$t_{i+1}$')
+    >>> plt.plot(x, y, 'o', alpha=0.4)
+    >>> plt.legend()
+    >>> plt.show()
+
+As seen in the plot above, the curves are pretty close to each other,
+even with roughly a quarter of the number of knots.
+
+How do you select knots when the data is not equally distributed?
+Usually it is best to have more knots in the regions where the data is
+dense and fewer knots in the other places. A simple recipe is to place
+the knots at quantiles of ``x``:
+
+.. plot::
+    :context: close-figs
+
+    >>> rng = np.random.default_rng(12345)
+    >>> # data sites concentrated near the left end
+    >>> x = np.sort(10 * rng.random(100)**2)
+    >>> y = np.sin(x) + 0.4 * rng.normal(size=len(x))
+    >>>
+    >>> # 8 interior knots, placed two ways
+    >>> qs = np.linspace(0, 1, 10)[1:-1]
+    >>> t_eq = clamped_knots(np.linspace(x[0], x[-1], 10)[1:-1], x[0], x[-1])
+    >>> t_qt = clamped_knots(np.quantile(x, qs, method='nearest'), x[0], x[-1])
+    >>>
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> for t, label in [(t_eq, 'equispaced knots'), (t_qt, 'knots at quantiles')]:
+    ...     spl = make_smoothing_spline(x, y, lam=1e-3, t=t)
+    ...     plt.plot(xnew, spl(xnew), label=label)
+    >>> plt.plot(x, y, 'o', alpha=0.4)
+    >>> plt.legend()
+    >>> plt.show()
+
+Both knot vectors have the same size and differ only in placement. The
+quantile based knots follow the density of the data, which is why that
+curve traces the local structure on the dense left side better. Note the
+``method='nearest'`` argument, with it, `numpy.quantile` returns actual
+elements of ``x``, so the knots are members of the data sites.
+
+The knots do not need to be a subset of the data sites, or coincide with
+them at all. Any non-decreasing knot vector works, as long as the boundary
+knots have multiplicity four and all data sites lie within the base
+interval, ``t[3] <= x <= t[-4]``. For instance, we can place the interior
+knots on a uniform grid that shares no points with ``x``:
+
+    >>> t = clamped_knots(np.linspace(x[0], x[-1], 12)[1:-1], x[0], x[-1])
+    >>> spl = make_smoothing_spline(x, y, lam=1e-3, t=t)
+
+Finally, the default ``t=None`` corresponds to a specific choice of the knot
+vector, knots at all data sites, with the boundary ones repeated four times.
+Passing that vector explicitly reproduces the default result:
+
+    >>> t = clamped_knots(x[1:-1], x[0], x[-1])
+    >>> spl_default = make_smoothing_spline(x, y, lam=1e-3)
+    >>> spl_user = make_smoothing_spline(x, y, lam=1e-3, t=t)
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> np.allclose(spl_default(xnew), spl_user(xnew), atol=1e-12)
+    True
+
+In other words, providing ``t`` generalizes the classic smoothing spline,
+you keep the same penalized least-squares problem, and additionally choose
+where the spline is allowed to bend.
+
+Repeated interior knots
+```````````````````````
+
+An interior knot may be repeated twice. Each repetition removes one
+continuity requirement, so a double knot allows the second derivative of
+the spline to jump at that point, while the spline and its slope stay
+continuous. This is useful when the underlying signal is known to change
+curvature abruptly somewhere, a single doubled knot at the breakpoint
+captures the feature, without spending extra knots everywhere else.
+
+.. plot::
+    :context: close-figs
+
+    >>> rng = np.random.default_rng(12345)
+    >>> x = np.linspace(0, 10, 100)
+    >>> # flat for x < 5, parabolic for x > 5: the curvature jumps at 5
+    >>> signal = np.where(x < 5, 0.0, (x - 5)**2 / 5)
+    >>> y = signal + 0.15 * rng.normal(size=len(x))
+    >>>
+    >>> t_single = clamped_knots(np.linspace(1, 9, 5), x[0], x[-1])
+    >>> # same knots, plus a second knot at the breakpoint x = 5
+    >>> t_double = np.sort(np.r_[t_single, 5.0])
+    >>>
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+    >>> for t, label in [(t_single, 'single knot at 5'),
+    ...                  (t_double, 'double knot at 5')]:
+    ...     spl = make_smoothing_spline(x, y, lam=1e-3, t=t)
+    ...     ax1.plot(xnew, spl(xnew), label=label)
+    ...     ax2.plot(xnew, spl.derivative(2)(xnew), label=label)
+    >>> ax1.plot(x, y, 'o', alpha=0.4)
+    >>> ax1.set_title('the fits (nearly identical)')
+    >>> ax2.axvline(5, color='k', ls=':', lw=1)
+    >>> ax2.set_title('second derivative')
+    >>> ax1.legend()
+    >>> plt.show()
+
+Notice that the two fits look nearly the same, the real difference shows
+up in the second derivative plot. With a single knot the second
+derivative has to change continuously, so the curvature change gets
+spread over the neighboring intervals. With the double knot it simply
+jumps at the breakpoint, which is exactly what the true signal does. So
+the fitted values barely change, but the double knot gets the curvature
+right. This matters when you care about the derivatives of the fit, for
+example when estimating velocities or accelerations from position data.
+
+Higher multiplicity is not allowed, repeating an interior knot three times
+would permit a jump in the first derivative, that is, a corner point.
+Recall that the penalty integrates the squared second derivative, which
+is not defined at a corner. Since the penalty cannot account for such a
+point, ``make_smoothing_spline`` raises a ``ValueError`` for interior
+multiplicity greater than two.
+
+The rules for a valid knot vector are as follows:
+
+- ``t`` must be non-decreasing.
+- The boundary knots must have multiplicity four (this is what the
+  ``clamped_knots`` helper above takes care of).
+- Every data site must lie within the base interval,
+  ``t[3] <= x <= t[-4]``.
+
+The boundary knots themselves need not be data sites, they only need to
+be at or beyond the data extremes.
+
+Choosing the knots and ``lam`` freely comes with two limits to be aware
+of, one at each extreme of ``lam``.
+
+At ``lam=0`` there is no penalty, so the data alone must determine every
+coefficient. This requires the knots to satisfy the Schoenberg-Whitney
+conditions, every basis function must have at least one data site inside
+its support, i.e. every interval ``(t[j], t[j+4])`` must contain some
+``x``. With many knots and few data points this fails, and
+``make_smoothing_spline`` raises a ``ValueError``. Any positive ``lam``
+reduces this requirement, the penalty determines the coefficients that the
+data cannot see, so in some sense some work is taken off the data. The
+only condition in that case is that the dataset should contain at least
+two distinct ``x`` values.
+
+At the other extreme, a very large ``lam`` makes the linear system
+numerically singular, the data term is massively dominated out by the penalty, 
+whose matrix is itself singular (a straight line has zero penalty). In practice
+the useful range of ``lam`` is bounded by machine precision on both ends,
+and values far outside it fail with a linear algebra error.
+
+Automatic selection of ``lam``
+``````````````````````````````
+
+In all the examples above we picked ``lam`` by hand. Just like in the
+default case, you can pass ``lam=None`` together with your knot vector,
+and the smoothing parameter is selected automatically by minimizing the
+generalized cross-validation (GCV) criterion:
+
+.. plot::
+    :context: close-figs
+
+    >>> rng = np.random.default_rng(12345)
+    >>> x = np.linspace(0, 10, 100)
+    >>> y = np.sin(x) + 0.4 * rng.normal(size=len(x))
+    >>> t = clamped_knots(x[1:-1:4], x[0], x[-1])
+    >>>
+    >>> spl = make_smoothing_spline(x, y, t=t)   # lam=None is the default
+    >>> xnew = np.linspace(x[0], x[-1], 400)
+    >>> plt.plot(xnew, spl(xnew), label='GCV-selected $\\lambda$')
+    >>> plt.plot(x, y, 'o', alpha=0.4)
+    >>> plt.legend()
+    >>> plt.show()
+
+The search is scale free. Internally the criterion is minimized over a
+dimensionless ratio, so rescaling ``x`` or ``y`` by a constant does not
+change the quality of the selected fit.
+
+
 .. _tutorial-interpolate_GCV_batching:
 
 Batching of ``y`` arrays
@@ -120,7 +350,6 @@ optional ``axis`` parameter and interprets them exactly the same way the
 interpolating spline constructor, `make_interp_spline` does. See the
 :ref:`interpolation section <tutorial-interpolate_batching>` for a discussion and
 examples.
-
 
 .. _tutorial_make_splrep:
 

--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -222,11 +222,14 @@ with 8 interior knots, uniform versus placed around the bump:
     ...                          x[0], x[-1])
     >>>
     >>> xnew = np.linspace(x[0], x[-1], 400)
-    >>> for t, label in [(t_uniform, 'uniform knots'), (t_placed, 'placed knots')]:
+    >>> fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=True)
+    >>> for ax, t, title in [(axes[0], t_uniform, 'uniform knots'),
+    ...                      (axes[1], t_placed, 'placed knots')]:
     ...     spl = make_smoothing_spline(x, y, lam=1e-9, t=t)
-    ...     plt.plot(xnew, spl(xnew), label=label)
-    >>> plt.plot(x, y, 'o', alpha=0.3, markersize=3)
-    >>> plt.legend()
+    ...     ax.plot(x, y, 'o', alpha=0.3, markersize=3)
+    ...     ax.plot(xnew, spl(xnew))
+    ...     ax.plot(t[4:-4], np.full(len(t) - 8, 0.15), '|', markersize=10)
+    ...     ax.set_title(title)
     >>> plt.show()
 
 The uniform knots oversmooth the bump and wiggle in the quiet region. The

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2982,13 +2982,11 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     n = y.shape[0]
 
     def _gcv(lam):
-        try:
-            c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, compute_trace=True,
-            )
-        except LinAlgError:
-            # numerically singular for this lam
-            return np.inf
+        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg, 
+        # use it to estimate rcond of the banded system before solving
+        c, tr = _solve_smoothing_spline_coefficients(
+            xtwx_banded, lam, omega, xtwy, compute_trace=True,
+        )
         rss = np.sum(w * np.square(y - X @ c)) / n
         return rss / (1 - tr / n) ** 2
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2582,8 +2582,8 @@ def _compute_b_inv(A):
 
     Notes
     -----
-    The algorithm is based on the cholesky decomposition and, therefore,
-    in case matrix ``A`` is close to not positive defined, the function
+    The algorithm is based on the Cholesky decomposition and, therefore,
+    in case matrix ``A`` is close to not positive definite, the function
     raises LinalgError.
 
     Both matrices ``A`` and ``B`` are stored in LAPACK banded storage.
@@ -2935,7 +2935,7 @@ def _penalty_matrix_banded(t):
        ``t[p:p+3]``: zero at ``t[p]``, one at ``t[p+1]``, zero at
        ``t[p+2]``.
     3. ``Omega = C.T @ R @ C``, returned in LAPACK symmetric
-       lower-banded storage of shape ``(4, m)``, ``m = len(t) - 4``, as
+       upper-banded storage of shape ``(4, m)``, ``m = len(t) - 4``, as
        accepted by ``scipy.linalg.solveh_banded``.
 
     ``Omega`` depends on ``t`` only (no data enters), is symmetric
@@ -2967,19 +2967,11 @@ def _penalty_matrix_banded(t):
     omega = C.T @ R @ C
     omega_banded = np.zeros((4, m))
     for i in range(4):
-        # Convert to LAPACK symmetric lower-banded storage,
+        # Convert to LAPACK symmetric upper-banded storage,
         # as accepted by solveh_banded.
-        omega_banded[i, : m - i] = omega.diagonal(-i)
+        omega_banded[3 - i, i:] = omega.diagonal(i)
 
     return omega_banded
-
-def _lower_to_upper_banded(ab):
-    """Reorder LAPACK lower-banded symmetric storage into upper-banded."""
-    m = ab.shape[1]
-    upper = np.zeros_like(ab)
-    for d in range(ab.shape[0]):
-        upper[-1 - d, d:] = ab[d, :m - d]
-    return upper
 
 
 def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
@@ -2988,12 +2980,12 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
-    xtwx_upper = _lower_to_upper_banded(xtwx_banded)
 
     def _gcv(lam):
         try:
             c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, xtwx_upper=xtwx_upper)
+                xtwx_banded, lam, omega, xtwy, compute_trace=True,
+            )
         except LinAlgError:
             # numerically singular for this lam
             return np.inf
@@ -3008,16 +3000,16 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         xtwx_upper=None):
+                                         compute_trace=False):
     _lhs = XtWX_banded + lam * omega
-    c = solveh_banded(_lhs, XtWy, lower=True)
-    if xtwx_upper is None:
+    c = solveh_banded(_lhs, XtWy, lower=False)
+    if not compute_trace:
         return c, None
     # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
     # 7-banded, so only the central bands of the inverse are needed
     # (Hutchinson & de Hoog, upper-banded storage).
-    b_banded = _compute_b_inv(_lower_to_upper_banded(_lhs))
-    tr = b_banded * xtwx_upper
+    b_banded = _compute_b_inv(_lhs)
+    tr = b_banded * XtWX_banded
     tr[:-1] *= 2
     return c, tr.sum()
 
@@ -3099,9 +3091,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     XtWy = X.T @ (w * y)
     XtWX_banded = np.zeros((4, m))
     for i in range(4):
-        # Convert to LAPACK symmetric lower-banded storage,
+        # Convert to LAPACK symmetric upper-banded storage,
         # as accepted by solveh_banded.
-        XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
+        XtWX_banded[3 - i, i:] = XtWX.diagonal(i)
     if lam is None:
         lam = _make_smoothing_spline_user_knots_gcv(
             XtWX_banded, X, y, w, XtWy, omega)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2975,14 +2975,20 @@ def _penalty_matrix_banded(t):
 
 
 def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
-    """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
+    """Select lam by minimizing the GCV criterion over the dimensionless
+    s = log10(lam / r), r = tr(X^T W X) / tr(Omega), so the fixed search
+    window is scale-free."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
 
+    # `r` is the factor which upon division makes `lam`
+    # dimensionless.
+    r = xtwx_banded[3, :].sum() / omega[3, :].sum()
+
     def _gcv(lam):
-        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg, 
+        # TODO: once LAPACK dpbcon is wrapped in scipy.linalg,
         # use it to estimate rcond of the banded system before solving
         c, tr = _solve_smoothing_spline_coefficients(
             xtwx_banded, lam, omega, xtwy, compute_trace=True,
@@ -2991,10 +2997,13 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
         return rss / (1 - tr / n) ** 2
 
     def _gcv_log(s):
-        return _gcv(10 ** s)
+        return _gcv(r * 10 ** s)
 
-    res = minimize_scalar(_gcv_log, bounds=(-14, 9), method="bounded")
-    lam_hat = 10 ** res.x
+    # The bounds of `log(lam/r)` are (eps, 1/eps) where `eps`
+    # is the machine precision 2.2 * 1e-16, hence (-15, 15) is
+    # strictly in the live area for the bounds.
+    res = minimize_scalar(_gcv_log, bounds=(-15, 15), method="bounded")
+    lam_hat = r * 10 ** res.x
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,10 +2973,31 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(x, y, w, t, axis, *, xp, device=None):
-    """Generalized Cross Validation (GCV) computation path for unequal knot
-    vectors and data points."""
-    pass
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
+    """Compute the appropriate smoothing parameter `lam` for cubic smoothing splines."""
+    # Implementation decisions detailed in the following companion report:
+    # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
+    n = y.shape[0]
+    def _gcv(lam):
+        c, tr = _solve_smoothing_spline_coefficients(
+            xtwx_banded, lam, omega, xtwy, gcv=True)
+        rss = np.sum(w * np.square(y - x @ c)) / n
+        return rss / (1 - tr / n) ** 2
+
+    def _gcv_log(s):
+        return _gcv(10 ** s)
+
+    res = minimize_scalar(_gcv_log, bounds=(-14, 9), method="bounded")
+    lam_hat = 10 ** res.x
+    return lam_hat
+
+def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy, gcv=False):
+    _lhs = XtWX_banded + lam * omega
+    c = solveh_banded(_lhs, XtWy, lower=True)
+    if gcv:
+        tr = np.sum((_lhs @ XtWX_banded).diagonal(0))
+        return (c, tr)
+    return c, None
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -2990,17 +3011,14 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     symmetric, so the system is solved with a banded Cholesky factorization.
     Assumes ``x``, ``y`` and ``w`` are already validated by the caller.
     """
-    if lam is None:
-        return _make_smoothing_spline_user_knots_gcv(
-            x, y, w, t, axis, xp, device=device
-        )
-    if np.ndim(lam) != 0:
-        raise NotImplementedError(
-            "`lam` must be a scalar (or a 0-d array) when `t` is provided; "
-            f"got an array of shape {np.shape(lam)}."
-        )
-    if lam < 0.:
-        raise ValueError('Regularization parameter should be non-negative')
+    if lam is not None:
+        if np.ndim(lam) != 0:
+            raise NotImplementedError(
+                "`lam` must be a scalar (or a 0-d array) when `t` is provided; "
+                f"got an array of shape {np.shape(lam)}."
+            )
+        if lam < 0.:
+            raise ValueError('Regularization parameter should be non-negative')
     if np.ndim(y) > 1:
         raise NotImplementedError(
             "batched `y` is not supported with user-provided knots yet; "
@@ -3062,8 +3080,10 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         # Convert to LAPACK symmetric lower-banded storage,
         # as accepted by solveh_banded.
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
+    if lam is None:
+        lam = _make_smoothing_spline_user_knots_gcv(XtWX_banded, XtWy)
     try:
-        c = solveh_banded(XtWX_banded + lam * omega, XtWy, lower=True)
+        c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:
         # why only the two extremes of lam can fail: companion report,
         # Sec. 15 FAQ 1 (link in make_smoothing_spline)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,20 +2973,31 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
+def _lower_to_upper_banded(ab):
+    """Reorder LAPACK lower-banded symmetric storage into upper-banded."""
+    m = ab.shape[1]
+    upper = np.zeros_like(ab)
+    for d in range(ab.shape[0]):
+        upper[-1 - d, d:] = ab[d, :m - d]
+    return upper
+
+
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, X, y, w, xtwy, omega):
     """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
+    xtwx_upper = _lower_to_upper_banded(xtwx_banded)
+
     def _gcv(lam):
         try:
             c, tr = _solve_smoothing_spline_coefficients(
-                xtwx_banded, lam, omega, xtwy, compute_trace=True)
+                xtwx_banded, lam, omega, xtwy, xtwx_upper=xtwx_upper)
         except LinAlgError:
             # numerically singular for this lam
             return np.inf
-        rss = np.sum(w * np.square(y - x @ c)) / n
+        rss = np.sum(w * np.square(y - X @ c)) / n
         return rss / (1 - tr / n) ** 2
 
     def _gcv_log(s):
@@ -2997,21 +3008,15 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         compute_trace=False):
+                                         xtwx_upper=None):
     _lhs = XtWX_banded + lam * omega
     c = solveh_banded(_lhs, XtWy, lower=True)
-    if not compute_trace:
+    if xtwx_upper is None:
         return c, None
     # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
     # 7-banded, so only the central bands of the inverse are needed
-    # (Hutchinson & de Hoog); convert lower- to upper-banded storage.
-    m = XtWX_banded.shape[1]
-    lhs_upper = np.zeros_like(_lhs)
-    xtwx_upper = np.zeros_like(XtWX_banded)
-    for d in range(4):
-        lhs_upper[3 - d, d:] = _lhs[d, :m - d]
-        xtwx_upper[3 - d, d:] = XtWX_banded[d, :m - d]
-    b_banded = _compute_b_inv(lhs_upper)
+    # (Hutchinson & de Hoog, upper-banded storage).
+    b_banded = _compute_b_inv(_lower_to_upper_banded(_lhs))
     tr = b_banded * xtwx_upper
     tr[:-1] *= 2
     return c, tr.sum()
@@ -3165,9 +3170,9 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, t=None, axis=0):
         repeated 4 times (clamped), and interior knots may repeat only to
         multiplicity 2 (higher multiplicity would allow kinks or jumps,
         for which the penalty :math:`\int (f'')^2` is not defined).
-        ``t`` can only be passed when ``lam``
-        is given explicitly. Default is None, in which case a clamped knot
-        vector at the data sites is used,
+        If ``lam`` is not given, it is selected automatically by
+        generalized cross-validation. Default is None, in which case a
+        clamped knot vector at the data sites is used,
         ``t = np.r_[[x[0]]*3, x, [x[-1]]*3]``.
     axis : int, optional
         The data axis. Default is zero.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,6 +2973,10 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
+def _make_smoothing_spline_user_knots_gcv(x, y, w, t, axis, *, xp, device=None):
+    """Generalized Cross Validation (GCV) computation path for unequal knot
+    vectors and data points."""
+    pass
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -2987,9 +2991,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
     Assumes ``x``, ``y`` and ``w`` are already validated by the caller.
     """
     if lam is None:
-        raise NotImplementedError(
-            "automatic GCV selection of `lam` is not supported with user knots, "
-            "pass `lam` explicitly")
+        return _make_smoothing_spline_user_knots_gcv(
+            x, y, w, t, axis, xp, device=device
+        )
     if np.ndim(lam) != 0:
         raise NotImplementedError(
             "`lam` must be a scalar (or a 0-d array) when `t` is provided; "

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,14 +2973,16 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
-    """Compute the appropriate smoothing parameter `lam` for cubic smoothing splines."""
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
+                                          xtwx_dense):
+    """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
+    # Eq. (32)
     n = y.shape[0]
     def _gcv(lam):
         c, tr = _solve_smoothing_spline_coefficients(
-            xtwx_banded, lam, omega, xtwy, gcv=True)
+            xtwx_banded, lam, omega, xtwy, xtwx_dense=xtwx_dense)
         rss = np.sum(w * np.square(y - x @ c)) / n
         return rss / (1 - tr / n) ** 2
 
@@ -2991,13 +2993,17 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     lam_hat = 10 ** res.x
     return lam_hat
 
-def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy, gcv=False):
+def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
+                                         xtwx_dense=None):
     _lhs = XtWX_banded + lam * omega
-    c = solveh_banded(_lhs, XtWy, lower=True)
-    if gcv:
-        tr = np.sum((_lhs @ XtWX_banded).diagonal(0))
-        return (c, tr)
-    return c, None
+    if xtwx_dense is None:
+        return solveh_banded(_lhs, XtWy, lower=True), None
+    # factor once, then reuse it for the coefficients and for
+    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]  (solve, don't invert)
+    cb = cholesky_banded(_lhs, lower=True)
+    c = cho_solve_banded((cb, True), XtWy)
+    tr = np.trace(cho_solve_banded((cb, True), xtwx_dense))
+    return c, tr
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -3081,7 +3087,8 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         # as accepted by solveh_banded.
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
     if lam is None:
-        lam = _make_smoothing_spline_user_knots_gcv(XtWX_banded, XtWy)
+        lam = _make_smoothing_spline_user_knots_gcv(
+            XtWX_banded, X, y, w, XtWy, omega, XtWX.toarray())
     try:
         c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2973,16 +2973,19 @@ def _penalty_matrix_banded(t):
 
     return omega_banded
 
-def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
-                                          xtwx_dense):
+def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega):
     """Select `lam` by minimizing the GCV criterion V(lam) in log-space."""
     # Implementation decisions detailed in the following companion report:
     # https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf
     # Eq. (32)
     n = y.shape[0]
     def _gcv(lam):
-        c, tr = _solve_smoothing_spline_coefficients(
-            xtwx_banded, lam, omega, xtwy, xtwx_dense=xtwx_dense)
+        try:
+            c, tr = _solve_smoothing_spline_coefficients(
+                xtwx_banded, lam, omega, xtwy, compute_trace=True)
+        except LinAlgError:
+            # numerically singular for this lam
+            return np.inf
         rss = np.sum(w * np.square(y - x @ c)) / n
         return rss / (1 - tr / n) ** 2
 
@@ -2994,16 +2997,24 @@ def _make_smoothing_spline_user_knots_gcv(xtwx_banded, x, y, w, xtwy, omega,
     return lam_hat
 
 def _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy,
-                                         xtwx_dense=None):
+                                         compute_trace=False):
     _lhs = XtWX_banded + lam * omega
-    if xtwx_dense is None:
-        return solveh_banded(_lhs, XtWy, lower=True), None
-    # factor once, then reuse it for the coefficients and for
-    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]  (solve, don't invert)
-    cb = cholesky_banded(_lhs, lower=True)
-    c = cho_solve_banded((cb, True), XtWy)
-    tr = np.trace(cho_solve_banded((cb, True), xtwx_dense))
-    return c, tr
+    c = solveh_banded(_lhs, XtWy, lower=True)
+    if not compute_trace:
+        return c, None
+    # tr A = tr[(X^T W X + lam*Omega)^{-1} X^T W X]: both factors are
+    # 7-banded, so only the central bands of the inverse are needed
+    # (Hutchinson & de Hoog); convert lower- to upper-banded storage.
+    m = XtWX_banded.shape[1]
+    lhs_upper = np.zeros_like(_lhs)
+    xtwx_upper = np.zeros_like(XtWX_banded)
+    for d in range(4):
+        lhs_upper[3 - d, d:] = _lhs[d, :m - d]
+        xtwx_upper[3 - d, d:] = XtWX_banded[d, :m - d]
+    b_banded = _compute_b_inv(lhs_upper)
+    tr = b_banded * xtwx_upper
+    tr[:-1] *= 2
+    return c, tr.sum()
 
 def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None):
     """`make_smoothing_spline` path for a user-provided knot vector ``t``.
@@ -3088,7 +3099,7 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         XtWX_banded[i, : m - i] = XtWX.diagonal(-i)
     if lam is None:
         lam = _make_smoothing_spline_user_knots_gcv(
-            XtWX_banded, X, y, w, XtWy, omega, XtWX.toarray())
+            XtWX_banded, X, y, w, XtWy, omega)
     try:
         c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
     except LinAlgError as e:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -3105,7 +3105,9 @@ def _make_smoothing_spline_user_knots(x, y, w, lam, t, axis, *, xp, device=None)
         lam = _make_smoothing_spline_user_knots_gcv(
             XtWX_banded, X, y, w, XtWy, omega)
     try:
-        c, _ = _solve_smoothing_spline_coefficients(XtWX_banded, lam, omega, XtWy)
+        c, _ = _solve_smoothing_spline_coefficients(
+            XtWX_banded, lam, omega, XtWy, compute_trace=False,
+        )
     except LinAlgError as e:
         # why only the two extremes of lam can fail: companion report,
         # Sec. 15 FAQ 1 (link in make_smoothing_spline)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2954,6 +2954,25 @@ class TestSmoothingSpline:
         with assert_raises(err, match=match):
             make_smoothing_spline(_x_err, y, **kwargs)
 
+    @pytest.mark.parametrize("scale", [
+        pytest.param(4.0, id="normal"),
+        pytest.param(3e-6, id="tiny"),
+        pytest.param(1e6, id="huge"),
+    ])
+    def test_gcv_user_knots_scale_free(self, scale):
+        """Auto lam selection works at any data scale: the search window is
+        the dimensionless log10(lam / r), so it needs no absolute bounds."""
+        rng = np.random.default_rng(11)
+        x = np.sort(rng.uniform(0, scale, 50))
+        y = np.sin(2 * np.pi * 3 * x / scale) + 0.3 * rng.normal(size=50)
+        tk = np.linspace(x[0], x[-1], 15)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        f = make_smoothing_spline(x, y, t=t)
+        assert np.all(np.isfinite(f(x)))
+        # the fit should be reasonable.
+        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
+
     def test_gcv_user_knots_matches_grid_argmin(self):
         """GCV-selected fit agrees with the fit at the argmin of a log-lam grid."""
         rng = np.random.default_rng(42)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2918,8 +2918,6 @@ class TestSmoothingSpline:
         xp_assert_close(spl(x), oc_vals, atol=1e-10)
 
     @pytest.mark.parametrize("y, kwargs, err, match", [
-        pytest.param(_y_err, dict(t=_t_good), NotImplementedError,
-                     "pass `lam` explicitly", id="no-lam"),
         pytest.param(_y_err, dict(t=_t_good, lam=np.ones(5)),
                      NotImplementedError, "must be a scalar", id="array-lam"),
         pytest.param(_y_err, dict(t=_t_good, lam=-1.0),
@@ -2955,6 +2953,77 @@ class TestSmoothingSpline:
         # invalid inputs on the user-knots path raise with a clear message
         with assert_raises(err, match=match):
             make_smoothing_spline(_x_err, y, **kwargs)
+
+    def test_gcv_user_knots_matches_grid_argmin(self):
+        """GCV-selected fit agrees with the fit at the argmin of a log-lam grid."""
+        rng = np.random.default_rng(42)
+        x = np.sort(rng.uniform(0, 4, 60))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=60)
+        tk = np.linspace(x[0], x[-1], 15)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        n = len(x)
+        lams = np.logspace(-6, 3, 30)
+        eye = np.eye(n)
+        V = np.empty(len(lams))
+        for i, lam in enumerate(lams):
+            yhat = make_smoothing_spline(x, y, lam=lam, t=t)(x)
+            trA = sum(make_smoothing_spline(x, eye[:, k], lam=lam, t=t)(x)[k]
+                      for k in range(n))
+            V[i] = np.mean((y - yhat)**2) / (1 - trA / n)**2
+        lam_star = lams[np.argmin(V)]
+        f_auto = make_smoothing_spline(x, y, t=t)(x)
+        f_star = make_smoothing_spline(x, y, lam=lam_star, t=t)(x)
+        # the continuous search converges within one grid step of the grid
+        # argmin; on the flat GCV valley the fits are close, not bit identical.
+        xp_assert_close(f_auto, f_star, atol=5e-2)
+
+    def test_gcv_user_knots_master(self):
+        """At clamped t = x, GCV knot-path selection agrees with the t=None path."""
+        rng = np.random.default_rng(7)
+        x = np.sort(rng.uniform(0, 4, 50))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=50)
+        t = np.r_[[x[0]]*3, x, [x[-1]]*3]
+        f_old = make_smoothing_spline(x, y)(x)          # existing GCV path
+        f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
+        xp_assert_close(f_new, f_old, atol=5e-2)
+
+    def test_gcv_user_knots_weights(self):
+        """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""
+        rng = np.random.default_rng(3)
+        x = np.sort(rng.uniform(0, 4, 50))
+        y = np.sin(2 * x) + 0.3 * rng.normal(size=50)
+        tk = np.linspace(x[0], x[-1], 12)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+        f_now = make_smoothing_spline(x, y, w=np.ones_like(x), t=t)(x)
+        f_no_w = make_smoothing_spline(x, y, t=t)(x)
+        xp_assert_close(f_now, f_no_w, atol=1e-12)
+        w = np.where(x < 2, 2.0, 0.5)
+        f_w = make_smoothing_spline(x, y, w=w, t=t)(x)
+        assert np.all(np.isfinite(f_w))
+
+    def test_gcv_user_knots_vs_R(self):
+        """GCV selection on fixed knots agrees with R's smooth.spline GCV."""
+        # Reproduction session (R 4.5.2):
+        #   x <- seq(0, 4, length.out = 25)
+        #   y <- sin(2 * x) + 0.25 * cos(11 * x)
+        #   fit <- smooth.spline(x, y, cv = FALSE,
+        #                        all.knots = c(0, c(0.8, 1.6, 2.4, 3.2)/4, 1))
+        #   predict(fit, x)$y    # fit$lambda = 2.463429220330e-04
+        x = np.linspace(0, 4, 25)
+        y = np.sin(2 * x) + 0.25 * np.cos(11 * x)
+        t = np.r_[[0.0]*4, [0.8, 1.6, 2.4, 3.2], [4.0]*4]
+        r_yhat = np.array([
+            0.186393846962, 0.398457768892, 0.615308455998, 0.802461275320,
+            0.925431593898, 0.949816825933, 0.858608383717, 0.673605986607,
+            0.421860372253, 0.130422278305, -0.173654841629, -0.463211951010,
+            -0.710952857343, -0.889572201770, -0.971764625430, -0.932419617350,
+            -0.779268094191, -0.545322368638, -0.264245078675, 0.030301137713,
+            0.307835131483, 0.561388945297, 0.794533303938, 1.010888642951,
+            1.214075397881])
+        f = make_smoothing_spline(x, y, t=t)(x)
+        xp_assert_close(f, r_yhat, atol=5e-4)
 
     def test_user_defined_knots_axis(self):
         # batched (n-D) `y` is not supported on the user-knots path yet,

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2988,30 +2988,6 @@ class TestSmoothingSpline:
         f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
         xp_assert_close(f_new, f_old, atol=5e-2)
 
-    @pytest.mark.xfail(
-        reason="pending review discussion on what to return for the "
-               "singular case")
-    def test_gcv_search_with_singular_lam_in_window(self):
-        """Auto lam selection succeeds even when part of the search window
-        is numerically singular for the given data scale."""
-        rng = np.random.default_rng(5)
-        x = np.sort(rng.uniform(0, 3e-6, 40))
-        y = np.sin(7e5 * x) + 0.1 * rng.normal(size=40)
-        tk = np.linspace(x[0], x[-1], 12)
-        tk[0], tk[-1] = x[0], x[-1]
-        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
-
-        # the upper end of the search window is numerically singular for
-        # this data scale: an explicit fit there raises
-        with assert_raises(ValueError, match="not positive definite"):
-            make_smoothing_spline(x, y, lam=1e9, t=t)
-
-        # the automatic search must route around that region
-        f = make_smoothing_spline(x, y, t=t)
-        assert np.all(np.isfinite(f(x)))
-        # and select a fit that tracks the signal, not the flattened limit
-        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
-
     def test_gcv_user_knots_weights(self):
         """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""
         rng = np.random.default_rng(3)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2476,7 +2476,7 @@ _t_mult5b = np.r_[[-2.0]*5, [0.0], [2.0]*4]               # boundary multiplicit
 _t_unclamped = np.r_[[-4., -3.5, -3., -2.], [0.], [2., 3., 3.5, 4.]]  # not clamped
 
 def _dense_omega(ab, m):
-    """Reconstruct a dense symmetric matrix from (4, m) lower-banded storage.
+    """Reconstruct a dense symmetric matrix from (4, m) upper-banded storage.
 
     Used for the penalty matrix Omega of the smoothing spline,
     ``Omega[i, j] = integral(B_i'' * B_j'')``, which
@@ -2484,9 +2484,9 @@ def _dense_omega(ab, m):
     """
     omega = np.zeros((m, m))
     for i in range(4):
-        omega += np.diag(ab[i, :m - i], -i)
+        omega += np.diag(ab[3 - i, i:], -i)
         if i > 0:
-            omega += np.diag(ab[i, :m - i], i)
+            omega += np.diag(ab[3 - i, i:], i)
     return omega
 
 @make_xp_test_case(make_smoothing_spline)
@@ -2987,6 +2987,30 @@ class TestSmoothingSpline:
         f_old = make_smoothing_spline(x, y)(x)          # existing GCV path
         f_new = make_smoothing_spline(x, y, t=t)(x)     # user-knots GCV path
         xp_assert_close(f_new, f_old, atol=5e-2)
+
+    @pytest.mark.xfail(
+        reason="pending review discussion on what to return for the "
+               "singular case")
+    def test_gcv_search_with_singular_lam_in_window(self):
+        """Auto lam selection succeeds even when part of the search window
+        is numerically singular for the given data scale."""
+        rng = np.random.default_rng(5)
+        x = np.sort(rng.uniform(0, 3e-6, 40))
+        y = np.sin(7e5 * x) + 0.1 * rng.normal(size=40)
+        tk = np.linspace(x[0], x[-1], 12)
+        tk[0], tk[-1] = x[0], x[-1]
+        t = np.r_[[tk[0]]*3, tk, [tk[-1]]*3]
+
+        # the upper end of the search window is numerically singular for
+        # this data scale: an explicit fit there raises
+        with assert_raises(ValueError, match="not positive definite"):
+            make_smoothing_spline(x, y, lam=1e9, t=t)
+
+        # the automatic search must route around that region
+        f = make_smoothing_spline(x, y, t=t)
+        assert np.all(np.isfinite(f(x)))
+        # and select a fit that tracks the signal, not the flattened limit
+        assert np.sqrt(np.mean((f(x) - y)**2)) < 0.75 * np.std(y)
 
     def test_gcv_user_knots_weights(self):
         """Unit weights reproduce the unweighted GCV fit; nonuniform weights run."""


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?

This PR adds a tutorial for the newly implemented `t=` keyword argument in `scipy.interpolate.make_smoothing_spline`. This PR depends on PR #26141 being merged. 

The only change this PR implements is present in `smoothing_splines.rst`.

#### Additional information

It covers the following:
* The `t` keyword argument itself
* Why it was added and the benefits of user-defined knots
* Where the knots should be added (quantile vs. uniformly spaced knots)
* The Generalized Cross Validation (GCV) case

#### AI Generation Disclosure
AI was used to rephrase handwritten content for language and flow improvements.